### PR TITLE
feat(inventory): relational mapping and strictly typed eloquent models (#83)

### DIFF
--- a/backend/app/Modules/Inventory/Models/Category.php
+++ b/backend/app/Modules/Inventory/Models/Category.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Modules\Inventory\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Category extends Model
+{
+    use HasUuids, SoftDeletes;
+
+    protected $table = 'inv_categories';
+
+    protected $fillable = [
+        'nama_kategori',
+        'deskripsi'
+    ];
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(Item::class, 'category_id');
+    }
+}

--- a/backend/app/Modules/Inventory/Models/InventoryStock.php
+++ b/backend/app/Modules/Inventory/Models/InventoryStock.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Modules\Inventory\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class InventoryStock extends Model
+{
+    use HasUuids;
+
+    protected $table = 'inv_inventory_stocks';
+
+    protected $fillable = [
+        'office_id',
+        'item_id',
+        'quantity'
+    ];
+
+    public function office(): BelongsTo
+    {
+        return $this->belongsTo(Office::class, 'office_id');
+    }
+
+    public function item(): BelongsTo
+    {
+        return $this->belongsTo(Item::class, 'item_id');
+    }
+}

--- a/backend/app/Modules/Inventory/Models/Item.php
+++ b/backend/app/Modules/Inventory/Models/Item.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Modules\Inventory\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Item extends Model
+{
+    use HasUuids, SoftDeletes;
+
+    protected $table = 'inv_items';
+
+    protected $fillable = [
+        'category_id',
+        'kode_barang',
+        'nama_barang',
+        'satuan',
+        'min_stock'
+    ];
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class, 'category_id');
+    }
+
+    public function stocks(): HasMany
+    {
+        return $this->hasMany(InventoryStock::class, 'item_id');
+    }
+}

--- a/backend/app/Modules/Inventory/Models/Office.php
+++ b/backend/app/Modules/Inventory/Models/Office.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Modules\Inventory\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Modules\Kepegawaian\Models\Employee;
+
+class Office extends Model
+{
+    use HasUuids, SoftDeletes;
+
+    protected $table = 'inv_offices';
+
+    protected $fillable = [
+        'nama_kantor',
+        'lokasi',
+        'penanggung_jawab_id'
+    ];
+
+    public function penanggungJawab(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class, 'penanggung_jawab_id');
+    }
+
+    public function stocks(): HasMany
+    {
+        return $this->hasMany(InventoryStock::class, 'office_id');
+    }
+}

--- a/backend/app/Modules/Inventory/Models/StockTransaction.php
+++ b/backend/app/Modules/Inventory/Models/StockTransaction.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Modules\Inventory\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\User;
+use App\Modules\Kepegawaian\Models\Employee;
+
+class StockTransaction extends Model
+{
+    use HasUuids;
+
+    protected $table = 'inv_stock_transactions';
+
+    protected $fillable = [
+        'office_id',
+        'item_id',
+        'type',             // 'in', 'out', 'adjustment'
+        'quantity',
+        'remaining_stock',  // WAJIB: Mencatat jumlah sisa saat itu
+        'keterangan',
+        'user_id',          // Siapa admin yang klik simpan
+        'employee_id'       // Siapa pegawai yang minta barang
+    ];
+
+    public function office(): BelongsTo
+    {
+        return $this->belongsTo(Office::class, 'office_id');
+    }
+
+    public function item(): BelongsTo
+    {
+        return $this->belongsTo(Item::class, 'item_id');
+    }
+
+    public function admin(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function recipient(): BelongsTo
+    {
+        return $this->belongsTo(Employee::class, 'employee_id');
+    }
+}


### PR DESCRIPTION
## Summary
5 Eloquent models for Inventory module with cross-module relations.

## Changes
- Category.php (HasMany items, SoftDeletes)
- Office.php (BelongsTo Employee, HasMany stocks, SoftDeletes)
- Item.php (BelongsTo Category, HasMany stocks, SoftDeletes)
- InventoryStock.php (BelongsTo Office+Item, no SoftDeletes)
- StockTransaction.php (BelongsTo Office+Item+User+Employee, no SoftDeletes)

## Rules Compliance
- [x] Rule 1.3: All models use explicit 
- [x] PHP lint 3x passed

Closes #83