### PR TITLE
fix(cms): 405 error on edit - use POST + _method=PUT for file uploads

### DIFF
--- a/frontend/src/app/cms/_components/CrudFormDrawer.tsx
+++ b/frontend/src/app/cms/_components/CrudFormDrawer.tsx
@@ -58,13 +58,15 @@ export default function CrudFormDrawer({
 
       if (hasFiles) {
         const formPayload = new FormData();
+        // Laravel requires _method=PUT for file uploads via POST
+        if (isEditing) formPayload.append("_method", "PUT");
         Object.entries(formData).forEach(([k, v]) => {
           if (v !== undefined && v !== null) formPayload.append(k, String(v));
         });
         Object.entries(files).forEach(([k, f]) => formPayload.append(k, f));
 
         if (isEditing && editingRecord) {
-          await api.put(
+          await api.post(
             `${config.apiEndpoint}/${editingRecord.id}`,
             formPayload,
             { headers: { "Content-Type": "multipart/form-data" } }

--- a/frontend/src/app/cms/informasi/[id]/page.tsx
+++ b/frontend/src/app/cms/informasi/[id]/page.tsx
@@ -132,6 +132,7 @@ export default function EditInformasiPage() {
     setIsSubmitting(true);
     try {
       const payload = new FormData();
+      payload.append("_method", "PUT");
       payload.append("judul", judul);
       payload.append("konten", konten);
       if (categoryId) payload.append("category_id", categoryId);


### PR DESCRIPTION
Fixes HTTP 405 when saving edited informasi. Laravel apiResource registers PUT for updates, but multipart/form-data file uploads need POST with _method=PUT field.