### PR TITLE
feat(security): migrate route protection to Next.js middleware (#271)

### DIFF
--- a/frontend/src/app/portal/page.tsx
+++ b/frontend/src/app/portal/page.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import React, { useEffect, useState, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
@@ -131,7 +131,7 @@ export default function PersonalDashboard() {
       const response = await api.get("/me/dashboard");
       setData(response.data);
       if (response.data?.user) {
-        localStorage.setItem("bksda_user", JSON.stringify(response.data.user));
+        authStore.updateUser(response.data.user);
       }
     } catch (error: unknown) {
       const err = error as { response?: { status?: number } };

--- a/frontend/src/lib/auth-store.ts
+++ b/frontend/src/lib/auth-store.ts
@@ -87,6 +87,16 @@ export const authStore = {
     window.dispatchEvent(new Event("auth-change"));
   },
 
+  // Update User Data only
+  updateUser(userData: unknown) {
+    if (typeof window === "undefined") return;
+
+    localStorage.setItem("bksda_user", JSON.stringify(userData));
+    document.cookie = `bksda_user=${encodeURIComponent(JSON.stringify(userData))}; path=/; max-age=604800; SameSite=Lax`;
+
+    window.dispatchEvent(new Event("auth-change"));
+  },
+
   // Fungsi Logout Sentral
   logout() {
     if (typeof window === "undefined") return;

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// Map route paths to module names
+const MODULE_ROUTES: Record<string, string> = {
+  "bmn": "bmn",
+  "inventory": "inventory",
+  "kepegawaian": "kepegawaian",
+  "dereporting": "dereporting",
+  "cms": "cms",
+};
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // 1. Define protected routes
+  const isProtectedRoute = 
+    pathname.startsWith('/portal') ||
+    pathname.startsWith('/bmn') ||
+    pathname.startsWith('/inventory') ||
+    pathname.startsWith('/kepegawaian') ||
+    pathname.startsWith('/dereporting') ||
+    pathname.startsWith('/cms');
+
+  if (!isProtectedRoute) {
+    return NextResponse.next();
+  }
+
+  // 2. Check for token
+  const token = request.cookies.get('bksda_token')?.value;
+  if (!token) {
+    const url = new URL('/login', request.url);
+    // Store original destination to redirect back after login if needed
+    // url.searchParams.set('callbackUrl', pathname);
+    return NextResponse.redirect(url);
+  }
+
+  // 3. Check for user access modules
+  const userCookie = request.cookies.get('bksda_user')?.value;
+  if (!userCookie) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  try {
+    const user = JSON.parse(decodeURIComponent(userCookie));
+    
+    // Super admin bypasses all checks
+    if (user.role === 'super_admin') {
+      return NextResponse.next();
+    }
+
+    // Identify which module the user is trying to access
+    // Path looks like /bmn/assets or /inventory
+    const segments = pathname.split('/');
+    const firstSegment = segments[1]; // segment[0] is empty string
+
+    const moduleToCheck = MODULE_ROUTES[firstSegment];
+
+    if (moduleToCheck) {
+      const userModules = user.access_modules || [];
+      if (!userModules.includes(moduleToCheck)) {
+        // Unauthorized for this specific module
+        return NextResponse.redirect(new URL('/portal?unauthorized=1', request.url));
+      }
+    }
+
+  } catch (error) {
+    console.error('Middleware auth parsing error:', error);
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+// See "Matching Paths" below to learn more
+export const config = {
+  matcher: [
+    '/portal/:path*',
+    '/bmn/:path*',
+    '/inventory/:path*',
+    '/kepegawaian/:path*',
+    '/dereporting/:path*',
+    '/cms/:path*',
+  ],
+};


### PR DESCRIPTION
Closes #271.
This PR migrates the route protection logic from client-side RouteGuard.tsx to centralized Next.js middleware.ts.
- Added middleware.ts to intercept /portal, /bmn, /inventory, /kepegawaian, /dereporting, /cms.
- Updated authStore to keep bksda_user cookie in sync with localStorage.
- Refactored PersonalDashboard to use authStore.updateUser.
- Verified with lint and tsc.