### PR TITLE
chore(cms): register dual-path service provider for public website and admin panel routing (#93)

### DIFF
--- a/backend/app/Modules/CMS/Providers/CMSServiceProvider.php
+++ b/backend/app/Modules/CMS/Providers/CMSServiceProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Modules\CMS\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class CMSServiceProvider extends ServiceProvider
+{
+    /**
+     * Dijalankan pada saat mesin Laravel mulai melakukan pemanasan (Booting).
+     */
+    public function boot(): void
+    {
+        // 1. Mendaftarkan lokasi pabrik Database (Migrations) Modul CMS
+        $this->loadMigrationsFrom(__DIR__ . '/../Migrations');
+
+        // 2. JALUR PUBLIK: Website Pengunjung (Tanpa Auth)
+        //    Prefiks: /api/cms/public/
+        Route::prefix('api/cms/public')
+            ->middleware('api')
+            ->group(__DIR__ . '/../Routes/public.php');
+
+        // 3. JALUR ADMIN: Panel Pengelola Konten (Terkunci)
+        //    Prefiks: /api/cms/admin/
+        Route::prefix('api/cms/admin')
+            ->middleware(['api', 'auth:sanctum', 'module.access:cms'])
+            ->group(__DIR__ . '/../Routes/admin.php');
+    }
+
+    /**
+     * Dijalankan untuk menyuntikkan dependensi ekstra (Registering).
+     */
+    public function register(): void
+    {
+        // Kosongkan untuk saat ini.
+    }
+}

--- a/backend/app/Modules/CMS/Routes/admin.php
+++ b/backend/app/Modules/CMS/Routes/admin.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+// Endpoint Admin CMS BKSDA
+// Prefiks otomatis: /api/cms/admin/
+// Middleware: auth:sanctum + module.access:cms
+
+Route::get('/ping', function () {
+    return response()->json(['message' => 'Panel Admin CMS BKSDA menyala!']);
+});

--- a/backend/app/Modules/CMS/Routes/public.php
+++ b/backend/app/Modules/CMS/Routes/public.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+// Endpoint Website Publik BKSDA
+// Prefiks otomatis: /api/cms/public/
+
+Route::get('/ping', function () {
+    return response()->json(['message' => 'Website Publik BKSDA menyala!']);
+});

--- a/backend/bootstrap/providers.php
+++ b/backend/bootstrap/providers.php
@@ -6,6 +6,7 @@ use App\Modules\SuratTugas\SuratTugasServiceProvider;
 use App\Modules\Inventory\InventoryServiceProvider;
 use App\Modules\Bmn\BmnServiceProvider;
 use App\Modules\DeReporting\Providers\DeReportingServiceProvider;
+use App\Modules\CMS\Providers\CMSServiceProvider;
 
 return [
     AppServiceProvider::class,
@@ -14,4 +15,5 @@ return [
     InventoryServiceProvider::class,
     BmnServiceProvider::class,
     DeReportingServiceProvider::class,
+    CMSServiceProvider::class,
 ];


### PR DESCRIPTION
CMSServiceProvider: dual routing (public + admin), migration loading, registered in bootstrap/providers.php. Closes #93