### PR TITLE
feat(cms): construct 17 Eloquent models with STI pattern (#92)

### DIFF
--- a/backend/app/Modules/CMS/Models/Buku.php
+++ b/backend/app/Modules/CMS/Models/Buku.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Buku extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_buku';
+
+    protected $fillable = [
+        'jenis_id',
+        'judul',
+        'slug',
+        'deskripsi',
+        'penulis',
+        'penerbit',
+        'tahun_terbit',
+        'cover_path',
+        'is_published',
+    ];
+
+    protected $casts = [
+        'is_published' => 'boolean',
+    ];
+
+    /** Jenis publikasi buku ini */
+    public function jenis()
+    {
+        return $this->belongsTo(Jenis::class, 'jenis_id');
+    }
+}

--- a/backend/app/Modules/CMS/Models/Category.php
+++ b/backend/app/Modules/CMS/Models/Category.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Category extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_categories';
+
+    protected $fillable = [
+        'nama',
+        'slug',
+        'tipe',
+        'urutan',
+    ];
+
+    protected $casts = [
+        'urutan' => 'integer',
+    ];
+
+    /** Berita yang termasuk kategori ini */
+    public function informasi()
+    {
+        return $this->hasMany(Informasi::class, 'category_id');
+    }
+}

--- a/backend/app/Modules/CMS/Models/Informasi.php
+++ b/backend/app/Modules/CMS/Models/Informasi.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Informasi extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_informasi';
+
+    protected $fillable = [
+        'category_id',
+        'user_id',
+        'judul',
+        'slug',
+        'konten',
+        'thumbnail_path',
+        'sumber',
+        'is_published',
+        'published_at',
+        'views_count',
+    ];
+
+    protected $casts = [
+        'is_published' => 'boolean',
+        'published_at' => 'datetime',
+        'views_count'  => 'integer',
+    ];
+
+    /** Kategori Berita (Siaran Pers, dll) */
+    public function category()
+    {
+        return $this->belongsTo(Category::class, 'category_id');
+    }
+
+    /** Penulis / Admin yang membuat berita */
+    public function author()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    /** Scope: Hanya tampilkan yang sudah dipublikasikan */
+    public function scopePublished($query)
+    {
+        return $query->where('is_published', true);
+    }
+}

--- a/backend/app/Modules/CMS/Models/Jenis.php
+++ b/backend/app/Modules/CMS/Models/Jenis.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Jenis extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_jenis';
+
+    protected $fillable = [
+        'nama',
+        'tipe',
+    ];
+
+    /** Buku yang termasuk jenis ini */
+    public function buku()
+    {
+        return $this->hasMany(Buku::class, 'jenis_id');
+    }
+
+    /** Regulasi yang termasuk jenis ini */
+    public function regulasi()
+    {
+        return $this->hasMany(Regulasi::class, 'jenis_id');
+    }
+}

--- a/backend/app/Modules/CMS/Models/Kawasan.php
+++ b/backend/app/Modules/CMS/Models/Kawasan.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Kawasan extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_kawasan';
+
+    protected $fillable = [
+        'nama',
+        'slug',
+        'deskripsi',
+        'thumbnail_path',
+        'latitude',
+        'longitude',
+        'luas_ha',
+        'tipe_kawasan',
+        'is_published',
+    ];
+
+    protected $casts = [
+        'latitude'     => 'float',
+        'longitude'    => 'float',
+        'luas_ha'      => 'float',
+        'is_published' => 'boolean',
+    ];
+}

--- a/backend/app/Modules/CMS/Models/Kepala.php
+++ b/backend/app/Modules/CMS/Models/Kepala.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Kepala extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_kepala';
+
+    protected $fillable = [
+        'nama',
+        'nip',
+        'jabatan',
+        'foto_path',
+        'sambutan',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+
+    /** Scope: Hanya tampilkan kepala yang aktif */
+    public function scopeActive($query)
+    {
+        return $query->where('is_active', true);
+    }
+}

--- a/backend/app/Modules/CMS/Models/Leaflet.php
+++ b/backend/app/Modules/CMS/Models/Leaflet.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Leaflet extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_leaflet';
+
+    protected $fillable = [
+        'jenis_id',
+        'judul',
+        'slug',
+        'deskripsi',
+        'file_path',
+        'thumbnail_path',
+        'tipe',
+        'is_published',
+    ];
+
+    protected $casts = [
+        'is_published' => 'boolean',
+    ];
+
+    /** Sihir STI: Otomatis filter hanya data bertipe 'leaflet' */
+    protected static function booted(): void
+    {
+        static::addGlobalScope('leaflet', function ($query) {
+            $query->where('tipe', 'leaflet');
+        });
+    }
+
+    /** Otomatis set tipe saat membuat data baru */
+    protected static function boot(): void
+    {
+        parent::boot();
+        static::creating(function ($model) {
+            $model->tipe = 'leaflet';
+        });
+    }
+
+    /** Jenis publikasi */
+    public function jenis()
+    {
+        return $this->belongsTo(Jenis::class, 'jenis_id');
+    }
+}

--- a/backend/app/Modules/CMS/Models/Link.php
+++ b/backend/app/Modules/CMS/Models/Link.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Link extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_links';
+
+    protected $fillable = [
+        'judul',
+        'url',
+        'logo_path',
+        'urutan',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'urutan'    => 'integer',
+        'is_active' => 'boolean',
+    ];
+}

--- a/backend/app/Modules/CMS/Models/Menu.php
+++ b/backend/app/Modules/CMS/Models/Menu.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Menu extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_menus';
+
+    protected $fillable = [
+        'label',
+        'url',
+        'posisi',
+        'parent_id',
+        'urutan',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+        'urutan'    => 'integer',
+    ];
+
+    /** Induk menu (jika ini adalah sub-menu) */
+    public function parent()
+    {
+        return $this->belongsTo(Menu::class, 'parent_id');
+    }
+
+    /** Anak-anak menu (sub-menu di bawahnya) */
+    public function children()
+    {
+        return $this->hasMany(Menu::class, 'parent_id')->orderBy('urutan');
+    }
+}

--- a/backend/app/Modules/CMS/Models/Pesan.php
+++ b/backend/app/Modules/CMS/Models/Pesan.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Pesan extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_pesan';
+
+    protected $fillable = [
+        'nama',
+        'email',
+        'subjek',
+        'isi',
+        // ip_address dan is_read diisi oleh sistem, bukan user
+    ];
+
+    protected $casts = [
+        'is_read' => 'boolean',
+    ];
+
+    /** Scope: Pesan yang belum dibaca */
+    public function scopeUnread($query)
+    {
+        return $query->where('is_read', false);
+    }
+}

--- a/backend/app/Modules/CMS/Models/Photo.php
+++ b/backend/app/Modules/CMS/Models/Photo.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Photo extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_photos';
+
+    protected $fillable = [
+        'judul',
+        'deskripsi',
+        'file_path',
+        'album',
+        'is_published',
+    ];
+
+    protected $casts = [
+        'is_published' => 'boolean',
+    ];
+}

--- a/backend/app/Modules/CMS/Models/Poster.php
+++ b/backend/app/Modules/CMS/Models/Poster.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Poster extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_leaflet'; // Tabel SAMA dengan Leaflet (STI)
+
+    protected $fillable = [
+        'jenis_id',
+        'judul',
+        'slug',
+        'deskripsi',
+        'file_path',
+        'thumbnail_path',
+        'tipe',
+        'is_published',
+    ];
+
+    protected $casts = [
+        'is_published' => 'boolean',
+    ];
+
+    /** Sihir STI: Otomatis filter hanya data bertipe 'poster' */
+    protected static function booted(): void
+    {
+        static::addGlobalScope('poster', function ($query) {
+            $query->where('tipe', 'poster');
+        });
+    }
+
+    /** Otomatis set tipe saat membuat data baru */
+    protected static function boot(): void
+    {
+        parent::boot();
+        static::creating(function ($model) {
+            $model->tipe = 'poster';
+        });
+    }
+
+    /** Jenis publikasi */
+    public function jenis()
+    {
+        return $this->belongsTo(Jenis::class, 'jenis_id');
+    }
+}

--- a/backend/app/Modules/CMS/Models/Profil.php
+++ b/backend/app/Modules/CMS/Models/Profil.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Profil extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_profil';
+
+    protected $fillable = [
+        'judul',
+        'slug',
+        'konten',
+        'thumbnail_path',
+        'urutan',
+        'is_published',
+    ];
+
+    protected $casts = [
+        'urutan'       => 'integer',
+        'is_published' => 'boolean',
+    ];
+}

--- a/backend/app/Modules/CMS/Models/Regulasi.php
+++ b/backend/app/Modules/CMS/Models/Regulasi.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Regulasi extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_regulasi';
+
+    protected $fillable = [
+        'jenis_id',
+        'judul',
+        'slug',
+        'nomor',
+        'tahun',
+        'deskripsi',
+        'file_path',
+        'is_published',
+    ];
+
+    protected $casts = [
+        'is_published' => 'boolean',
+    ];
+
+    /** Jenis regulasi */
+    public function jenis()
+    {
+        return $this->belongsTo(Jenis::class, 'jenis_id');
+    }
+}

--- a/backend/app/Modules/CMS/Models/Tsl.php
+++ b/backend/app/Modules/CMS/Models/Tsl.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Tsl extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_tsl';
+
+    protected $fillable = [
+        'nama_lokal',
+        'nama_latin',
+        'slug',
+        'deskripsi',
+        'thumbnail_path',
+        'status_iucn',
+        'tipe',
+        'is_published',
+    ];
+
+    protected $casts = [
+        'is_published' => 'boolean',
+    ];
+
+    /** Scope: Hanya tampilkan satwa */
+    public function scopeSatwa($query)
+    {
+        return $query->where('tipe', 'satwa');
+    }
+
+    /** Scope: Hanya tampilkan tumbuhan */
+    public function scopeTumbuhan($query)
+    {
+        return $query->where('tipe', 'tumbuhan');
+    }
+}

--- a/backend/app/Modules/CMS/Models/Video.php
+++ b/backend/app/Modules/CMS/Models/Video.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Video extends Model
+{
+    use HasFactory, HasUuids, SoftDeletes;
+
+    protected $table = 'cms_videos';
+
+    protected $fillable = [
+        'judul',
+        'deskripsi',
+        'youtube_url',
+        'file_path',
+        'thumbnail_path',
+        'is_published',
+    ];
+
+    protected $casts = [
+        'is_published' => 'boolean',
+    ];
+}

--- a/backend/app/Modules/CMS/Models/Website.php
+++ b/backend/app/Modules/CMS/Models/Website.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Modules\CMS\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Website extends Model
+{
+    use HasFactory, HasUuids;
+
+    // Singleton — no SoftDeletes needed
+    protected $table = 'cms_website';
+
+    protected $fillable = [
+        'nama_instansi',
+        'alamat',
+        'telepon',
+        'email',
+        'fax',
+        'tentang',
+        'logo_path',
+        'favicon_path',
+        'facebook',
+        'instagram',
+        'youtube',
+        'twitter',
+    ];
+}


### PR DESCRIPTION
17 models for 16 CMS tables: STI (Leaflet/Poster), self-referencing (Menu), scoped (Tsl, Pesan, Kepala). Closes #92