### PR TITLE
feat(kepegawaian): module service provider registration (#46)

### DIFF
--- a/backend/app/Modules/Kepegawaian/Providers/KepegawaianServiceProvider.php
+++ b/backend/app/Modules/Kepegawaian/Providers/KepegawaianServiceProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Modules\Kepegawaian\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class KepegawaianServiceProvider extends ServiceProvider
+{
+    /**
+     * Dijalankan untuk meregistrasi bindings di memori (IOC container).
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Dijalankan terakhir, untuk menghubungkan modul (seperti route, views, migration).
+     */
+    public function boot(): void
+    {
+        $this->registerRoutes();
+    }
+
+    /**
+     * Daftarkan routing API khusus modul ini (Sesuai Rule 8.3).
+     * Semua endpoint di modul ini tak perlu ditulis prefix-nya lagi, sudah diurus otomatis.
+     */
+    protected function registerRoutes(): void
+    {
+        $routePath = base_path('app/Modules/Kepegawaian/Routes/api.php');
+
+        if (file_exists($routePath)) {
+            Route::prefix('api/kepegawaian')
+                ->middleware('api') // Membawa serta perlindungan dasar API seperti JSON & log
+                ->group($routePath);
+        }
+    }
+}

--- a/backend/app/Modules/Kepegawaian/Routes/api.php
+++ b/backend/app/Modules/Kepegawaian/Routes/api.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+// Di sinilah endpoint-endpoint modul kepegawaian akan hidup (Dikerjakan di Issue #027)
+// Ingat: Semua route di dalam file ini OTOMATIS memiliki prefix /api/kepegawaian/
+
+// Contoh (Hanya testing, boleh dihapus nanti):
+// Route::get('/ping', function() { return 'pong kepegawaian'; });

--- a/backend/bootstrap/providers.php
+++ b/backend/bootstrap/providers.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Providers\AppServiceProvider;
+use App\Modules\Kepegawaian\Providers\KepegawaianServiceProvider;
 
 return [
     AppServiceProvider::class,
+    KepegawaianServiceProvider::class,
 ];


### PR DESCRIPTION
## Summary
Membangun Service Provider agar modul Kepegawaian terisolasi rutenya dari sistem utama.

## Changes
- File kosong Routes/api.php sebagai kanvas endpoint.
- Class KepegawaianServiceProvider dengan integrasi Route::prefix('api/kepegawaian').
- Injeksi class ke file sistem bootstrap/providers.php.

## Verification
- [x] Lolos Composer Autoload (6695 classes).
- [x] Tidak ada Fatality Error saat Laravel booting.
- [x] php artisan route:clear sukses.

Closes #46