### PR TITLE
feat(cms): deploy trait-powered admin controller fleet for 16 content entities (#95)

### DIFF
--- a/backend/app/Modules/CMS/Controllers/Admin/BukuController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/BukuController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Modules\CMS\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\CMS\Traits\AdminCrudTrait;
+use App\Modules\CMS\Models\Buku;
+use Illuminate\Http\Request;
+
+class BukuController extends Controller
+{
+    use AdminCrudTrait;
+
+    protected string $model = Buku::class;
+
+    /** Override index: Eager load jenis publikasi */
+    public function index(Request $request)
+    {
+        $query = Buku::with('jenis:id,nama')->latest();
+
+        if ($request->filled('search')) {
+            $query->where('judul', 'ilike', '%' . $request->search . '%');
+        }
+
+        return response()->json($query->paginate(20));
+    }
+}

--- a/backend/app/Modules/CMS/Controllers/Admin/CategoryController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/CategoryController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\CMS\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\CMS\Traits\AdminCrudTrait;
+use App\Modules\CMS\Models\Category;
+
+class CategoryController extends Controller
+{
+    use AdminCrudTrait;
+
+    protected string $model = Category::class;
+}

--- a/backend/app/Modules/CMS/Controllers/Admin/InformasiController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/InformasiController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Modules\CMS\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\CMS\Traits\AdminCrudTrait;
+use App\Modules\CMS\Models\Informasi;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class InformasiController extends Controller
+{
+    use AdminCrudTrait;
+
+    protected string $model = Informasi::class;
+
+    /**
+     * Override index: Eager load category + author
+     */
+    public function index(Request $request)
+    {
+        $query = Informasi::with('category:id,nama', 'author:id,name')->latest();
+
+        if ($request->filled('search')) {
+            $query->where('judul', 'ilike', '%' . $request->search . '%');
+        }
+        if ($request->filled('category_id')) {
+            $query->where('category_id', $request->category_id);
+        }
+
+        return response()->json($query->paginate(20));
+    }
+
+    /**
+     * Override store: Inject user_id dan published_at
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'judul' => 'required|string|max:500',
+            'konten' => 'required|string',
+            'thumbnail' => 'nullable|file|max:5120|mimes:jpg,jpeg,png,webp',
+        ]);
+
+        $data = $request->only((new Informasi())->getFillable());
+        $data['user_id'] = $request->user()->id;
+        $data['slug'] = Str::slug($data['judul']) . '-' . Str::random(5);
+
+        // Jika langsung dipublikasi
+        if ($request->boolean('is_published')) {
+            $data['published_at'] = now();
+        }
+
+        $data = $this->handleFileUpload($request, $data);
+        $record = Informasi::create($data);
+
+        return response()->json([
+            'message' => 'Berita berhasil disimpan.',
+            'data' => $record
+        ], 201);
+    }
+
+    /**
+     * Endpoint khusus: Toggle status Publikasi (Terbitkan / Tarik)
+     */
+    public function togglePublish(string $id)
+    {
+        $berita = Informasi::findOrFail($id);
+        $berita->update([
+            'is_published' => !$berita->is_published,
+            'published_at' => !$berita->is_published ? now() : $berita->published_at,
+        ]);
+
+        $status = $berita->is_published ? 'diterbitkan' : 'ditarik dari publikasi';
+        return response()->json(['message' => "Berita berhasil {$status}.", 'data' => $berita]);
+    }
+}

--- a/backend/app/Modules/CMS/Controllers/Admin/JenisController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/JenisController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\CMS\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\CMS\Traits\AdminCrudTrait;
+use App\Modules\CMS\Models\Jenis;
+
+class JenisController extends Controller
+{
+    use AdminCrudTrait;
+
+    protected string $model = Jenis::class;
+}

--- a/backend/app/Modules/CMS/Controllers/Admin/KawasanController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/KawasanController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\CMS\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\CMS\Traits\AdminCrudTrait;
+use App\Modules\CMS\Models\Kawasan;
+
+class KawasanController extends Controller
+{
+    use AdminCrudTrait;
+
+    protected string $model = Kawasan::class;
+}

--- a/backend/app/Modules/CMS/Controllers/Admin/LeafletController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/LeafletController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\CMS\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\CMS\Traits\AdminCrudTrait;
+use App\Modules\CMS\Models\Leaflet;
+
+class LeafletController extends Controller
+{
+    use AdminCrudTrait;
+
+    protected string $model = Leaflet::class;
+}

--- a/backend/app/Modules/CMS/Controllers/Admin/LinkController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/LinkController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\CMS\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\CMS\Traits\AdminCrudTrait;
+use App\Modules\CMS\Models\Link;
+
+class LinkController extends Controller
+{
+    use AdminCrudTrait;
+
+    protected string $model = Link::class;
+}

--- a/backend/app/Modules/CMS/Controllers/Admin/PesanController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/PesanController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Modules\CMS\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\CMS\Models\Pesan;
+use Illuminate\Http\Request;
+
+class PesanController extends Controller
+{
+    /** Daftar pesan masuk */
+    public function index(Request $request)
+    {
+        $query = Pesan::latest();
+
+        if ($request->filled('is_read')) {
+            $query->where('is_read', $request->boolean('is_read'));
+        }
+
+        return response()->json($query->paginate(20));
+    }
+
+    /** Tandai sudah dibaca */
+    public function markAsRead(string $id)
+    {
+        $pesan = Pesan::findOrFail($id);
+        $pesan->update(['is_read' => true]);
+        return response()->json(['message' => 'Pesan ditandai sudah dibaca.', 'data' => $pesan]);
+    }
+
+    /** Hapus pesan */
+    public function destroy(string $id)
+    {
+        Pesan::findOrFail($id)->delete();
+        return response()->json(['message' => 'Pesan dihapus.']);
+    }
+}

--- a/backend/app/Modules/CMS/Controllers/Admin/PhotoController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/PhotoController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\CMS\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\CMS\Traits\AdminCrudTrait;
+use App\Modules\CMS\Models\Photo;
+
+class PhotoController extends Controller
+{
+    use AdminCrudTrait;
+
+    protected string $model = Photo::class;
+}

--- a/backend/app/Modules/CMS/Controllers/Admin/PosterController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/PosterController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\CMS\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\CMS\Traits\AdminCrudTrait;
+use App\Modules\CMS\Models\Poster;
+
+class PosterController extends Controller
+{
+    use AdminCrudTrait;
+
+    protected string $model = Poster::class;
+}

--- a/backend/app/Modules/CMS/Controllers/Admin/ProfilController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/ProfilController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\CMS\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\CMS\Traits\AdminCrudTrait;
+use App\Modules\CMS\Models\Profil;
+
+class ProfilController extends Controller
+{
+    use AdminCrudTrait;
+
+    protected string $model = Profil::class;
+}

--- a/backend/app/Modules/CMS/Controllers/Admin/RegulasiController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/RegulasiController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Modules\CMS\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\CMS\Traits\AdminCrudTrait;
+use App\Modules\CMS\Models\Regulasi;
+use Illuminate\Http\Request;
+
+class RegulasiController extends Controller
+{
+    use AdminCrudTrait;
+
+    protected string $model = Regulasi::class;
+
+    /** Override index: Eager load jenis + filter tahun */
+    public function index(Request $request)
+    {
+        $query = Regulasi::with('jenis:id,nama')->latest();
+
+        if ($request->filled('search')) {
+            $query->where('judul', 'ilike', '%' . $request->search . '%');
+        }
+        if ($request->filled('tahun')) {
+            $query->where('tahun', $request->tahun);
+        }
+
+        return response()->json($query->paginate(20));
+    }
+}

--- a/backend/app/Modules/CMS/Controllers/Admin/TslController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/TslController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\CMS\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\CMS\Traits\AdminCrudTrait;
+use App\Modules\CMS\Models\Tsl;
+
+class TslController extends Controller
+{
+    use AdminCrudTrait;
+
+    protected string $model = Tsl::class;
+}

--- a/backend/app/Modules/CMS/Controllers/Admin/VideoController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/VideoController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Modules\CMS\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\CMS\Traits\AdminCrudTrait;
+use App\Modules\CMS\Models\Video;
+
+class VideoController extends Controller
+{
+    use AdminCrudTrait;
+
+    protected string $model = Video::class;
+}

--- a/backend/app/Modules/CMS/Controllers/Admin/WebsiteController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/WebsiteController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Modules\CMS\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Modules\CMS\Models\Website;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class WebsiteController extends Controller
+{
+    /** Website bersifat Singleton — hanya 1 baris */
+    public function show()
+    {
+        $data = Website::firstOrCreate([], ['nama_instansi' => 'BKSDA']);
+        return response()->json(['data' => $data]);
+    }
+
+    public function update(Request $request)
+    {
+        $website = Website::firstOrCreate([], ['nama_instansi' => 'BKSDA']);
+        $data = $request->only($website->getFillable());
+
+        // Handle logo dan favicon
+        foreach (['logo' => 'logo_path', 'favicon' => 'favicon_path'] as $input => $col) {
+            if ($request->hasFile($input)) {
+                $file = $request->file($input);
+                $filename = Str::uuid() . '.' . $file->getClientOriginalExtension();
+                $data[$col] = $file->storeAs('private/cms', $filename);
+            }
+        }
+
+        $website->update($data);
+        return response()->json(['message' => 'Pengaturan website berhasil diperbarui.', 'data' => $website]);
+    }
+}

--- a/backend/app/Modules/CMS/Traits/AdminCrudTrait.php
+++ b/backend/app/Modules/CMS/Traits/AdminCrudTrait.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Modules\CMS\Traits;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * TRAIT SERBAGUNA UNTUK ADMIN CRUD
+ *
+ * Cara Penggunaan:
+ * 1. Di Controller, tulis: use AdminCrudTrait;
+ * 2. Buat properti: protected string $model = \App\Modules\CMS\Models\Profil::class;
+ * 3. (Opsional) Override metode jika butuh logika khusus.
+ */
+trait AdminCrudTrait
+{
+    /**
+     * GET — Daftar semua data (termasuk draft, karena ini Admin)
+     */
+    public function index(Request $request)
+    {
+        $query = $this->model::query()->latest();
+
+        if ($request->filled('search')) {
+            // Cari di kolom 'judul' atau 'nama' (keduanya umum di CMS)
+            $search = $request->search;
+            $query->where(function ($q) use ($search) {
+                $q->where('judul', 'ilike', "%{$search}%")
+                  ->orWhere('nama', 'ilike', "%{$search}%");
+            });
+        }
+
+        return response()->json($query->paginate(20));
+    }
+
+    /**
+     * GET — Detail satu data
+     */
+    public function show(string $id)
+    {
+        $record = $this->model::findOrFail($id);
+        return response()->json(['data' => $record]);
+    }
+
+    /**
+     * POST — Buat data baru
+     */
+    public function store(Request $request)
+    {
+        $modelInstance = new $this->model();
+        $data = $request->only($modelInstance->getFillable());
+
+        // Auto-generate slug jika ada kolom 'judul'
+        if (isset($data['judul']) && !isset($data['slug'])) {
+            $data['slug'] = Str::slug($data['judul']) . '-' . Str::random(5);
+        }
+
+        // Handle file upload jika ada
+        $data = $this->handleFileUpload($request, $data);
+
+        $record = $this->model::create($data);
+
+        return response()->json([
+            'message' => 'Data berhasil ditambahkan.',
+            'data' => $record
+        ], 201);
+    }
+
+    /**
+     * PUT — Perbarui data
+     */
+    public function update(Request $request, string $id)
+    {
+        $record = $this->model::findOrFail($id);
+        $data = $request->only($record->getFillable());
+
+        // Regenerate slug jika judul berubah
+        if (isset($data['judul']) && $data['judul'] !== $record->judul) {
+            $data['slug'] = Str::slug($data['judul']) . '-' . Str::random(5);
+        }
+
+        $data = $this->handleFileUpload($request, $data);
+        $record->update($data);
+
+        return response()->json([
+            'message' => 'Data berhasil diperbarui.',
+            'data' => $record
+        ]);
+    }
+
+    /**
+     * DELETE — Hapus Lunak (SoftDelete)
+     */
+    public function destroy(string $id)
+    {
+        $record = $this->model::findOrFail($id);
+
+        try {
+            $record->delete();
+            return response()->json(['message' => 'Data berhasil dihapus.']);
+        } catch (\Exception $e) {
+            return response()->json([
+                'error' => 'Data tidak dapat dihapus karena masih terkait data lain.'
+            ], 422);
+        }
+    }
+
+    /**
+     * Pemroses File Upload Otomatis
+     * Mendeteksi field umum: thumbnail, file, foto, cover, logo
+     */
+    protected function handleFileUpload(Request $request, array $data): array
+    {
+        $fileFields = [
+            'thumbnail'  => 'thumbnail_path',
+            'file'       => 'file_path',
+            'foto'       => 'foto_path',
+            'cover'      => 'cover_path',
+            'logo'       => 'logo_path',
+            'favicon'    => 'favicon_path',
+        ];
+
+        foreach ($fileFields as $inputName => $dbColumn) {
+            if ($request->hasFile($inputName)) {
+                $file = $request->file($inputName);
+                $filename = Str::uuid() . '.' . $file->getClientOriginalExtension();
+                $path = $file->storeAs('private/cms', $filename);
+                $data[$dbColumn] = $path;
+            }
+        }
+
+        return $data;
+    }
+}


### PR DESCRIPTION
## Summary
Pembangunan Armada Pengendali Admin CMS menggunakan arsitektur *Trait Injection Pattern*.

## Changes
- Penciptaan `AdminCrudTrait` — senjata pemusnah kode berulang yang menyediakan 5 metode CRUD generik + *Auto File Upload Handler*.
- 10 Controller Ringan (`ProfilController`, `KawasanController`, dll) masing-masing hanya 12 baris berkat Trait.
- 5 Controller Khusus (`InformasiController`, `BukuController`, `RegulasiController`, `WebsiteController`, `PesanController`) dengan logika *Override* spesifik.
- Fitur `togglePublish` pada Informasi untuk mengubah status Draft ↔ Terbit.

## Files Created (16 files)
- **Trait**:  — 136 lines, reusable CRUD methods + file upload handler
- **10 Lightweight Controllers**: Profil, Kawasan, Tsl, Photo, Video, Link, Leaflet, Poster, Category, Jenis
- **5 Special Controllers**: Informasi (+togglePublish), Buku (+jenis eager load), Regulasi (+tahun filter), Website (singleton), Pesan (custom index/destroy)

## Acceptance Criteria
- [x] AdminCrudTrait.php diciptakan dengan 5 metode CRUD generik + handleFileUpload
- [x] 10 Controller Ringan masing-masing hanya 14 baris (trait + model declaration)
- [x] 5 Controller Khusus dengan override metode sesuai kebutuhan
- [x] InformasiController memiliki togglePublish() untuk Draft ↔ Terbit
- [x] WebsiteController singleton pattern (firstOrCreate)

Closes #95