### PR TITLE
fix(backend): add Supabase storage service (#118)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -65,13 +65,16 @@ MAIL_FROM_ADDRESS="noreply@bksda-kaltim.go.id"
 MAIL_FROM_NAME="${APP_NAME}"
 
 # =============================================================================
-# Supabase Storage — S3-compatible (production only)
+# Supabase Storage — S3-compatible
 # =============================================================================
-# Set FILESYSTEM_DISK=s3 di production
-# AWS_ACCESS_KEY_ID=
-# AWS_SECRET_ACCESS_KEY=
-# AWS_DEFAULT_REGION=ap-southeast-1
-# AWS_BUCKET=
-# AWS_ENDPOINT=
-# AWS_URL=
-# AWS_USE_PATH_STYLE_ENDPOINT=true
+SUPABASE_PROJECT_URL=https://xxxxxxxxxxxxx.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=
+SUPABASE_BUCKET=cms
+SUPABASE_DEFAULT_REGION=ap-southeast-1
+
+# S3-compatible disk config (for Laravel Storage facade)
+SUPABASE_ACCESS_KEY_ID=
+SUPABASE_SECRET_ACCESS_KEY=
+SUPABASE_URL=https://xxxxxxxxxxxxx.supabase.co/storage/v1/s3
+SUPABASE_ENDPOINT=https://xxxxxxxxxxxxx.supabase.co/storage/v1/s3
+SUPABASE_USE_PATH_STYLE_ENDPOINT=true

--- a/backend/app/Services/SupabaseStorageService.php
+++ b/backend/app/Services/SupabaseStorageService.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Http\UploadedFile;
+
+class SupabaseStorageService
+{
+    private string $supabaseUrl;
+    private string $serviceRoleKey;
+    private string $bucket;
+
+    public function __construct()
+    {
+        $this->supabaseUrl = env('SUPABASE_PROJECT_URL', 'https://xxx.supabase.co');
+        $this->serviceRoleKey = env('SUPABASE_SERVICE_ROLE_KEY', '');
+        $this->bucket = env('SUPABASE_BUCKET', 'cms');
+    }
+
+    public function upload(UploadedFile $file, string $folder = ''): string
+    {
+        $extension = $file->getClientOriginalExtension();
+        $filename = uniqid() . '_' . time() . '.' . $extension;
+
+        $storagePath = $folder ? "{$folder}/{$filename}" : $filename;
+
+        $url = "{$this->supabaseUrl}/storage/v1/object/{$this->bucket}/{$storagePath}";
+
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_CUSTOMREQUEST => 'POST',
+            CURLOPT_POSTFIELDS => file_get_contents($file->getRealPath()),
+            CURLOPT_HTTPHEADER => [
+                "Authorization: Bearer {$this->serviceRoleKey}",
+                "Content-Type: {$file->getMimeType()}",
+                "x-upsert: true",
+            ],
+            CURLOPT_SSL_VERIFYPEER => false,
+            CURLOPT_TIMEOUT => 30,
+        ]);
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($httpCode < 200 || $httpCode >= 300) {
+            throw new \RuntimeException(
+                "Supabase upload gagal (HTTP {$httpCode}): {$response}"
+            );
+        }
+
+        return $storagePath;
+    }
+
+    public function delete(string $path): void
+    {
+        if (!$path) return;
+
+        $url = "{$this->supabaseUrl}/storage/v1/object/{$this->bucket}/{$path}";
+
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_CUSTOMREQUEST => 'DELETE',
+            CURLOPT_HTTPHEADER => [
+                "Authorization: Bearer {$this->serviceRoleKey}",
+            ],
+            CURLOPT_SSL_VERIFYPEER => false,
+            CURLOPT_TIMEOUT => 10,
+        ]);
+
+        curl_exec($ch);
+        curl_close($ch);
+    }
+
+    public static function publicUrl(?string $path): ?string
+    {
+        if (!$path) return null;
+
+        if (filter_var($path, FILTER_VALIDATE_URL)) {
+            return $path;
+        }
+
+        $baseUrl = env('SUPABASE_PROJECT_URL', 'https://xxx.supabase.co');
+        $bucket = env('SUPABASE_BUCKET', 'cms');
+        return "{$baseUrl}/storage/v1/object/public/{$bucket}/{$path}";
+    }
+}

--- a/backend/config/filesystems.php
+++ b/backend/config/filesystems.php
@@ -60,6 +60,20 @@ return [
             'report' => false,
         ],
 
+        'supabase' => [
+            'driver' => 's3',
+            'key' => env('SUPABASE_ACCESS_KEY_ID'),
+            'secret' => env('SUPABASE_SECRET_ACCESS_KEY'),
+            'region' => env('SUPABASE_DEFAULT_REGION', 'ap-southeast-1'),
+            'bucket' => env('SUPABASE_BUCKET'),
+            'url' => env('SUPABASE_URL'),
+            'endpoint' => env('SUPABASE_ENDPOINT'),
+            'use_path_style_endpoint' => env('SUPABASE_USE_PATH_STYLE_ENDPOINT', true),
+            'visibility' => 'public',
+            'throw' => false,
+            'report' => false,
+        ],
+
     ],
 
     /*


### PR DESCRIPTION
## Changes
- config/filesystems.php: Added supabase disk (S3-compatible)
- SupabaseStorageService.php: New service with upload(), delete(), publicUrl() methods
- .env.example: Added Supabase environment variables documentation

## Acceptance Criteria
- [x] config/filesystems.php has supabase disk with S3 driver
- [x] SupabaseStorageService has upload(), delete(), publicUrl() methods
- [x] .env.example has Supabase credential placeholders
- [x] File upload uses unique filename (uniqid + timestamp)
- [x] Old file deletion on replace/delete follows pattern in spec

Closes #118