### PR TITLE
feat(dereporting): construct operator delegation system via IAM payload mutation (#83)

### DIFF
--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -27,6 +27,8 @@ class User extends Authenticatable
         'role',
         'access_modules',
         'is_active',
+        'dereporting_role',
+        'dereporting_bidang_id',
     ];
 
     /**
@@ -54,5 +56,13 @@ class User extends Authenticatable
             'access_modules' => 'array', // Mengubah JSON DB menjadi Array PHP
             'is_active' => 'boolean',
         ];
+    }
+
+    /**
+     * Relasi ke Bidang DeReporting (Operator)
+     */
+    public function dereportingBidang()
+    {
+        return $this->belongsTo(\App\Modules\DeReporting\Models\Bidang::class, 'dereporting_bidang_id');
     }
 }

--- a/backend/app/Modules/DeReporting/Controllers/OperatorController.php
+++ b/backend/app/Modules/DeReporting/Controllers/OperatorController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Modules\DeReporting\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+// KUNCI ARSITEKTUR: Kita memanggil Model Pusat IAM, bukan model DeReporting!
+use App\Models\User;
+use App\Modules\DeReporting\Models\Bidang;
+
+class OperatorController extends Controller
+{
+    /**
+     * GET /api/dereporting/operators
+     * Menampilkan daftar Pegawai yang telah diangkat menjadi Operator Laporan
+     */
+    public function index(Request $request)
+    {
+        // 1. Ambil HANYA User yang memiliki jabatan Operator DeReporting
+        // 2. Gunakan Eager Loading (with) untuk menempelkan nama Bidang tugasnya
+        $query = User::where('dereporting_role', 'operator')
+                     ->with('dereportingBidang:id,nama') // Asumsi fungsi relasi 'dereportingBidang' ada di Model User
+                     ->latest();
+
+        if ($request->filled('search')) {
+            $search = $request->search;
+            $query->where('name', 'ilike', "%{$search}%")
+                  ->orWhere('username', 'ilike', "%{$search}%");
+        }
+
+        // Project Rule 3.1: Wajib Paging
+        return response()->json($query->paginate(20));
+    }
+
+    /**
+     * POST /api/dereporting/operators
+     * Mengangkat Pegawai Menjadi Operator Bidang
+     */
+    public function store(Request $request)
+    {
+        // Validasi: Pastikan User ID dan Bidang ID benar-benar eksis di Database
+        $request->validate([
+            'user_id'   => 'required|uuid|exists:users,id',
+            'bidang_id' => 'required|uuid|exists:dr_bidang,id',
+        ]);
+
+        $user = User::findOrFail($request->user_id);
+
+        // Manuver Promosi Jabatan (Promote)
+        $user->update([
+            'dereporting_role'      => 'operator',
+            'dereporting_bidang_id' => $request->bidang_id,
+        ]);
+
+        return response()->json([
+            'message' => "Pegawai {$user->name} berhasil diangkat menjadi Operator Laporan.",
+            'data'    => $user
+        ], 201);
+    }
+
+    /**
+     * PUT /api/dereporting/operators/{id}
+     * Memutasi (Memindah) Operator ke Bidang Lain
+     */
+    public function update(Request $request, string $id)
+    {
+        $request->validate([
+            'bidang_id' => 'required|uuid|exists:dr_bidang,id',
+        ]);
+
+        $user = User::findOrFail($id);
+        
+        // Peringatan Keamanan: Pastikan yang diupdate memang benar seorang operator
+        if ($user->dereporting_role !== 'operator') {
+            return response()->json(['message' => 'Pegawai ini bukan seorang operator.'], 403);
+        }
+
+        $user->update([
+            'dereporting_bidang_id' => $request->bidang_id,
+        ]);
+
+        return response()->json([
+            'message' => "Wilayah tugas Operator {$user->name} berhasil dimutasi.",
+            'data'    => $user
+        ]);
+    }
+
+    /**
+     * DELETE /api/dereporting/operators/{id}
+     * Mencabut Jabatan Operator (Pemecatan Damai)
+     */
+    public function destroy(string $id)
+    {
+        $user = User::findOrFail($id);
+
+        // Manuver Pemecatan (Demote): Kembalikan ke titik Nol (Null)
+        // Kita TIDAK BOLEH memanggil $user->delete() karena itu akan menghapus Pegawai tersebut dari BKSDA!
+        $user->update([
+            'dereporting_role'      => null,
+            'dereporting_bidang_id' => null,
+        ]);
+
+        return response()->json([
+            'message' => "Jabatan Operator untuk {$user->name} telah resmi dicabut."
+        ]);
+    }
+}

--- a/backend/app/Modules/DeReporting/Routes/api.php
+++ b/backend/app/Modules/DeReporting/Routes/api.php
@@ -1,10 +1,19 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Modules\DeReporting\Controllers\OperatorController;
 
 // Endpoint Modul Laporan Eksternal & Internal BKSDA
 // Semua rute di bawah ini akan otomatis memiliki prefiks: /api/dereporting/
 
 Route::get('/ping', function () {
     return response()->json(['message' => 'Modul DeReporting BKSDA menyala!']);
+});
+
+// Operator Delegation Routes (RBAC via IAM)
+Route::middleware(['auth:sanctum', 'module.access:dereporting'])->group(function () {
+    Route::get('/operators', [OperatorController::class, 'index']);
+    Route::post('/operators', [OperatorController::class, 'store']);
+    Route::put('/operators/{id}', [OperatorController::class, 'update']);
+    Route::delete('/operators/{id}', [OperatorController::class, 'destroy']);
 });

--- a/backend/database/migrations/0001_01_02_add_dereporting_columns_to_users_table.php
+++ b/backend/database/migrations/0001_01_02_add_dereporting_columns_to_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('dereporting_role')->nullable()->after('access_modules')->comment('operator, null = bukan operator');
+            $table->uuid('dereporting_bidang_id')->nullable()->after('dereporting_role');
+            $table->foreign('dereporting_bidang_id')->references('id')->on('dr_bidang')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropForeign(['dereporting_bidang_id']);
+            $table->dropColumn(['dereporting_role', 'dereporting_bidang_id']);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
Pembangkitan sistem kendali Otoritas Wilayah Kerja *(Operator Delegation)*.

## Changes
- Pembuatan \OperatorController\ yang berpusat pada penarikan mutasi kelas inti \App\Models\User\.
- Implementasi sistem Pengangkatan *(Promote)* dan Pemecatan *(Demote)* tanpa merusak integritas tabel \users\, dengan mereset atribut nilai ke \
ull\.
- Injeksi penambal relasional \dereportingBidang\ pada Entitas \User\.
- Migration untuk menambahkan kolom \dereporting_role\ dan \dereporting_bidang_id\ ke tabel \users\.

## Rules Compliance
- [x] Lolos Doktrin Penghindaran Data Ganda (Anti-Redundancy): Keberhasilan memblokir pembuatan tabel baru yang sia-sia *(seperti dr_operators)* dengan memanfaatkan ekstensi IAM bawaan *(Identity and Access Management)* yang telah kita persiapkan di Fase 1 (Issue 009).

Closes #83