### PR TITLE
feat(bmn): complete API routing with apiResource, loan, and maintenance endpoints

### DIFF
--- a/backend/app/Modules/Bmn/Routes/api.php
+++ b/backend/app/Modules/Bmn/Routes/api.php
@@ -1,12 +1,15 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Modules\Bmn\Controllers\AssetController;
+use App\Modules\Bmn\Controllers\LoanController;
+use App\Modules\Bmn\Controllers\MaintenanceController;
 
 /*
 |--------------------------------------------------------------------------
 | BMN (Barang Milik Negara) Routes
 |--------------------------------------------------------------------------
-| Prefix: /api/bmn
+| Base URL Prefix: /api/bmn
 | Perlindungan: auth:sanctum, module.access:bmn
 |--------------------------------------------------------------------------
 */
@@ -15,7 +18,19 @@ Route::get('/ping', function () {
     return response()->json([
         'status' => 'success',
         'module' => 'BMN',
-        'message' => '🏛️ Sirkuit Keuangan Barang Milik Negara Aktif!',
-        'timestamp' => now()
+        'message' => '🏛️ Sirkuit Keuangan Barang Milik Negara Aktif & Terlindungi!'
     ]);
 });
+
+// 1. JALUR MASTER ASET
+Route::apiResource('assets', AssetController::class)->except(['destroy']);
+Route::delete('assets/{asset}/dispose', [AssetController::class, 'dispose']);
+
+// 2. LALU LINTAS PEMINJAMAN (LOAN)
+Route::get('loans', [LoanController::class, 'index']);
+Route::post('assets/{asset}/loans', [LoanController::class, 'borrow']);
+Route::post('loans/{loan}/return', [LoanController::class, 'return']);
+
+// 3. REKAM MEDIS PEMELIHARAAN (MAINTENANCE)
+Route::get('maintenances', [MaintenanceController::class, 'index']);
+Route::post('assets/{asset}/maintenances', [MaintenanceController::class, 'record']);


### PR DESCRIPTION
Closes #123. Overwrites BMN api.php with complete routing: apiResource for assets (no destroy), custom dispose DELETE, loan borrow/return, and maintenance record. Verified 11 routes with php artisan route:list.