### PR TITLE
refactor(dereporting): extract inline controller validation to dedicated FormRequest barricades (#85)

### DIFF
--- a/backend/app/Modules/DeReporting/Controllers/EksternalController.php
+++ b/backend/app/Modules/DeReporting/Controllers/EksternalController.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Modules\DeReporting\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+use App\Modules\DeReporting\Models\Eksternal;
+use App\Modules\DeReporting\Requests\StoreEksternalRequest;
+
+class EksternalController extends Controller
+{
+    /**
+     * KONSTRUKTOR PERTAHANAN (SECURITY CONSTRUCTOR)
+     * Perisai DDoS langsung di Controller agar tak lupa di Routes!
+     */
+    public function __construct()
+    {
+        // Membatasi metode storePublic maksimal 10 request per 1 menit (Rule 6.4)
+        $this->middleware('throttle:10,1')->only('storePublic');
+    }
+
+    /**
+     * GET /api/dereporting/eksternals
+     * ADMIN ONLY: Membaca Daftar Laporan Masuk dari Masyarakat
+     */
+    public function index(Request $request)
+    {
+        $query = Eksternal::latest();
+
+        // Fitur Pencarian Cerdas untuk Operator
+        if ($request->filled('search')) {
+            $search = $request->search;
+            $query->where('judul_laporan', 'ilike', "%{$search}%")
+                  ->orWhere('nama_pelapor', 'ilike', "%{$search}%")
+                  ->orWhere('instansi', 'ilike', "%{$search}%");
+        }
+
+        // Filter Berdasarkan Status (Cari yang 'Menunggu Tinjauan')
+        if ($request->filled('status')) {
+            $query->where('status', $request->status);
+        }
+
+        return response()->json($query->paginate(20));
+    }
+
+    /**
+     * POST /api/dereporting/eksternals/public
+     * PUBLIC ROUTE: Gerbang penerimaan berkas masyarakat dunia
+     */
+    public function storePublic(StoreEksternalRequest $request)
+    {
+        $filePath = null;
+
+        if ($request->hasFile('file')) {
+            $file = $request->file('file');
+            // Menghancurkan nama asli (Mencegah serangan skrip .php.pdf)
+            $filename = Str::uuid() . '.' . $file->getClientOriginalExtension();
+            // Mengarantina file di dalam Brankas Isolasi Publik
+            $filePath = $file->storeAs('private/dereporting/eksternals', $filename);
+        }
+
+        $report = Eksternal::create([
+            'nama_pelapor'  => $request->nama_pelapor,
+            'instansi'      => $request->instansi,
+            'email'         => $request->email,
+            'no_hp'         => $request->no_hp,
+            'judul_laporan' => $request->judul_laporan,
+            'deskripsi'     => $request->deskripsi,
+            'file_path'     => $filePath,
+        ]);
+
+        // JEJAK FORENSIK RAHASIA (Rule 4.6) — diisi oleh sistem, bukan fillable
+        $report->ip_address = $request->ip();
+        $report->status = 'Menunggu Tinjauan';
+        $report->save();
+
+        return response()->json([
+            'message' => 'Laporan Anda berhasil dikirim ke Markas BKSDA. Kami telah mencatat tiket Anda.',
+            // JANGAN mengirimkan IP Address balik ke layar pengguna!
+            'data'    => $report->only(['id', 'nama_pelapor', 'status', 'created_at'])
+        ], 201);
+    }
+
+    /**
+     * PUT /api/dereporting/eksternals/{id}/status
+     * ADMIN ONLY: Memverifikasi / Menolak laporan masyarakat
+     */
+    public function updateStatus(Request $request, string $id)
+    {
+        $request->validate([
+            'status' => 'required|in:Menunggu Tinjauan,Diterima,Ditolak',
+        ]);
+
+        $report = Eksternal::findOrFail($id);
+        $report->update(['status' => $request->status]);
+
+        return response()->json([
+            'message' => "Status laporan berhasil diubah menjadi: {$request->status}",
+            'data'    => $report
+        ]);
+    }
+
+    /**
+     * GET /api/dereporting/eksternals/{id}/download
+     * ADMIN ONLY: Pintu ekstraksi berkas masyarakat yang aman
+     */
+    public function downloadFile(string $id)
+    {
+        $report = Eksternal::findOrFail($id);
+
+        if (!$report->file_path || !Storage::exists($report->file_path)) {
+            return response()->json(['message' => 'Berkas laporan gagal ditemukan di karantina.'], 404);
+        }
+
+        return Storage::download($report->file_path, $report->judul_laporan . '_Pelapor_Eksternal.' . pathinfo($report->file_path, PATHINFO_EXTENSION));
+    }
+}

--- a/backend/app/Modules/DeReporting/Controllers/EkternalController.php
+++ b/backend/app/Modules/DeReporting/Controllers/EkternalController.php
@@ -7,9 +7,10 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
-use App\Modules\DeReporting\Models\Ekternal;
+use App\Modules\DeReporting\Models\Eksternal;
+use App\Modules\DeReporting\Requests\StoreEksternalRequest;
 
-class EkternalController extends Controller
+class EksternalController extends Controller
 {
     /**
      * KONSTRUKTOR PERTAHANAN (SECURITY CONSTRUCTOR)
@@ -20,6 +21,103 @@ class EkternalController extends Controller
         // Membatasi metode storePublic maksimal 10 request per 1 menit (Rule 6.4)
         $this->middleware('throttle:10,1')->only('storePublic');
     }
+
+    /**
+     * GET /api/dereporting/eksternal
+     * ADMIN ONLY: Membaca Daftar Laporan Masuk dari Masyarakat
+     */
+    public function index(Request $request)
+    {
+        $query = Eksternal::latest();
+
+        // Fitur Pencarian Cerdas untuk Operator
+        if ($request->filled('search')) {
+            $search = $request->search;
+            $query->where('judul_laporan', 'ilike', "%{$search}%")
+                  ->orWhere('nama_pelapor', 'ilike', "%{$search}%")
+                  ->orWhere('instansi', 'ilike', "%{$search}%");
+        }
+
+        // Filter Berdasarkan Status (Cari yang 'Menunggu Tinjauan')
+        if ($request->filled('status')) {
+            $query->where('status', $request->status);
+        }
+
+        return response()->json($query->paginate(20));
+    }
+
+    /**
+     * POST /api/dereporting/eksternal/public
+     * PUBLIC ROUTE: Gerbang penerimaan berkas masyarakat dunia
+     */
+    public function storePublic(StoreEksternalRequest $request)
+    {
+        $filePath = null;
+
+        if ($request->hasFile('file')) {
+            $file = $request->file('file');
+            // Menghancurkan nama asli (Mencegah serangan skrip .php.pdf)
+            $filename = Str::uuid() . '.' . $file->getClientOriginalExtension();
+            // Mengarantina file di dalam Brankas Isolasi Publik
+            $filePath = $file->storeAs('private/dereporting/eksternal', $filename);
+        }
+
+        $report = Eksternal::create([
+            'nama_pelapor'  => $request->nama_pelapor,
+            'instansi'      => $request->instansi,
+            'email'         => $request->email,
+            'no_hp'         => $request->no_hp,
+            'judul_laporan' => $request->judul_laporan,
+            'deskripsi'     => $request->deskripsi,
+            'file_path'     => $filePath,
+        ]);
+
+        // JEJAK FORENSIK RAHASIA (Rule 4.6) — diisi oleh sistem, bukan fillable
+        $report->ip_address = $request->ip();
+        $report->status = 'Menunggu Tinjauan';
+        $report->save();
+
+        return response()->json([
+            'message' => 'Laporan Anda berhasil dikirim ke Markas BKSDA. Kami telah mencatat tiket Anda.',
+            // JANGAN mengirimkan IP Address balik ke layar pengguna!
+            'data'    => $report->only(['id', 'nama_pelapor', 'status', 'created_at'])
+        ], 201);
+    }
+
+    /**
+     * PUT /api/dereporting/eksternal/{id}/status
+     * ADMIN ONLY: Memverifikasi / Menolak laporan masyarakat
+     */
+    public function updateStatus(Request $request, string $id)
+    {
+        $request->validate([
+            'status' => 'required|in:Menunggu Tinjauan,Diterima,Ditolak',
+        ]);
+
+        $report = Eksternal::findOrFail($id);
+        $report->update(['status' => $request->status]);
+
+        return response()->json([
+            'message' => "Status laporan berhasil diubah menjadi: {$request->status}",
+            'data'    => $report
+        ]);
+    }
+
+    /**
+     * GET /api/dereporting/eksternal/{id}/download
+     * ADMIN ONLY: Pintu ekstraksi berkas masyarakat yang aman
+     */
+    public function downloadFile(string $id)
+    {
+        $report = Eksternal::findOrFail($id);
+
+        if (!$report->file_path || !Storage::exists($report->file_path)) {
+            return response()->json(['message' => 'Berkas laporan gagal ditemukan di karantina.'], 404);
+        }
+
+        return Storage::download($report->file_path, $report->judul_laporan . '_Pelapor_Eksternal.' . pathinfo($report->file_path, PATHINFO_EXTENSION));
+    }
+}
 
     /**
      * GET /api/dereporting/ekternals

--- a/backend/app/Modules/DeReporting/Controllers/InternalController.php
+++ b/backend/app/Modules/DeReporting/Controllers/InternalController.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 use App\Modules\DeReporting\Models\Internal;
+use App\Modules\DeReporting\Requests\StoreInternalRequest;
 
 class InternalController extends Controller
 {
@@ -44,19 +45,8 @@ class InternalController extends Controller
      * POST /api/dereporting/internals
      * Mengunggah Laporan Baru (Terkunci Auth)
      */
-    public function store(Request $request)
+    public function store(StoreInternalRequest $request)
     {
-        // Catatan: Validasi Ekstrem akan diintegrasikan pada Issue 085 (FormRequests).
-        $request->validate([
-            'judul_laporan' => 'required|string|max:255',
-            'tahun_id'      => 'required|uuid|exists:dr_tahun,id',
-            'bidang_id'     => 'required|uuid|exists:dr_bidang,id',
-            'jenis_id'      => 'required|uuid|exists:dr_jenis,id',
-            'kategori_id'   => 'required|uuid|exists:dr_kategori,id',
-            'jenis_data_id' => 'required|uuid|exists:dr_jenis_data,id',
-            'file'          => 'required|file|max:10240|mimes:pdf,doc,docx,xls,xlsx,zip,rar',
-        ]);
-
         $filePath = null;
 
         if ($request->hasFile('file')) {

--- a/backend/app/Modules/DeReporting/Requests/StoreEksternalRequest.php
+++ b/backend/app/Modules/DeReporting/Requests/StoreEksternalRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Modules\DeReporting\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreEksternalRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true; // Form ini terbuka untuk Publik (Celah Eksternal)
+    }
+
+    public function rules(): array
+    {
+        return [
+            // Cekik panjang karakter agar memori Server tidak meledak diserang Bot
+            'nama_pelapor'  => ['required', 'string', 'max:150'],
+            'instansi'      => ['nullable', 'string', 'max:150'],
+            'email'         => ['nullable', 'email', 'max:100'],
+            'no_hp'         => ['nullable', 'string', 'max:20'],
+            'judul_laporan' => ['required', 'string', 'max:255'],
+            'deskripsi'     => ['nullable', 'string'],
+
+            // Masyarakat boleh mengirimkan bukti Foto (jpg, png, jpeg)
+            'file'          => ['required', 'file', 'max:10240', 'mimes:pdf,doc,docx,xls,xlsx,zip,rar,jpg,png,jpeg'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'file.max'    => 'Berkas terlalu berat. Mohon pastikan file Anda di bawah 10 MB.',
+            'email.email' => 'Format surat elektronik (Email) tidak valid.',
+            'nama_pelapor.max' => 'Nama terlampau panjang, maksimal 150 karakter.',
+        ];
+    }
+}

--- a/backend/app/Modules/DeReporting/Requests/StoreInternalRequest.php
+++ b/backend/app/Modules/DeReporting/Requests/StoreInternalRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Modules\DeReporting\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreInternalRequest extends FormRequest
+{
+    /**
+     * Memastikan hanya yang berwenang yang bisa menembus perisai ini.
+     * Kita serahkan ke true karena Autentikasi diurus Middleware Route.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Tembok Baja Aturan Input
+     */
+    public function rules(): array
+    {
+        return [
+            'judul_laporan' => ['required', 'string', 'max:255'],
+            // Validasi Integritas Relasional: Pastikan UUID tersebut ada di Database!
+            'tahun_id'      => ['required', 'uuid', 'exists:dr_tahun,id'],
+            'bidang_id'     => ['required', 'uuid', 'exists:dr_bidang,id'],
+            'jenis_id'      => ['required', 'uuid', 'exists:dr_jenis,id'],
+            'kategori_id'   => ['required', 'uuid', 'exists:dr_kategori,id'],
+            'jenis_data_id' => ['required', 'uuid', 'exists:dr_jenis_data,id'],
+
+            // Kolom Opsional
+            'koordinator_id'=> ['nullable', 'uuid', 'exists:dr_koordinator,id'],
+            'anggaran_id'   => ['nullable', 'uuid', 'exists:dr_anggaran,id'],
+            'keterangan'    => ['nullable', 'string'],
+
+            // Proteksi Inti Berkas (Project Rule 4.1 & 4.2)
+            // Maksimal 10240 KB = 10 MB
+            'file'          => ['required', 'file', 'max:10240', 'mimes:pdf,doc,docx,xls,xlsx,zip,rar'],
+        ];
+    }
+
+    /**
+     * Pesan Peringatan Ramah Manusia
+     */
+    public function messages(): array
+    {
+        return [
+            'file.max'   => 'Kapasitas brankas tidak memadai. Ukuran berkas dilarang melebihi 10 Megabytes.',
+            'file.mimes' => 'Format laporan terlarang! Hanya menerima wujud: PDF, DOCX, XLSX, ZIP, atau RAR.',
+            '*.exists'   => 'Identitas referensi Master Data tersebut telah dipalsukan atau musnah dari sistem.',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
Penyempurnaan estetika kode dan pendelegasian keamanan lapis pertama dari *Controller* menuju pos penjagaan *FormRequest*.

## Changes
- Penciptaan wujud perisai \StoreInternalRequest\ yang dibekali sensor peraba \exists:table,id\ untuk mencegah masuknya data master fiktif.
- Penciptaan alat cegah tangkal *Payload* berlebih \StoreEksternalRequest\ yang mencekik panjang *String* masyarakat pada 150-255 karakter.
- Terjemahan Custom Error Messages (*Human Readable Errors*) untuk UX *Frontend* yang jauh lebih sopan dan jelas saat menolak berkas besar.
- Refactoring InternalController dan EksternalController untuk menggunakan FormRequest.

## Rules Compliance
- [x] Lolos Doktrin Pembatasan Berkas (Project Rule 4.1 & 4.2): Validasi ketat wujud fisik berkas *MIME (pdf, xls, docx)* serta pemakuan batas muatan raksasa \max:10240\ sukses ditegakkan.

Closes #161