### PR TITLE
feat(bmn): BmnServiceProvider with module routing registration

### DIFF
--- a/backend/app/Modules/Bmn/BmnServiceProvider.php
+++ b/backend/app/Modules/Bmn/BmnServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Modules\Bmn;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class BmnServiceProvider extends ServiceProvider
+{
+    public function register(): void {}
+
+    public function boot(): void
+    {
+        $this->loadMigrationsFrom(__DIR__ . '/Migrations');
+
+        Route::middleware(['api', 'auth:sanctum', 'module.access:bmn'])
+             ->prefix('api/bmn')
+             ->group(__DIR__ . '/Routes/api.php');
+    }
+}

--- a/backend/app/Modules/Bmn/Requests/DisposeAssetRequest.php
+++ b/backend/app/Modules/Bmn/Requests/DisposeAssetRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Modules\Bmn\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DisposeAssetRequest extends FormRequest
+{
+    public function authorize(): bool { return true; }
+
+    public function rules(): array
+    {
+        return [
+            'alasan_pemutihan' => ['required', 'string', 'min:10', 'max:1000'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'alasan_pemutihan.min' => 'Alasan pemutihan aset negara harus jelas (minimal 10 karakter).',
+        ];
+    }
+}

--- a/backend/app/Modules/Bmn/Requests/StoreAssetLoanRequest.php
+++ b/backend/app/Modules/Bmn/Requests/StoreAssetLoanRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Modules\Bmn\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreAssetLoanRequest extends FormRequest
+{
+    public function authorize(): bool { return true; }
+
+    public function rules(): array
+    {
+        return [
+            'employee_id' => ['required', 'uuid', 'exists:kpg_employees,id'],
+            'tanggal_pinjam' => ['required', 'date', 'before_or_equal:today'],
+            'keterangan' => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'employee_id.exists' => 'NIP tersebut tidak tercatat di buku Kepegawaian BKSDA.',
+        ];
+    }
+}

--- a/backend/app/Modules/Bmn/Requests/StoreAssetMaintenanceRequest.php
+++ b/backend/app/Modules/Bmn/Requests/StoreAssetMaintenanceRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Modules\Bmn\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreAssetMaintenanceRequest extends FormRequest
+{
+    public function authorize(): bool { return true; }
+
+    public function rules(): array
+    {
+        return [
+            'tanggal_service' => ['required', 'date', 'before_or_equal:today'],
+            'biaya' => ['required', 'numeric', 'min:0'],
+            'deskripsi' => ['required', 'string', 'max:2000'],
+            'bukti_nota_url' => ['nullable', 'string', 'max:1000'],
+            'kondisi_baru' => ['nullable', 'string', Rule::in(['Baik', 'Rusak Ringan', 'Rusak Berat'])],
+        ];
+    }
+}

--- a/backend/app/Modules/Bmn/Requests/StoreAssetRequest.php
+++ b/backend/app/Modules/Bmn/Requests/StoreAssetRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Modules\Bmn\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreAssetRequest extends FormRequest
+{
+    public function authorize(): bool { return true; }
+
+    public function rules(): array
+    {
+        return [
+            'kode_barang' => ['required', 'string', 'max:50'],
+            'nup' => [
+                'required', 'string', 'max:20',
+                Rule::unique('bmn_assets')->where(function ($query) {
+                    return $query->where('kode_barang', $this->kode_barang);
+                })
+            ],
+            'nama_barang' => ['required', 'string', 'max:255'],
+            'merk_tipe' => ['nullable', 'string', 'max:255'],
+            'tahun_perolehan' => ['nullable', 'integer', 'digits:4', 'min:1945', 'max:' . (date('Y') + 1)],
+            'kondisi' => ['required', 'string', Rule::in(['Baik', 'Rusak Ringan', 'Rusak Berat'])],
+            'nilai_perolehan' => ['required', 'numeric', 'min:0'],
+            'nilai_buku' => ['required', 'numeric', 'min:0'],
+            'lokasi_spesifik' => ['nullable', 'string', 'max:500'],
+            'foto_url' => ['nullable', 'string', 'max:1000'],
+            'keterangan' => ['nullable', 'string'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'nup.unique' => 'NUP ini sudah terpakai pada Kode Barang yang sama.',
+            'nilai_perolehan.numeric' => 'Nilai Perolehan wajib berwujud angka murni.',
+            'kondisi.in' => 'Kondisi harus: Baik, Rusak Ringan, atau Rusak Berat.',
+        ];
+    }
+}

--- a/backend/app/Modules/Bmn/Requests/UpdateAssetRequest.php
+++ b/backend/app/Modules/Bmn/Requests/UpdateAssetRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Modules\Bmn\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateAssetRequest extends FormRequest
+{
+    public function authorize(): bool { return true; }
+
+    public function rules(): array
+    {
+        $assetId = $this->route('asset');
+
+        return [
+            'kode_barang' => ['required', 'string', 'max:50'],
+            'nup' => [
+                'required', 'string', 'max:20',
+                Rule::unique('bmn_assets')->where(function ($query) {
+                    return $query->where('kode_barang', $this->kode_barang);
+                })->ignore($assetId)
+            ],
+            'nama_barang' => ['required', 'string', 'max:255'],
+            'merk_tipe' => ['nullable', 'string', 'max:255'],
+            'tahun_perolehan' => ['nullable', 'integer', 'digits:4'],
+            'kondisi' => ['required', 'string', Rule::in(['Baik', 'Rusak Ringan', 'Rusak Berat'])],
+            'nilai_perolehan' => ['required', 'numeric', 'min:0'],
+            'nilai_buku' => ['required', 'numeric', 'min:0'],
+            'lokasi_spesifik' => ['nullable', 'string', 'max:500'],
+            'foto_url' => ['nullable', 'string', 'max:1000'],
+            'keterangan' => ['nullable', 'string'],
+            'keterangan_audit' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/backend/app/Modules/Bmn/Routes/api.php
+++ b/backend/app/Modules/Bmn/Routes/api.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| BMN (Barang Milik Negara) Routes
+|--------------------------------------------------------------------------
+| Prefix: /api/bmn
+| Perlindungan: auth:sanctum, module.access:bmn
+|--------------------------------------------------------------------------
+*/
+
+Route::get('/ping', function () {
+    return response()->json([
+        'status' => 'success',
+        'module' => 'BMN',
+        'message' => '🏛️ Sirkuit Keuangan Barang Milik Negara Aktif!',
+        'timestamp' => now()
+    ]);
+});

--- a/backend/bootstrap/providers.php
+++ b/backend/bootstrap/providers.php
@@ -4,10 +4,12 @@ use App\Providers\AppServiceProvider;
 use App\Modules\Kepegawaian\Providers\KepegawaianServiceProvider;
 use App\Modules\SuratTugas\SuratTugasServiceProvider;
 use App\Modules\Inventory\InventoryServiceProvider;
+use App\Modules\Bmn\BmnServiceProvider;
 
 return [
     AppServiceProvider::class,
     KepegawaianServiceProvider::class,
     SuratTugasServiceProvider::class,
     InventoryServiceProvider::class,
+    BmnServiceProvider::class,
 ];


### PR DESCRIPTION
Closes #116. Registers BmnServiceProvider, creates Routes/api.php with ping endpoint, and adds provider to bootstrap/providers.php. Route verified via php artisan route:list --path=bmn.