### PR TITLE
feat: frontend reactive auth sync store (#19)

### DIFF
--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { useRouter } from "next/navigation";
 import { api } from "@/lib/api";
 import { isAxiosError } from "axios";
+import { authStore } from "@/lib/auth-store";
 
 export default function LoginPage() {
   const router = useRouter();
@@ -31,9 +32,8 @@ export default function LoginPage() {
 
       const { token, data } = response.data;
 
-      // Simpan token ke local storage
-      localStorage.setItem("bksda_token", token);
-      localStorage.setItem("bksda_user", JSON.stringify(data));
+      // Simpan token ke local storage via authStore
+      authStore.login(token, data); // <-- Panggil fungsi login dari store
 
       // Redirect ke dashboard (nanti akan kita buat)
       router.push("/");

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { authStore } from "@/lib/auth-store";
+
+export function useAuth() {
+  // Hook sakti React 18: otomatis re-render komponen jika snapshot berubah
+  const userStr = useSyncExternalStore(
+    authStore.subscribe,
+    authStore.getSnapshot,
+    () => null // Server-side fallback
+  );
+
+  // Parse JSON dengan aman
+  let user = null;
+  if (userStr) {
+    try {
+      user = JSON.parse(userStr);
+    } catch {
+      console.error("Gagal membaca profil pengguna.");
+    }
+  }
+
+  return {
+    user,
+    isAuthenticated: !!user,
+    login: authStore.login,
+    logout: authStore.logout,
+  };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { authStore } from './auth-store';
 
 // 1. Buat Instance Axios dengan Base URL bawaan
 export const api = axios.create({
@@ -39,8 +40,7 @@ api.interceptors.response.use(
       // 401 Unauthenticated: Token habis / tidak valid. 
       // Hapus token dan tendang user ke halaman login.
       if (typeof window !== 'undefined') {
-        localStorage.removeItem('bksda_token');
-        localStorage.removeItem('bksda_user'); // (opsional) menghapus identitas profil
+        authStore.logout(); // <-- Panggil fungsi logout dari store
         
         // Jangan redirect jika posisinya memang sudah di /login
         if (window.location.pathname !== '/login') {

--- a/frontend/src/lib/auth-store.ts
+++ b/frontend/src/lib/auth-store.ts
@@ -1,0 +1,33 @@
+let listeners: Array<() => void> = [];
+
+export const authStore = {
+  // Mendaftarkan komponen yang mau mendengarkan perubahan
+  subscribe(listener: () => void) {
+    listeners.push(listener);
+    return () => {
+      listeners = listeners.filter((l) => l !== listener);
+    };
+  },
+
+  // Mengambil data saat ini (Snapshot)
+  getSnapshot() {
+    if (typeof window === "undefined") return null;
+    return localStorage.getItem("bksda_user"); // Kita pantau data user-nya
+  },
+
+  // Fungsi Login Sentral
+  login(token: string, userData: unknown) {
+    localStorage.setItem("bksda_token", token);
+    localStorage.setItem("bksda_user", JSON.stringify(userData));
+    // Beritahu semua komponen bahwa data berubah!
+    listeners.forEach((l) => l());
+  },
+
+  // Fungsi Logout Sentral
+  logout() {
+    localStorage.removeItem("bksda_token");
+    localStorage.removeItem("bksda_user");
+    // Beritahu semua komponen bahwa data terhapus!
+    listeners.forEach((l) => l());
+  }
+};


### PR DESCRIPTION
## Summary
Mensentralisasi state management untuk Autentikasi dengan sangat ringan.

## Changes
- Membuat \uth-store.ts\ (Observer pattern).
- Membuat \useAuth()\ hook berbasis \useSyncExternalStore\.
- Refactoring \pi.ts\ (401 interceptor) dan \LoginPage\ agar menggunakan AuthStore.

## Verification
- [x] Linter React lolos.
- [x] Halaman Login masih berfungsi normal.

## Rules Compliance
- [x] Mendukung \Clean Code\ dengan menghindari redundansi localStorage.setItem.
- [x] Arsitektur yang ringan tanpa \Redux\ atau \Context\ yang berat (menghindari Re-render Hell).

Closes #19