### PR TITLE
feat(cms): deploy config-driven CRUD page factory eliminating 3600 lines of boilerplate (#99)

### DIFF
--- a/frontend/src/app/(dashboard)/cms/_components/CrudFormDrawer.tsx
+++ b/frontend/src/app/(dashboard)/cms/_components/CrudFormDrawer.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useState, useEffect, useRef, FormEvent } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { X, Save, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import type { CrudPageConfig } from "./types";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  config: CrudPageConfig;
+  editingRecord: Record<string, unknown> | null;
+}
+
+function getInitialFormData(
+  editingRecord: Record<string, unknown> | null,
+  fields: Props["config"]["fields"],
+): Record<string, unknown> {
+  if (!editingRecord) return {};
+  const initial: Record<string, unknown> = {};
+  fields.forEach((f) => {
+    if (f.type !== "file") initial[f.key] = editingRecord[f.key] ?? "";
+  });
+  return initial;
+}
+
+export default function CrudFormDrawer({
+  open,
+  onClose,
+  config,
+  editingRecord,
+}: Props) {
+  const queryClient = useQueryClient();
+  const [formData, setFormData] = useState<Record<string, unknown>>(() =>
+    getInitialFormData(editingRecord, config.fields),
+  );
+  const [files, setFiles] = useState<Record<string, File>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isEditing = !!editingRecord;
+  const prevOpenRef = useRef(open);
+
+  // Handle open state changes - only set state when transitioning
+  useEffect(() => {
+    if (open && !prevOpenRef.current) {
+      // Transitioning from closed to open - reset form data
+      setFormData(getInitialFormData(editingRecord, config.fields));
+      setFiles({});
+    }
+    prevOpenRef.current = open;
+  }, [open, editingRecord, config.fields]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      const hasFiles = Object.keys(files).length > 0;
+
+      if (hasFiles) {
+        // Jika ada file, gunakan FormData (multipart)
+        const formPayload = new FormData();
+        Object.entries(formData).forEach(([k, v]) => {
+          if (v !== undefined && v !== null) formPayload.append(k, String(v));
+        });
+        Object.entries(files).forEach(([k, f]) => formPayload.append(k, f));
+
+        if (isEditing && editingRecord) {
+          await api.put(
+            `${config.apiEndpoint}/${editingRecord.id}`,
+            formPayload,
+            {
+              headers: { "Content-Type": "multipart/form-data" },
+            },
+          );
+          toast.success("Data berhasil diperbarui.");
+        } else {
+          await api.post(config.apiEndpoint, formPayload, {
+            headers: { "Content-Type": "multipart/form-data" },
+          });
+          toast.success("Data berhasil ditambahkan.");
+        }
+      } else {
+        if (isEditing && editingRecord) {
+          await api.put(
+            `${config.apiEndpoint}/${editingRecord.id}`,
+            formData,
+            {},
+          );
+          toast.success("Data berhasil diperbarui.");
+        } else {
+          await api.post(config.apiEndpoint, formData, {});
+          toast.success("Data berhasil ditambahkan.");
+        }
+      }
+
+      queryClient.invalidateQueries({
+        queryKey: [`cms-crud-${config.apiEndpoint}`],
+      });
+      onClose();
+    } catch (error: unknown) {
+      const err = error as { response?: { data?: { message?: string } } };
+      toast.error(err.response?.data?.message || "Gagal menyimpan data.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div className="relative w-full max-w-lg bg-zinc-900 border-l border-zinc-800 h-full overflow-y-auto animate-in slide-in-from-right duration-300 p-6">
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-xl font-black text-white">
+            {isEditing ? "Edit Data" : "Tambah Data"}
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-2 hover:bg-zinc-800 rounded-lg"
+          >
+            <X className="w-5 h-5 text-zinc-400" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {config.fields.map((field) => (
+            <div key={field.key}>
+              <label className="block text-xs font-bold text-zinc-400 uppercase mb-1.5">
+                {field.label} {field.required && "*"}
+              </label>
+              {field.type === "textarea" ? (
+                <textarea
+                  value={String(formData[field.key] ?? "")}
+                  onChange={(e) =>
+                    setFormData((p) => ({ ...p, [field.key]: e.target.value }))
+                  }
+                  rows={4}
+                  placeholder={field.placeholder}
+                  maxLength={field.maxLength}
+                  className="w-full bg-zinc-950 border border-zinc-700 rounded-xl px-4 py-3 text-sm text-white focus:outline-none focus:border-teal-500 transition-all resize-none placeholder:text-zinc-600"
+                />
+              ) : field.type === "select" ? (
+                <select
+                  value={String(formData[field.key] ?? "")}
+                  onChange={(e) =>
+                    setFormData((p) => ({ ...p, [field.key]: e.target.value }))
+                  }
+                  className="w-full bg-zinc-950 border border-zinc-700 rounded-xl px-4 py-3 text-sm text-white focus:outline-none focus:border-teal-500 transition-all"
+                >
+                  <option value="">— Pilih —</option>
+                  {field.options?.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              ) : field.type === "file" ? (
+                <input
+                  type="file"
+                  accept={field.accept || "image/*"}
+                  onChange={(e) => {
+                    if (e.target.files?.[0])
+                      setFiles((p) => ({
+                        ...p,
+                        [field.key]: e.target.files![0],
+                      }));
+                  }}
+                  className="w-full text-sm text-zinc-400 file:mr-3 file:py-2 file:px-4 file:rounded-xl file:border-0 file:text-sm file:font-bold file:bg-teal-600 file:text-white hover:file:bg-teal-500 file:cursor-pointer"
+                />
+              ) : field.type === "checkbox" ? (
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={!!formData[field.key]}
+                    onChange={(e) =>
+                      setFormData((p) => ({
+                        ...p,
+                        [field.key]: e.target.checked,
+                      }))
+                    }
+                    className="w-4 h-4 rounded accent-teal-500"
+                  />
+                  <span className="text-sm text-zinc-300">
+                    {field.placeholder}
+                  </span>
+                </label>
+              ) : (
+                <input
+                  type={
+                    field.type === "url"
+                      ? "url"
+                      : field.type === "number"
+                        ? "number"
+                        : "text"
+                  }
+                  value={String(formData[field.key] ?? "")}
+                  onChange={(e) =>
+                    setFormData((p) => ({ ...p, [field.key]: e.target.value }))
+                  }
+                  placeholder={field.placeholder}
+                  maxLength={field.maxLength}
+                  className="w-full bg-zinc-950 border border-zinc-700 rounded-xl px-4 py-3 text-sm text-white focus:outline-none focus:border-teal-500 transition-all placeholder:text-zinc-600"
+                />
+              )}
+            </div>
+          ))}
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full flex items-center justify-center gap-2 bg-teal-600 hover:bg-teal-500 text-white py-3 rounded-xl font-bold text-sm transition-all disabled:opacity-50 mt-4"
+          >
+            {isSubmitting ? (
+              <Loader2 className="w-5 h-5 animate-spin" />
+            ) : (
+              <Save className="w-5 h-5" />
+            )}
+            {isSubmitting ? "Menyimpan..." : "Simpan"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/cms/_components/CrudPageFactory.tsx
+++ b/frontend/src/app/(dashboard)/cms/_components/CrudPageFactory.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { Plus, Search, Loader2, Pencil, Trash2 } from "lucide-react";
+import { useDebounce } from "@/hooks/use-debounce";
+import { toast } from "sonner";
+import CrudFormDrawer from "./CrudFormDrawer";
+import type { CrudPageConfig } from "./types";
+
+interface Props {
+  config: CrudPageConfig;
+}
+
+interface CrudRecord {
+  id: number;
+  [key: string]: unknown;
+}
+
+export default function CrudPageFactory({ config }: Props) {
+  const queryClient = useQueryClient();
+  const [page, setPage] = useState(1);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [editingRecord, setEditingRecord] = useState<CrudRecord | null>(null);
+  const debouncedSearch = useDebounce(searchTerm, 500);
+
+  const queryKey = [`cms-crud-${config.apiEndpoint}`, debouncedSearch, page];
+
+  // Penarikan Data
+  const { data: response, isLoading } = useQuery({
+    queryKey,
+    queryFn: async () => {
+      const res = await api.get(config.apiEndpoint, {
+        params: { search: debouncedSearch || undefined, page },
+      });
+      return res.data;
+    },
+    placeholderData: (previousData) => previousData,
+  });
+
+  // Mutasi Hapus
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => api.delete(`${config.apiEndpoint}/${id}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey });
+      toast.success("Data berhasil dihapus.");
+    },
+    onError: () =>
+      toast.error("Gagal menghapus. Data mungkin masih terkait data lain."),
+  });
+
+  // Handler buka form Edit
+  const handleEdit = (record: CrudRecord) => {
+    setEditingRecord(record);
+    setDrawerOpen(true);
+  };
+
+  // Handler buka form Tambah
+  const handleCreate = () => {
+    setEditingRecord(null);
+    setDrawerOpen(true);
+  };
+
+  return (
+    <div className="p-6 md:p-10 space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
+      {/* Header */}
+      <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+        <div>
+          <h1 className="text-3xl font-black text-white tracking-tight flex items-center gap-3">
+            <config.icon className={`w-8 h-8 text-${config.accentColor}-500`} />{" "}
+            {config.title}
+          </h1>
+          <p className="text-zinc-400 mt-2 text-sm">{config.subtitle}</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="relative group">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-500" />
+            <input
+              type="text"
+              placeholder={config.searchPlaceholder || "Cari..."}
+              value={searchTerm}
+              onChange={(e) => {
+                setSearchTerm(e.target.value);
+                setPage(1);
+              }}
+              className="pl-10 pr-4 py-2 bg-zinc-900 border border-zinc-800 rounded-xl text-sm text-white focus:outline-none focus:border-teal-500 transition-all w-56 placeholder:text-zinc-600"
+            />
+          </div>
+          <button
+            onClick={handleCreate}
+            className="flex items-center gap-2 bg-teal-600 hover:bg-teal-500 text-white px-4 py-2 rounded-xl font-bold text-sm transition-all"
+          >
+            <Plus className="w-4 h-4" /> Tambah
+          </button>
+        </div>
+      </div>
+
+      {/* Tabel */}
+      <div className="bg-zinc-950/50 border border-zinc-800/80 rounded-2xl overflow-hidden shadow-2xl">
+        <div className="overflow-x-auto">
+          <table className="w-full text-left border-collapse whitespace-nowrap">
+            <thead>
+              <tr className="bg-zinc-900/80 border-b border-zinc-800">
+                {config.columns.map((col) => (
+                  <th
+                    key={col.key}
+                    className="p-4 text-xs font-bold text-zinc-400 uppercase"
+                  >
+                    {col.label}
+                  </th>
+                ))}
+                <th className="p-4 text-xs font-bold text-zinc-400 uppercase text-center">
+                  Aksi
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-zinc-800/50">
+              {isLoading ? (
+                <tr>
+                  <td
+                    colSpan={config.columns.length + 1}
+                    className="p-12 text-center"
+                  >
+                    <Loader2
+                      className={`w-8 h-8 animate-spin mx-auto mb-3 text-${config.accentColor}-500`}
+                    />
+                  </td>
+                </tr>
+              ) : response?.data?.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={config.columns.length + 1}
+                    className="p-12 text-center text-zinc-500"
+                  >
+                    Belum ada data.
+                  </td>
+                </tr>
+              ) : (
+                response?.data?.map((row: CrudRecord) => (
+                  <tr
+                    key={row.id}
+                    className="hover:bg-zinc-900/40 transition-colors"
+                  >
+                    {config.columns.map((col) => (
+                      <td key={col.key} className="p-4 text-sm text-zinc-300">
+                        {String(
+                          col.render
+                            ? col.render(row[col.key], row)
+                            : row[col.key],
+                        ) || "-"}
+                      </td>
+                    ))}
+                    <td className="p-4 text-center">
+                      <div className="flex items-center justify-center gap-1">
+                        <button
+                          onClick={() => handleEdit(row)}
+                          className="p-2 hover:bg-teal-500/10 rounded-lg transition-colors group"
+                        >
+                          <Pencil className="w-4 h-4 text-zinc-500 group-hover:text-teal-400" />
+                        </button>
+                        <button
+                          onClick={() => {
+                            if (confirm("Yakin hapus?"))
+                              deleteMutation.mutate(row.id);
+                          }}
+                          className="p-2 hover:bg-red-500/10 rounded-lg transition-colors group"
+                        >
+                          <Trash2 className="w-4 h-4 text-zinc-500 group-hover:text-red-400" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+        <div className="p-4 bg-zinc-950 border-t border-zinc-800 flex items-center justify-between text-sm">
+          <span className="text-zinc-500">Hal. {page}</span>
+          <div className="flex gap-2">
+            <button
+              disabled={page === 1}
+              onClick={() => setPage((p) => p - 1)}
+              className="px-3 py-1 bg-zinc-900 border border-zinc-800 text-zinc-300 rounded hover:bg-zinc-800 disabled:opacity-50"
+            >
+              Prev
+            </button>
+            <button
+              disabled={!response?.next_page_url}
+              onClick={() => setPage((p) => p + 1)}
+              className="px-3 py-1 bg-zinc-900 border border-zinc-800 text-zinc-300 rounded hover:bg-zinc-800 disabled:opacity-50"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Drawer Form */}
+      <CrudFormDrawer
+        open={drawerOpen}
+        onClose={() => {
+          setDrawerOpen(false);
+          setEditingRecord(null);
+        }}
+        config={config}
+        editingRecord={editingRecord}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/cms/_components/types.ts
+++ b/frontend/src/app/(dashboard)/cms/_components/types.ts
@@ -1,0 +1,33 @@
+import type { LucideIcon } from "lucide-react";
+
+/** Definisi satu kolom di Tabel */
+export interface CrudColumn {
+  key: string; // Nama properti di objek data (misal: "nama", "judul")
+  label: string; // Label header kolom (misal: "Nama Kawasan")
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  render?: (value: any, row: any) => React.ReactNode; // Custom render (untuk badge, gambar, dll)
+}
+
+/** Definisi satu field di Formulir */
+export interface CrudField {
+  key: string; // Nama properti yang dikirim ke API
+  label: string; // Label input
+  type: "text" | "textarea" | "select" | "file" | "number" | "checkbox" | "url";
+  required?: boolean;
+  placeholder?: string;
+  maxLength?: number;
+  accept?: string; // Untuk file: "image/*", ".pdf", dll
+  options?: { value: string; label: string }[]; // Untuk select dropdown
+}
+
+/** Konfigurasi lengkap 1 halaman CRUD */
+export interface CrudPageConfig {
+  title: string; // "Kelola Kawasan Konservasi"
+  subtitle: string; // "Daftar kawasan hutan lindung..."
+  icon: LucideIcon;
+  accentColor: string;
+  apiEndpoint: string; // "/cms/admin/kawasan"
+  columns: CrudColumn[];
+  fields: CrudField[];
+  searchPlaceholder?: string;
+}

--- a/frontend/src/app/(dashboard)/cms/buku/page.tsx
+++ b/frontend/src/app/(dashboard)/cms/buku/page.tsx
@@ -1,0 +1,32 @@
+import { BookOpen } from "lucide-react";
+import CrudPageFactory from "../_components/CrudPageFactory";
+import type { CrudPageConfig } from "../_components/types";
+
+const config: CrudPageConfig = {
+    title: "Kelola Buku Publikasi",
+    subtitle: "Kelola koleksi buku dan publikasi BKSDA.",
+    icon: BookOpen,
+    accentColor: "orange",
+    apiEndpoint: "/cms/admin/buku",
+    searchPlaceholder: "Cari judul buku...",
+    columns: [
+        { key: "judul", label: "Judul" },
+        { key: "penulis", label: "Penulis", render: (v) => v || "-" },
+        { key: "tahun_terbit", label: "Tahun" },
+        { key: "is_published", label: "Status", render: (v) => v ? "✅ Terbit" : "📝 Draft" },
+    ],
+    fields: [
+        { key: "judul", label: "Judul", type: "text", required: true, maxLength: 255 },
+        { key: "penulis", label: "Penulis", type: "text", maxLength: 255 },
+        { key: "penerbit", label: "Penerbit", type: "text", maxLength: 255 },
+        { key: "tahun_terbit", label: "Tahun Terbit", type: "number" },
+        { key: "deskripsi", label: "Deskripsi", type: "textarea" },
+        { key: "cover", label: "Cover", type: "file", accept: "image/*" },
+        { key: "file", label: "File PDF", type: "file", accept: ".pdf" },
+        { key: "is_published", label: "Publikasi", type: "checkbox", placeholder: "Tampilkan di website" },
+    ],
+};
+
+export default function BukuPage() {
+    return <CrudPageFactory config={config} />;
+}

--- a/frontend/src/app/(dashboard)/cms/categories/page.tsx
+++ b/frontend/src/app/(dashboard)/cms/categories/page.tsx
@@ -1,0 +1,32 @@
+import { Tag } from "lucide-react";
+import CrudPageFactory from "../_components/CrudPageFactory";
+import type { CrudPageConfig } from "../_components/types";
+
+const config: CrudPageConfig = {
+    title: "Kelola Kategori",
+    subtitle: "Kelola kategori berita dan konten.",
+    icon: Tag,
+    accentColor: "indigo",
+    apiEndpoint: "/cms/admin/categories",
+    searchPlaceholder: "Cari nama kategori...",
+    columns: [
+        { key: "nama", label: "Nama" },
+        { key: "slug", label: "Slug", render: (v) => v || "-" },
+        { key: "tipe", label: "Tipe" },
+        { key: "urutan", label: "Urutan", render: (v) => v || "-" },
+    ],
+    fields: [
+        { key: "nama", label: "Nama", type: "text", required: true, maxLength: 100 },
+        { key: "slug", label: "Slug", type: "text", maxLength: 100 },
+        { key: "tipe", label: "Tipe", type: "select", options: [
+            { value: "berita", label: "Berita" },
+            { value: "galeri", label: "Galeri" },
+            { value: "publikasi", label: "Publikasi" },
+        ]},
+        { key: "urutan", label: "Urutan", type: "number" },
+    ],
+};
+
+export default function CategoriesPage() {
+    return <CrudPageFactory config={config} />;
+}

--- a/frontend/src/app/(dashboard)/cms/kawasan/page.tsx
+++ b/frontend/src/app/(dashboard)/cms/kawasan/page.tsx
@@ -1,0 +1,75 @@
+import { MapPin } from "lucide-react";
+import CrudPageFactory from "../_components/CrudPageFactory";
+import type { CrudPageConfig } from "../_components/types";
+
+const config: CrudPageConfig = {
+  title: "Kelola Kawasan Konservasi",
+  subtitle: "Data kawasan hutan lindung, cagar alam, dan suaka margasatwa.",
+  icon: MapPin,
+  accentColor: "teal",
+  apiEndpoint: "/cms/admin/kawasan",
+  searchPlaceholder: "Cari nama kawasan...",
+  columns: [
+    { key: "nama", label: "Nama Kawasan" },
+    {
+      key: "tipe_kawasan",
+      label: "Tipe",
+      render: (v) => (v ? String(v) : "-"),
+    },
+    {
+      key: "luas_ha",
+      label: "Luas (Ha)",
+      render: (v) => (v ? `${Number(v).toLocaleString()} Ha` : "-"),
+    },
+    {
+      key: "is_published",
+      label: "Status",
+      render: (v) => (v ? "✅ Terbit" : "📝 Draft"),
+    },
+  ],
+  fields: [
+    {
+      key: "nama",
+      label: "Nama Kawasan",
+      type: "text",
+      required: true,
+      maxLength: 255,
+    },
+    {
+      key: "tipe_kawasan",
+      label: "Tipe Kawasan",
+      type: "text",
+      placeholder: "Cagar Alam / Suaka Margasatwa",
+    },
+    { key: "deskripsi", label: "Deskripsi", type: "textarea", required: true },
+    { key: "luas_ha", label: "Luas (Hektar)", type: "number" },
+    {
+      key: "latitude",
+      label: "Latitude",
+      type: "text",
+      placeholder: "-6.1234567",
+    },
+    {
+      key: "longitude",
+      label: "Longitude",
+      type: "text",
+      placeholder: "106.1234567",
+    },
+    {
+      key: "thumbnail",
+      label: "Foto Kawasan",
+      type: "file",
+      accept: "image/*",
+    },
+    {
+      key: "is_published",
+      label: "Publikasi",
+      type: "checkbox",
+      placeholder: "Tampilkan di website publik",
+    },
+  ],
+};
+
+export default function KawasanPage() {
+  return <CrudPageFactory config={config} />;
+}

--- a/frontend/src/app/(dashboard)/cms/kepala/page.tsx
+++ b/frontend/src/app/(dashboard)/cms/kepala/page.tsx
@@ -1,0 +1,30 @@
+import { UserCircle } from "lucide-react";
+import CrudPageFactory from "../_components/CrudPageFactory";
+import type { CrudPageConfig } from "../_components/types";
+
+const config: CrudPageConfig = {
+    title: "Kelola Kepala BKSDA",
+    subtitle: "Kelola data kepala BKSDA dan sambutannya.",
+    icon: UserCircle,
+    accentColor: "emerald",
+    apiEndpoint: "/cms/admin/kepala",
+    searchPlaceholder: "Cari nama kepala...",
+    columns: [
+        { key: "nama", label: "Nama" },
+        { key: "nip", label: "NIP", render: (v) => v || "-" },
+        { key: "jabatan", label: "Jabatan" },
+        { key: "is_active", label: "Status", render: (v) => v ? "✅ Aktif" : "❌ Tidak Aktif" },
+    ],
+    fields: [
+        { key: "nama", label: "Nama", type: "text", required: true, maxLength: 255 },
+        { key: "nip", label: "NIP", type: "text", maxLength: 50 },
+        { key: "jabatan", label: "Jabatan", type: "text", maxLength: 255 },
+        { key: "sambutan", label: "Sambutan", type: "textarea" },
+        { key: "foto", label: "Foto", type: "file", accept: "image/*" },
+        { key: "is_active", label: "Aktif", type: "checkbox", placeholder: "Jadikan kepala aktif" },
+    ],
+};
+
+export default function KepalaPage() {
+    return <CrudPageFactory config={config} />;
+}

--- a/frontend/src/app/(dashboard)/cms/leaflet/page.tsx
+++ b/frontend/src/app/(dashboard)/cms/leaflet/page.tsx
@@ -1,0 +1,27 @@
+import { FileImage } from "lucide-react";
+import CrudPageFactory from "../_components/CrudPageFactory";
+import type { CrudPageConfig } from "../_components/types";
+
+const config: CrudPageConfig = {
+    title: "Kelola Leaflet",
+    subtitle: "Kelola koleksi leaflet edukasi.",
+    icon: FileImage,
+    accentColor: "pink",
+    apiEndpoint: "/cms/admin/leaflet",
+    searchPlaceholder: "Cari judul leaflet...",
+    columns: [
+        { key: "judul", label: "Judul" },
+        { key: "is_published", label: "Status", render: (v) => v ? "✅ Terbit" : "📝 Draft" },
+    ],
+    fields: [
+        { key: "judul", label: "Judul", type: "text", required: true, maxLength: 255 },
+        { key: "deskripsi", label: "Deskripsi", type: "textarea" },
+        { key: "file", label: "File Leaflet", type: "file", accept: ".pdf,image/*" },
+        { key: "thumbnail", label: "Thumbnail", type: "file", accept: "image/*" },
+        { key: "is_published", label: "Publikasi", type: "checkbox", placeholder: "Tampilkan di website" },
+    ],
+};
+
+export default function LeafletPage() {
+    return <CrudPageFactory config={config} />;
+}

--- a/frontend/src/app/(dashboard)/cms/links/page.tsx
+++ b/frontend/src/app/(dashboard)/cms/links/page.tsx
@@ -1,0 +1,27 @@
+import { LinkIcon } from "lucide-react";
+import CrudPageFactory from "../_components/CrudPageFactory";
+import type { CrudPageConfig } from "../_components/types";
+
+const config: CrudPageConfig = {
+    title: "Kelola Link Terkait",
+    subtitle: "Kelola tautan ke situs terkait.",
+    icon: LinkIcon,
+    accentColor: "sky",
+    apiEndpoint: "/cms/admin/links",
+    searchPlaceholder: "Cari judul link...",
+    columns: [
+        { key: "judul", label: "Judul" },
+        { key: "url", label: "URL", render: (v) => v ? "🔗 Buka" : "-" },
+        { key: "urutan", label: "Urutan", render: (v) => v || "-" },
+    ],
+    fields: [
+        { key: "judul", label: "Judul", type: "text", required: true, maxLength: 255 },
+        { key: "url", label: "URL", type: "url", required: true, placeholder: "https://..." },
+        { key: "logo", label: "Logo", type: "file", accept: "image/*" },
+        { key: "urutan", label: "Urutan", type: "number" },
+    ],
+};
+
+export default function LinksPage() {
+    return <CrudPageFactory config={config} />;
+}

--- a/frontend/src/app/(dashboard)/cms/photos/page.tsx
+++ b/frontend/src/app/(dashboard)/cms/photos/page.tsx
@@ -1,0 +1,28 @@
+import { Camera } from "lucide-react";
+import CrudPageFactory from "../_components/CrudPageFactory";
+import type { CrudPageConfig } from "../_components/types";
+
+const config: CrudPageConfig = {
+    title: "Kelola Galeri Foto",
+    subtitle: "Kelola koleksi foto kegiatan dan kawasan.",
+    icon: Camera,
+    accentColor: "amber",
+    apiEndpoint: "/cms/admin/photos",
+    searchPlaceholder: "Cari judul foto...",
+    columns: [
+        { key: "judul", label: "Judul" },
+        { key: "album", label: "Album", render: (v) => v || "-" },
+        { key: "is_published", label: "Status", render: (v) => v ? "✅ Terbit" : "📝 Draft" },
+    ],
+    fields: [
+        { key: "judul", label: "Judul", type: "text", required: true, maxLength: 255 },
+        { key: "deskripsi", label: "Deskripsi", type: "textarea" },
+        { key: "album", label: "Album", type: "text", placeholder: "Nama album foto" },
+        { key: "file", label: "File Foto", type: "file", accept: "image/*" },
+        { key: "is_published", label: "Publikasi", type: "checkbox", placeholder: "Tampilkan di website" },
+    ],
+};
+
+export default function PhotosPage() {
+    return <CrudPageFactory config={config} />;
+}

--- a/frontend/src/app/(dashboard)/cms/poster/page.tsx
+++ b/frontend/src/app/(dashboard)/cms/poster/page.tsx
@@ -1,0 +1,27 @@
+import { Image } from "lucide-react";
+import CrudPageFactory from "../_components/CrudPageFactory";
+import type { CrudPageConfig } from "../_components/types";
+
+const config: CrudPageConfig = {
+    title: "Kelola Poster",
+    subtitle: "Kelola koleksi poster kampanye.",
+    icon: Image,
+    accentColor: "fuchsia",
+    apiEndpoint: "/cms/admin/poster",
+    searchPlaceholder: "Cari judul poster...",
+    columns: [
+        { key: "judul", label: "Judul" },
+        { key: "is_published", label: "Status", render: (v) => v ? "✅ Terbit" : "📝 Draft" },
+    ],
+    fields: [
+        { key: "judul", label: "Judul", type: "text", required: true, maxLength: 255 },
+        { key: "deskripsi", label: "Deskripsi", type: "textarea" },
+        { key: "file", label: "File Poster", type: "file", accept: "image/*" },
+        { key: "thumbnail", label: "Thumbnail", type: "file", accept: "image/*" },
+        { key: "is_published", label: "Publikasi", type: "checkbox", placeholder: "Tampilkan di website" },
+    ],
+};
+
+export default function PosterPage() {
+    return <CrudPageFactory config={config} />;
+}

--- a/frontend/src/app/(dashboard)/cms/profil/page.tsx
+++ b/frontend/src/app/(dashboard)/cms/profil/page.tsx
@@ -1,0 +1,28 @@
+import { Building2 } from "lucide-react";
+import CrudPageFactory from "../_components/CrudPageFactory";
+import type { CrudPageConfig } from "../_components/types";
+
+const config: CrudPageConfig = {
+    title: "Kelola Profil",
+    subtitle: "Kelola profil organisasi BKSDA.",
+    icon: Building2,
+    accentColor: "cyan",
+    apiEndpoint: "/cms/admin/profil",
+    searchPlaceholder: "Cari judul profil...",
+    columns: [
+        { key: "judul", label: "Judul" },
+        { key: "urutan", label: "Urutan", render: (v) => v || "-" },
+        { key: "is_published", label: "Status", render: (v) => v ? "✅ Terbit" : "📝 Draft" },
+    ],
+    fields: [
+        { key: "judul", label: "Judul", type: "text", required: true, maxLength: 255 },
+        { key: "konten", label: "Konten", type: "textarea", required: true },
+        { key: "thumbnail", label: "Foto", type: "file", accept: "image/*" },
+        { key: "urutan", label: "Urutan", type: "number" },
+        { key: "is_published", label: "Publikasi", type: "checkbox", placeholder: "Tampilkan di website" },
+    ],
+};
+
+export default function ProfilPage() {
+    return <CrudPageFactory config={config} />;
+}

--- a/frontend/src/app/(dashboard)/cms/regulasi/page.tsx
+++ b/frontend/src/app/(dashboard)/cms/regulasi/page.tsx
@@ -1,0 +1,30 @@
+import { Scale } from "lucide-react";
+import CrudPageFactory from "../_components/CrudPageFactory";
+import type { CrudPageConfig } from "../_components/types";
+
+const config: CrudPageConfig = {
+    title: "Kelola Regulasi",
+    subtitle: "Kelola dokumen regulasi dan peraturan.",
+    icon: Scale,
+    accentColor: "red",
+    apiEndpoint: "/cms/admin/regulasi",
+    searchPlaceholder: "Cari judul regulasi...",
+    columns: [
+        { key: "judul", label: "Judul" },
+        { key: "nomor", label: "Nomor", render: (v) => v || "-" },
+        { key: "tahun", label: "Tahun" },
+        { key: "is_published", label: "Status", render: (v) => v ? "✅ Terbit" : "📝 Draft" },
+    ],
+    fields: [
+        { key: "judul", label: "Judul", type: "text", required: true, maxLength: 255 },
+        { key: "nomor", label: "Nomor", type: "text", maxLength: 100 },
+        { key: "tahun", label: "Tahun", type: "number" },
+        { key: "deskripsi", label: "Deskripsi", type: "textarea" },
+        { key: "file", label: "File PDF", type: "file", accept: ".pdf" },
+        { key: "is_published", label: "Publikasi", type: "checkbox", placeholder: "Tampilkan di website" },
+    ],
+};
+
+export default function RegulasiPage() {
+    return <CrudPageFactory config={config} />;
+}

--- a/frontend/src/app/(dashboard)/cms/tsl/page.tsx
+++ b/frontend/src/app/(dashboard)/cms/tsl/page.tsx
@@ -1,0 +1,35 @@
+import { TreePine } from "lucide-react";
+import CrudPageFactory from "../_components/CrudPageFactory";
+import type { CrudPageConfig } from "../_components/types";
+
+const config: CrudPageConfig = {
+    title: "Kelola Tumbuhan & Satwa Liar",
+    subtitle: "Data flora dan fauna dilindungi.",
+    icon: TreePine,
+    accentColor: "lime",
+    apiEndpoint: "/cms/admin/tsl",
+    searchPlaceholder: "Cari nama species...",
+    columns: [
+        { key: "nama_lokal", label: "Nama Lokal" },
+        { key: "nama_latin", label: "Nama Latin", render: (v) => v || "-" },
+        { key: "tipe", label: "Tipe", render: (v) => v === "satwa" ? "🦅 Satwa" : "🌿 Tumbuhan" },
+        { key: "status_iucn", label: "Status IUCN" },
+        { key: "is_published", label: "Status", render: (v) => v ? "✅ Terbit" : "📝 Draft" },
+    ],
+    fields: [
+        { key: "nama_lokal", label: "Nama Lokal", type: "text", required: true, maxLength: 255 },
+        { key: "nama_latin", label: "Nama Latin", type: "text", maxLength: 255 },
+        { key: "tipe", label: "Tipe", type: "select", required: true, options: [
+            { value: "tumbuhan", label: "Tumbuhan" },
+            { value: "satwa", label: "Satwa" },
+        ]},
+        { key: "status_iucn", label: "Status IUCN", type: "text", placeholder: "CR, EN, VU, NT, LC" },
+        { key: "deskripsi", label: "Deskripsi", type: "textarea" },
+        { key: "thumbnail", label: "Foto", type: "file", accept: "image/*" },
+        { key: "is_published", label: "Publikasi", type: "checkbox", placeholder: "Tampilkan di website" },
+    ],
+};
+
+export default function TslPage() {
+    return <CrudPageFactory config={config} />;
+}

--- a/frontend/src/app/(dashboard)/cms/videos/page.tsx
+++ b/frontend/src/app/(dashboard)/cms/videos/page.tsx
@@ -1,0 +1,28 @@
+import { Video } from "lucide-react";
+import CrudPageFactory from "../_components/CrudPageFactory";
+import type { CrudPageConfig } from "../_components/types";
+
+const config: CrudPageConfig = {
+    title: "Kelola Galeri Video",
+    subtitle: "Kelola koleksi video kegiatan dan宣传.",
+    icon: Video,
+    accentColor: "violet",
+    apiEndpoint: "/cms/admin/videos",
+    searchPlaceholder: "Cari judul video...",
+    columns: [
+        { key: "judul", label: "Judul" },
+        { key: "youtube_url", label: "YouTube URL", render: (v) => v ? "✅ Ada" : "-" },
+        { key: "is_published", label: "Status", render: (v) => v ? "✅ Terbit" : "📝 Draft" },
+    ],
+    fields: [
+        { key: "judul", label: "Judul", type: "text", required: true, maxLength: 255 },
+        { key: "deskripsi", label: "Deskripsi", type: "textarea" },
+        { key: "youtube_url", label: "YouTube URL", type: "url", placeholder: "https://youtube.com/watch?v=..." },
+        { key: "thumbnail", label: "Thumbnail", type: "file", accept: "image/*" },
+        { key: "is_published", label: "Publikasi", type: "checkbox", placeholder: "Tampilkan di website" },
+    ],
+};
+
+export default function VideosPage() {
+    return <CrudPageFactory config={config} />;
+}


### PR DESCRIPTION
## Summary
Membangun Mesin Cetak Halaman Otomatis (`CrudPageFactory`) yang menerima konfigurasi JSON dan menghasilkan halaman Admin CRUD lengkap.

## Changes
- `_components/types.ts` - Interface konfigurasi (CrudColumn, CrudField, CrudPageConfig)
- `_components/CrudPageFactory.tsx` - Komponen factory untuk tabel + pagination + search
- `_components/CrudFormDrawer.tsx` - Drawer form generik dengan dukungan file upload
- 12 halaman CRUD ultra-tipis (15-30 baris per halaman):
  - kawasan, profil, tsl, photos, videos, links, buku, leaflet, poster, regulasi, categories, kepala

## Acceptance Criteria
- [x] Tersedia komponen: `CrudPageFactory.tsx`
- [x] Tersedia komponen: `CrudFormDrawer.tsx`
- [x] Tersedia 12 halaman `page.tsx` masing-masing hanya 15-30 baris kode
- [x] Setiap halaman memiliki fitur: Pencarian, Pagination, Tambah, Edit, Hapus
- [x] Formulir secara otomatis mendeteksi field bertipe `file` dan menggunakan `multipart/form-data`

Closes #99