### PR TITLE
feat(public): /profil hub page + /page/[slug] CMS renderer

### DIFF
--- a/frontend/src/app/(publik)/page/[slug]/page.tsx
+++ b/frontend/src/app/(publik)/page/[slug]/page.tsx
@@ -1,0 +1,130 @@
+/* eslint-disable @next/next/no-img-element */
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import axios from "axios";
+import { Loader2, ArrowLeft } from "lucide-react";
+import Link from "next/link";
+
+const API = process.env.NEXT_PUBLIC_API_URL;
+const STORAGE = process.env.NEXT_PUBLIC_STORAGE_URL;
+
+interface PageData {
+  id: string;
+  judul: string;
+  slug: string;
+  konten: string;
+  thumbnail_path?: string;
+}
+
+export default function GenericCmsPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const [page, setPage] = useState<PageData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!slug) return;
+    let cancelled = false;
+    axios
+      .get(`${API}/cms/public/page/${slug}`)
+      .then((r) => { if (!cancelled) setPage(r.data?.data || null); })
+      .catch(() => { if (!cancelled) setError(true); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [slug]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <Loader2 className="w-8 h-8 animate-spin text-green-600" />
+      </div>
+    );
+  }
+
+  if (error || !page) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 py-20 text-center">
+        <h2 className="text-2xl font-black text-gray-900 mb-3">
+          Halaman Tidak Ditemukan
+        </h2>
+        <p className="text-gray-500 mb-6">
+          Halaman yang Anda cari belum tersedia atau telah dihapus.
+        </p>
+        <Link
+          href="/profil"
+          className="inline-flex items-center gap-2 text-green-700 font-bold text-sm hover:text-green-600"
+        >
+          <ArrowLeft className="w-4 h-4" /> Kembali ke Profil
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-white">
+      {/* Hero */}
+      <div className="relative h-[280px] md:h-[350px] bg-green-900 overflow-hidden flex items-center justify-center">
+        {page.thumbnail_path ? (
+          <img
+            src={`${STORAGE}/${page.thumbnail_path}`}
+            alt={page.judul}
+            className="absolute inset-0 w-full h-full object-cover opacity-30"
+          />
+        ) : (
+          <img
+            src="/assets/header-new.png"
+            alt=""
+            className="absolute inset-0 w-full h-full object-cover opacity-20"
+          />
+        )}
+        <div className="absolute inset-0 bg-gradient-to-t from-green-900/90 to-green-900/50" />
+        <div className="relative z-10 text-center px-4">
+          <h1 className="text-3xl md:text-5xl font-black text-white uppercase tracking-wide">
+            {page.judul}
+          </h1>
+          <div className="w-16 h-1.5 bg-green-400 mx-auto rounded-full mt-4" />
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="max-w-4xl mx-auto px-4 py-12 md:py-16">
+        {/* Breadcrumb */}
+        <div className="flex items-center gap-2 text-sm text-gray-400 mb-8">
+          <Link href="/" className="hover:text-green-700">
+            Beranda
+          </Link>
+          <span>/</span>
+          <Link href="/profil" className="hover:text-green-700">
+            Profil
+          </Link>
+          <span>/</span>
+          <span className="text-gray-700 font-medium">{page.judul}</span>
+        </div>
+
+        {/* Article Content */}
+        <article
+          className="prose prose-lg prose-green max-w-none
+            prose-headings:font-black prose-headings:text-gray-900
+            prose-p:text-gray-600 prose-p:leading-relaxed
+            prose-img:rounded-xl prose-img:shadow-lg
+            prose-a:text-green-700 prose-a:no-underline hover:prose-a:underline
+            prose-strong:text-gray-900
+            prose-ul:text-gray-600 prose-ol:text-gray-600"
+          dangerouslySetInnerHTML={{ __html: page.konten }}
+        />
+
+        {/* Back Link */}
+        <div className="mt-12 pt-8 border-t border-gray-100">
+          <Link
+            href="/profil"
+            className="inline-flex items-center gap-2 text-green-700 font-bold text-sm hover:text-green-600"
+          >
+            <ArrowLeft className="w-4 h-4" /> Kembali ke Profil
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(publik)/profil/page.tsx
+++ b/frontend/src/app/(publik)/profil/page.tsx
@@ -1,0 +1,81 @@
+/* eslint-disable @next/next/no-img-element */
+"use client";
+
+import Link from "next/link";
+import { History, Building2, UserCircle } from "lucide-react";
+
+const CARDS = [
+  {
+    title: "Sejarah",
+    description:
+      "Pelajari tapak tilas dan awal mula berdirinya Balai Konservasi Sumber Daya Alam Kalimantan Timur.",
+    icon: History,
+    href: "/page/sejarah",
+  },
+  {
+    title: "Organisasi",
+    description:
+      "Informasi mengenai struktur kelembagaan, tugas pokok, dan fungsi BKSDA Kalimantan Timur.",
+    icon: Building2,
+    href: "/page/organisasi",
+  },
+  {
+    title: "Kepala Balai",
+    description:
+      "Profil singkat pucuk pimpinan Balai Konservasi Sumber Daya Alam Provinsi Kalimantan Timur.",
+    icon: UserCircle,
+    href: "/page/kepala-balai",
+  },
+];
+
+export default function ProfilPage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Hero Banner */}
+      <div className="relative h-[320px] md:h-[400px] bg-green-900 overflow-hidden flex items-center justify-center">
+        <img
+          src="/assets/header-new.png"
+          alt="Profil BKSDA"
+          className="absolute inset-0 w-full h-full object-cover opacity-20"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-green-900/90 via-green-900/40 to-green-900/60" />
+        <div className="relative z-10 text-center px-4">
+          <h1 className="text-4xl md:text-5xl font-black text-white tracking-wider uppercase mb-4">
+            Tentang Kami
+          </h1>
+          <div className="w-20 h-1.5 bg-green-400 mx-auto rounded-full" />
+          <p className="text-green-200 mt-4 max-w-lg mx-auto text-sm md:text-base">
+            Mengenal lebih dekat Balai Konservasi Sumber Daya Alam Kalimantan
+            Timur — visi, misi, dan struktur organisasi.
+          </p>
+        </div>
+      </div>
+
+      {/* Cards Grid */}
+      <div className="max-w-5xl mx-auto px-4 -mt-16 relative z-20 pb-24">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {CARDS.map((card) => {
+            const Icon = card.icon;
+            return (
+              <Link
+                key={card.title}
+                href={card.href}
+                className="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition-all p-8 flex flex-col items-center text-center border border-gray-100 hover:-translate-y-2 duration-300"
+              >
+                <div className="w-16 h-16 rounded-full bg-green-50 group-hover:bg-green-500 text-green-600 group-hover:text-white transition-colors duration-300 flex items-center justify-center mb-5">
+                  <Icon className="w-7 h-7" />
+                </div>
+                <h3 className="text-xl font-black text-gray-900 mb-3 group-hover:text-green-700 transition-colors uppercase">
+                  {card.title}
+                </h3>
+                <p className="text-gray-500 text-sm leading-relaxed">
+                  {card.description}
+                </p>
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Phase C: Public Pages\n\n### New Pages\n- **/profil** — Hub page with 3 cards (Sejarah, Organisasi, Kepala Balai) linking to /page/{slug}\n- **/page/[slug]** — Generic CMS page renderer fetching from /api/cms/public/page/{slug}, renders HTML content with prose styling, breadcrumbs, hero banner\n\n### Already Existing (No Changes Needed)\n- /publikasi — Already has 4-tab UI (buku, leaflet, poster, regulasi)\n- /galeri — Already has foto/video tabs with lightbox and YouTube embed\n- /informasi, /kawasan, /tsl, /hubungi-kami — All functional\n\n### Build\n- tsc --noEmit: 0 errors\n- eslint: 0 warnings\n- next build: exit code 0