### PR TITLE
feat(dereporting): configure strict RBAC routing topologies for internal and external telemetries (#84)

### DIFF
--- a/backend/app/Modules/DeReporting/Routes/api.php
+++ b/backend/app/Modules/DeReporting/Routes/api.php
@@ -1,19 +1,61 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+
+// Import 4 Pengendali Raksasa kita
+use App\Modules\DeReporting\Controllers\MasterDataController;
+use App\Modules\DeReporting\Controllers\InternalController;
+use App\Modules\DeReporting\Controllers\EkternalController;
 use App\Modules\DeReporting\Controllers\OperatorController;
 
-// Endpoint Modul Laporan Eksternal & Internal BKSDA
-// Semua rute di bawah ini akan otomatis memiliki prefiks: /api/dereporting/
+/*
+|--------------------------------------------------------------------------
+| ZONA PUBLIK (INTERNET TERBUKA)
+|--------------------------------------------------------------------------
+| Tanpa Token. Digunakan khusus oleh layar eksternal masyarakat.
+*/
 
-Route::get('/ping', function () {
-    return response()->json(['message' => 'Modul DeReporting BKSDA menyala!']);
-});
+// 1. Ekstraktor Dropdown (Peringatan: Controller memiliki perisai exception di dalamnya)
+Route::get('/master/{type}', [MasterDataController::class, 'index']);
 
-// Operator Delegation Routes (RBAC via IAM)
+// 2. Lubang Penerima Formulir Masyarakat (Rate Limiting telah diurus di Controller)
+Route::post('/eksternals/public', [EksternalController::class, 'storePublic']);
+
+/*
+|--------------------------------------------------------------------------
+| ZONA PEGAWAI BKSDA (TERKUNCI)
+|--------------------------------------------------------------------------
+| Wajib menyertakan Bearer Token Sanctum & Hak Akses Modul 'dereporting'.
+*/
 Route::middleware(['auth:sanctum', 'module.access:dereporting'])->group(function () {
-    Route::get('/operators', [OperatorController::class, 'index']);
-    Route::post('/operators', [OperatorController::class, 'store']);
-    Route::put('/operators/{id}', [OperatorController::class, 'update']);
-    Route::delete('/operators/{id}', [OperatorController::class, 'destroy']);
+
+    // 1. LALU LINTAS LAPORAN INTERNAL (Seluruh Pegawai)
+    // Otomatis menciptakan rute index, store, show, update, destroy
+    Route::apiResource('internals', InternalController::class);
+    // Pintu gaib pengunduh PDF dari Brankas Privat
+    Route::get('/internals/{id}/download', [InternalController::class, 'downloadFile']);
+
+    /*
+    |--------------------------------------------------------------------------
+    | ZONA ADMIN & SUPER ADMIN (OTORITAS TINGGI)
+    |--------------------------------------------------------------------------
+    | Mengunci wewenang perubahan struktur Master Data dan Modifikasi Operator.
+    */
+    Route::middleware('role:admin,super_admin')->group(function () {
+
+        // A. PENGENDALI MASTER DATA DINAMIS (POST, PUT, DELETE)
+        Route::post('/master/{type}', [MasterDataController::class, 'store']);
+        Route::put('/master/{type}/{id}', [MasterDataController::class, 'update']);
+        Route::delete('/master/{type}/{id}', [MasterDataController::class, 'destroy']);
+
+        // B. PENUGASAN OPERATOR WILAYAH
+        Route::apiResource('operators', OperatorController::class)->except(['show']);
+
+        // C. PENINJAUAN LAPORAN MASYARAKAT (EKSTERNAL)
+        Route::get('/eksternals', [EksternalController::class, 'index']);
+        Route::put('/eksternals/{id}/status', [EksternalController::class, 'updateStatus']);
+        Route::get('/eksternals/{id}/download', [EksternalController::class, 'downloadFile']);
+        Route::delete('/eksternals/{id}', [EksternalController::class, 'destroy']); // Ekstra fungsi buang laporan sampah
+    });
+
 });


### PR DESCRIPTION
## Summary
Pembangkitan Sirkuit Kesadaran Arsitektur *(Architecture Routing Phase)* untuk Modul DeReporting. Penggantian Rute Umpan menjadi Papan Kendali Lalu Lintas sungguhan.

## Changes
- Inisiasi pemisahan taktis antara \GET /master\ (Publik/Dropdown) vs \POST /master\ (Admin).
- Pemasangan tameng lapis pertama: \uth:sanctum\ & \module.access:dereporting\ untuk mengusir penyusup anonim dari zona Operasional BKSDA.
- Pemasangan tameng lapis kedua *(Deep Vault)*: \ole:admin,super_admin\ khusus untuk gerbang Master Data, Manajemen Laporan Eksternal, dan Penugasan Operator.

## Rules Compliance
- [x] Lolos Doktrin Privilese Tunggal (Project Rule 2.5): Operasi manipulasi (CRUD) di ranah Master Data telah dikunci mutlak menggunakan sistem *Routing Role Middleware*, membuatnya mustahil dibobol oleh pegawai rendahan.

Closes #159