### PR TITLE
feat(cms): architect comprehensive 16-table content management schema for public website (#91)

### DIFF
--- a/backend/app/Modules/CMS/Migrations/2024_01_01_000001_create_cms_foundation_tables.php
+++ b/backend/app/Modules/CMS/Migrations/2024_01_01_000001_create_cms_foundation_tables.php
@@ -1,0 +1,77 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // 1. Kategori Konten (Berita, Pengumuman, Siaran Pers, dll)
+        Schema::create('cms_categories', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('nama', 100)->unique();
+            $table->string('slug', 120)->unique(); // URL-friendly: "siaran-pers"
+            $table->string('tipe', 50)->default('informasi'); // informasi, publikasi, galeri
+            $table->integer('urutan')->default(0); // Untuk pengurutan manual
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 2. Pengaturan Website (Singleton — Hanya 1 Baris Data)
+        Schema::create('cms_website', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('nama_instansi', 255)->default('BKSDA');
+            $table->string('alamat', 500)->nullable();
+            $table->string('telepon', 30)->nullable();
+            $table->string('email', 100)->nullable();
+            $table->string('fax', 30)->nullable();
+            $table->text('tentang')->nullable(); // Deskripsi singkat di Footer
+            $table->string('logo_path', 500)->nullable();
+            $table->string('favicon_path', 500)->nullable();
+            // Sosial Media
+            $table->string('facebook', 255)->nullable();
+            $table->string('instagram', 255)->nullable();
+            $table->string('youtube', 255)->nullable();
+            $table->string('twitter', 255)->nullable();
+            $table->timestamps();
+        });
+
+        // 3. Kepala Kantor (Pimpinan BKSDA — Ditampilkan di Halaman Profil)
+        Schema::create('cms_kepala', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('nama', 150);
+            $table->string('nip', 30)->nullable();
+            $table->string('jabatan', 100)->default('Kepala BKSDA');
+            $table->string('foto_path', 500)->nullable();
+            $table->text('sambutan')->nullable(); // Kata Sambutan Pimpinan
+            $table->boolean('is_active')->default(true); // Hanya 1 yang aktif
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 4. Menu Navigasi Website (Header & Footer)
+        Schema::create('cms_menus', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('label', 100);          // Teks yang ditampilkan
+            $table->string('url', 500);             // Link tujuan
+            $table->string('posisi', 20)->default('header'); // header, footer
+            $table->uuid('parent_id')->nullable();  // Sub-menu (self-referencing)
+            $table->integer('urutan')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->foreign('parent_id')->references('id')->on('cms_menus')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cms_menus');
+        Schema::dropIfExists('cms_kepala');
+        Schema::dropIfExists('cms_website');
+        Schema::dropIfExists('cms_categories');
+    }
+};

--- a/backend/app/Modules/CMS/Migrations/2024_01_01_000002_create_cms_content_tables.php
+++ b/backend/app/Modules/CMS/Migrations/2024_01_01_000002_create_cms_content_tables.php
@@ -1,0 +1,83 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // 5. Informasi / Berita (Konten utama website)
+        Schema::create('cms_informasi', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('category_id')->nullable()->constrained('cms_categories')->onDelete('set null');
+            $table->foreignUuid('user_id')->nullable()->constrained('users')->onDelete('set null');
+            $table->string('judul', 500);
+            $table->string('slug', 520)->unique();
+            $table->text('konten');                  // Konten HTML dari Rich Text Editor
+            $table->string('thumbnail_path', 500)->nullable();
+            $table->string('sumber', 255)->nullable(); // Sumber berita (jika dari luar)
+            $table->boolean('is_published')->default(false);
+            $table->timestamp('published_at')->nullable();
+            $table->integer('views_count')->default(0);
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index('is_published');
+            $table->index('published_at');
+        });
+
+        // 6. Profil Organisasi (Visi, Misi, Sejarah, Struktur)
+        Schema::create('cms_profil', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('judul', 255);
+            $table->string('slug', 270)->unique();
+            $table->text('konten');
+            $table->string('thumbnail_path', 500)->nullable();
+            $table->integer('urutan')->default(0);
+            $table->boolean('is_published')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 7. Kawasan Konservasi (Data Teknis + Peta)
+        Schema::create('cms_kawasan', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('nama', 255);
+            $table->string('slug', 270)->unique();
+            $table->text('deskripsi');
+            $table->string('thumbnail_path', 500)->nullable();
+            $table->decimal('latitude', 10, 7)->nullable();   // Koordinat Peta
+            $table->decimal('longitude', 10, 7)->nullable();
+            $table->decimal('luas_ha', 12, 2)->nullable();     // Luas dalam Hektar
+            $table->string('tipe_kawasan', 100)->nullable();   // "Cagar Alam", "Suaka Margasatwa"
+            $table->boolean('is_published')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 8. TSL — Tumbuhan & Satwa Liar (Spesies Dilindungi)
+        Schema::create('cms_tsl', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('nama_lokal', 255);         // Nama Indonesia
+            $table->string('nama_latin', 255)->nullable(); // Nama Ilmiah
+            $table->string('slug', 270)->unique();
+            $table->text('deskripsi');
+            $table->string('thumbnail_path', 500)->nullable();
+            $table->string('status_iucn', 50)->nullable(); // CR, EN, VU, NT, LC
+            $table->string('tipe', 20)->default('satwa');  // satwa, tumbuhan
+            $table->boolean('is_published')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cms_tsl');
+        Schema::dropIfExists('cms_kawasan');
+        Schema::dropIfExists('cms_profil');
+        Schema::dropIfExists('cms_informasi');
+    }
+};

--- a/backend/app/Modules/CMS/Migrations/2024_01_01_000003_create_cms_media_tables.php
+++ b/backend/app/Modules/CMS/Migrations/2024_01_01_000003_create_cms_media_tables.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // 9. Galeri Foto
+        Schema::create('cms_photos', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('judul', 255)->nullable();
+            $table->string('deskripsi', 500)->nullable();
+            $table->string('file_path', 500);
+            $table->string('album', 100)->nullable(); // Pengelompokan album
+            $table->boolean('is_published')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 10. Galeri Video (Embed YouTube / Upload)
+        Schema::create('cms_videos', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('judul', 255);
+            $table->string('deskripsi', 500)->nullable();
+            $table->string('youtube_url', 500)->nullable();  // Embed YouTube
+            $table->string('file_path', 500)->nullable();    // Atau upload langsung
+            $table->string('thumbnail_path', 500)->nullable();
+            $table->boolean('is_published')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 11. Pesan Masuk (Kontak Kami / Feedback)
+        Schema::create('cms_pesan', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('nama', 150);
+            $table->string('email', 100)->nullable();
+            $table->string('subjek', 255);
+            $table->text('isi');
+            $table->string('ip_address', 45)->nullable();
+            $table->boolean('is_read')->default(false);   // Sudah dibaca admin?
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 12. Tautan Penting / Link Terkait
+        Schema::create('cms_links', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('judul', 255);
+            $table->string('url', 500);
+            $table->string('logo_path', 500)->nullable(); // Logo instansi terkait
+            $table->integer('urutan')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cms_links');
+        Schema::dropIfExists('cms_pesan');
+        Schema::dropIfExists('cms_videos');
+        Schema::dropIfExists('cms_photos');
+    }
+};

--- a/backend/app/Modules/CMS/Migrations/2024_01_01_000004_create_cms_publication_tables.php
+++ b/backend/app/Modules/CMS/Migrations/2024_01_01_000004_create_cms_publication_tables.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // 13. Jenis Publikasi (Kategori khusus dokumen: "Peraturan Gubernur", "SK Menteri")
+        Schema::create('cms_jenis', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('nama', 100)->unique();
+            $table->string('tipe', 50); // buku, leaflet, poster, regulasi
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 14. Buku Publikasi
+        Schema::create('cms_buku', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('jenis_id')->nullable()->constrained('cms_jenis')->onDelete('set null');
+            $table->string('judul', 500);
+            $table->string('slug', 520)->unique();
+            $table->text('deskripsi')->nullable();
+            $table->string('penulis', 255)->nullable();
+            $table->string('penerbit', 255)->nullable();
+            $table->string('tahun_terbit', 4)->nullable();
+            $table->string('cover_path', 500)->nullable(); // PDF untuk diunduh
+            $table->boolean('is_published')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 15. Leaflet & Poster (Brosur Digital)
+        Schema::create('cms_leaflet', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('jenis_id')->nullable()->constrained('cms_jenis')->onDelete('set null');
+            $table->string('judul', 500);
+            $table->string('slug', 520)->unique();
+            $table->text('deskripsi')->nullable();
+            $table->string('file_path', 500);          // Gambar/PDF leaflet
+            $table->string('thumbnail_path', 500)->nullable();
+            $table->string('tipe', 20)->default('leaflet'); // leaflet, poster
+            $table->boolean('is_published')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // 16. Regulasi & Peraturan Hukum
+        Schema::create('cms_regulasi', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('jenis_id')->nullable()->constrained('cms_jenis')->onDelete('set null');
+            $table->string('judul', 500);
+            $table->string('slug', 520)->unique();
+            $table->string('nomor', 100)->nullable();       // "PP No. 7 Tahun 1999"
+            $table->string('tahun', 4)->nullable();
+            $table->text('deskripsi')->nullable();
+            $table->string('file_path', 500)->nullable();    // PDF regulasi
+            $table->boolean('is_published')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cms_regulasi');
+        Schema::dropIfExists('cms_leaflet');
+        Schema::dropIfExists('cms_buku');
+        Schema::dropIfExists('cms_jenis');
+    }
+};


### PR DESCRIPTION
## Summary
Penancapan fondasi Database Raksasa untuk Modul CMS — Wajah Publik BKSDA.

## Changes
- **Gelombang 1**: Fondasi (\cms_categories\, \cms_website\, \cms_kepala\, \cms_menus\)
- **Gelombang 2**: Konten Utama (\cms_informasi\, \cms_profil\, \cms_kawasan\, \cms_tsl\)
- **Gelombang 3**: Media (\cms_photos\, \cms_videos\, \cms_pesan\, \cms_links\)
- **Gelombang 4**: Publikasi (\cms_jenis\, \cms_buku\, \cms_leaflet\, \cms_regulasi\)
- Seluruh tabel konten memiliki kolom \is_published\ dan \SoftDeletes\.

## Rules Compliance
- [x] Lolos Doktrin Isolasi Modular (Project Rule 3.7): Seluruh 16 tabel diisolasi sempurna menggunakan prefiks \cms_\.

Closes #91