### PR TITLE
fix(surat-tugas): stabilize ST Builder print layout (#312)

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -56,14 +56,55 @@ git push origin main
 
 | Field | Value |
 |-------|-------|
-| **Issue Terakhir Selesai** | Phase 37: Production Deployment to AWS EC2 (🔄 IN PROGRESS) |
-| **Issue Selanjutnya** | SSL setup + fix API 500 + seed data + test all modules on production |
-| **Branch Aktif** | `main` |
-| **Commit Terakhir** | fix: remove duplicate ST create migration + add .kiro specs |
-| **Model Terakhir** | Claude Opus 4.6 (Kiro) |
-| **Timestamp** | 2026-05-17T18:35:00+08:00 |
+| **Issue Terakhir Selesai** | Issue #312: ST Builder print layout stabilization (READY FOR PR) |
+| **Issue Selanjutnya** | Deploy ST Builder print fix to production, then import BMN Excel and continue public sub-pages styling |
+| **Branch Aktif** | `issue/312-st-builder-print-layout` |
+| **Commit Terakhir** | fix(surat-tugas): stabilize ST Builder print layout (#312) |
+| **Model Terakhir** | GPT-5 Codex |
+| **Timestamp** | 2026-05-18T18:00:00+08:00 |
 
 ---
+
+---
+
+**UPDATE SESI CODEX (2026-05-18 - Issue #312: ST Builder Print Layout Stabilization):**
+- **Objective**: Stabilize ST Builder print output for FOLU and DIPA letters after production fixes.
+- **Status**: READY FOR PR - local print tuning completed, pending PR review/merge and production deploy.
+- **Accomplishments**:
+  - KOP surat halaman 1 no longer cropped in Chrome print preview.
+  - KOP is isolated from the main letter content so content margins do not affect the header.
+  - Main letter content is wrapped in `.surat-content` for consistent left/right margins across page breaks.
+  - Page 2+ keeps top margin via `@page` while page 1 gets a smaller top margin for KOP.
+  - `Kepada` block was refactored from a single large table row into block/grid layout.
+  - Employee entries now paginate per employee (`.employee-entry { break-inside: avoid }`) instead of moving the entire `Kepada` list to the next page.
+  - Verified scenarios discussed in session: FOLU, DIPA, 1 employee, 4 employees, 7 employees, and 11 employees no longer force the whole employee list down.
+- **Final Print CSS State**:
+  - `@page { size: A4; margin: 3cm 1cm 1cm 1.55cm; }`
+  - `@page :first { margin: 0.7cm 1cm 1cm 1.55cm; }`
+  - `.kop-surat` remains outside `.surat-content` and uses print-only sizing/spacing.
+  - `.surat-content { margin-left: 1.25cm; width: calc(100% - 2.2cm); margin-right: 0.95cm; }`
+  - `.kepada-list` may break across pages, `.employee-entry` avoids splitting inside an employee.
+- **Known Issues / Risks**:
+  - Full project lint still has pre-existing errors outside this change (`AssignmentLetterHistory.tsx`, `portal/page.tsx`, `portal/surat-tugas/[id]/page.tsx`).
+  - Only touched ST Builder print layout; untracked local deployment/import helper files and secrets were intentionally not staged.
+  - Need production deploy after PR merge.
+- **Key Files Modified**:
+  - `frontend/src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx`
+  - `frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx`
+  - `docs/HANDOFF.md`
+  - `docs/progress.md`
+- **Validation**:
+  - `npx eslint "src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx"` clean.
+  - `npx eslint "src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx"` clean.
+  - `npx tsc --noEmit` clean.
+  - `npm run build` clean.
+  - Full `npm run lint -- --max-warnings=0` not clean due to unrelated pre-existing files noted above.
+- **Next Steps**:
+  - [ ] Push branch and open PR for issue #312.
+  - [ ] Merge PR after review/testing.
+  - [ ] Deploy ST Builder print fix to production.
+  - [ ] Import BMN Excel in production.
+  - [ ] Continue styling public sub-pages (/kawasan, /tsl, /galeri, /publikasi).
 
 ---
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,48 @@
+# Progress - Phase 38: Production Fixes + ST Builder FOLU Template
+
+> Document updated: 2026-05-18
+> Status: **READY FOR PR**
+
+---
+
+## Issue #312: ST Builder Print Layout Stabilization
+
+### Completed:
+- [x] **Production**: SSL active, login works, employee import works, API URL fixed to `bksdakaltim.net/api`.
+- [x] **ST Builder FOLU Template**: FOLU header, nomor prefix, menimbang/dasar defaults, TTD wording, penutup, and tembusan are implemented.
+- [x] **KOP Print**: KOP only appears on page 1 and no longer crops in Chrome print preview.
+- [x] **Content Margins**: Main letter body now uses `.surat-content` so page 1, page 2, and later pages keep consistent margins independent of KOP.
+- [x] **Page Margins**: `@page` top margin keeps continuation pages readable; first page uses a smaller top margin for KOP.
+- [x] **Employee Pagination**: `Kepada` was refactored from one large table row to block/grid layout so employee entries can paginate one-by-one instead of all moving to the next page.
+- [x] **Employee Row Safety**: `.employee-entry` uses `break-inside: avoid` / `page-break-inside: avoid` so each employee is not split in the middle.
+- [x] **Scenarios Checked During Session**: FOLU/DIPA, 1 employee, 4 employees, 7 employees, and 11 employees print behavior.
+
+### Current Print CSS State:
+```css
+@page { size: A4; margin: 3cm 1cm 1cm 1.55cm; }
+@page :first { margin: 0.7cm 1cm 1cm 1.55cm; }
+.kop-surat { margin-left: 0; margin-right: -0.95cm; margin-top: -0.25cm; }
+.kop-surat img { width: 18.8cm; height: auto; }
+.surat-content { margin-left: 1.25cm; width: calc(100% - 2.2cm); margin-right: 0.95cm; }
+.field-section, .kepada-section, .kepada-list { break-inside: auto; page-break-inside: auto; }
+.employee-entry { break-inside: avoid; page-break-inside: avoid; }
+```
+
+### Validation:
+- [x] `npx eslint "src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx"`
+- [x] `npx eslint "src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx"`
+- [x] `npx tsc --noEmit`
+- [x] `npm run build`
+- [ ] Full `npm run lint -- --max-warnings=0` still blocked by unrelated pre-existing lint errors in portal/kepegawaian files.
+
+### Pending:
+- [ ] PR review/merge for #312.
+- [ ] Deploy ST Builder print fix to production.
+- [ ] Import BMN Excel in production.
+- [ ] Style public sub-pages (/kawasan, /tsl, /galeri, /publikasi).
+
+---
+
 # Progress - Phase 37: Production Deployment
 
 > Document updated: 2026-05-17

--- a/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx
+++ b/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx
@@ -72,6 +72,9 @@ export default function STBuilderPreview({
         <colgroup>
           <col style={{ width: "100%" }} />
         </colgroup>
+        <thead className="page-spacer">
+          <tr><td style={{ height: 0, padding: 0, lineHeight: 0, fontSize: 0 }}></td></tr>
+        </thead>
         <tbody>
           <tr>
             <td>
@@ -84,6 +87,7 @@ export default function STBuilderPreview({
                   style={{ width: "18.8cm", height: "auto", display: "block" }}
                 />
               </div>
+              <div className="surat-content">
               {/* === JUDUL === */}
               <p style={{ textAlign: "center", fontWeight: "bold", fontSize: "11pt", margin: "0 0 2px" }}>
                 SURAT TUGAS
@@ -162,59 +166,57 @@ export default function STBuilderPreview({
               <p style={{ textAlign: "center", fontWeight: "bold", margin: "16px 0 4px" }}>MEMBERI TUGAS,</p>
 
               {/* === KEPADA === */}
-              <table style={{ width: "100%", borderCollapse: "collapse", marginBottom: "12px", marginLeft: "0", tableLayout: "fixed" }}>
-                <tbody>
-                  <tr>
-                    <td style={{ width: "110px", verticalAlign: "top", padding: "2px 0" }}>Kepada</td>
-                    <td style={{ width: "12px", verticalAlign: "top", padding: "2px 0" }}>:</td>
-                    <td style={{ verticalAlign: "top", padding: "2px 0" }}>
-                      <table style={{ width: "100%", borderCollapse: "collapse", tableLayout: "fixed" }}>
-                        <tbody>
-                          {selectedEmployees.length === 0 ? (
-                            <tr>
-                              <td colSpan={2} style={{ padding: "4px 0", fontStyle: "italic", color: "#999" }}>
-                                ( Belum ada pegawai dipilih )
-                              </td>
-                            </tr>
-                          ) : (
-                            selectedEmployees.map((emp, idx) => (
-                              <React.Fragment key={emp.id}>
-                                <tr>
-                                  <td style={{ width: "24px", verticalAlign: "top", padding: "2px 0" }}>{idx + 1}.</td>
-                                  <td style={{ padding: "2px 0" }}>
-                                    <table style={{ borderCollapse: "collapse", width: "100%", tableLayout: "fixed" }}>
-                                      <tbody>
-                                        <tr>
-                                          <td style={{ width: "70px", padding: "1px 0" }}>Nama</td>
-                                          <td style={{ width: "20px", padding: "1px 0" }}>:</td>
-                                          <td style={{ padding: "1px 0", fontWeight: "bold" }}>{emp.nama_lengkap || emp.name}</td>
-                                        </tr>
-                                        <tr>
-                                          <td style={{ width: "70px", padding: "1px 0" }}>NIP</td>
-                                          <td style={{ width: "20px", padding: "1px 0" }}>:</td>
-                                          <td style={{ padding: "1px 0" }}>{formatNIP(emp.nip)}</td>
-                                        </tr>
-                                        <tr>
-                                          <td style={{ width: "70px", padding: "1px 0" }}>Jabatan</td>
-                                          <td style={{ width: "20px", padding: "1px 0" }}>:</td>
-                                          <td style={{ padding: "1px 0" }}>{emp.jabatan}</td>
-                                        </tr>
-                                      </tbody>
-                                    </table>
-                                  </td>
-                                </tr>
-                                {idx < selectedEmployees.length - 1 && (
-                                  <tr><td colSpan={2} style={{ padding: "4px 0" }}></td></tr>
-                                )}
-                              </React.Fragment>
-                            ))
-                          )}
-                        </tbody>
-                      </table>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+              <div
+                className="field-section kepada-section"
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "110px 12px 1fr",
+                  columnGap: 0,
+                  marginBottom: "12px",
+                }}
+              >
+                <div style={{ padding: "2px 0" }}>Kepada</div>
+                <div style={{ padding: "2px 0" }}>:</div>
+                <div className="kepada-list" style={{ padding: "2px 0" }}>
+                  {selectedEmployees.length === 0 ? (
+                    <div style={{ padding: "4px 0", fontStyle: "italic", color: "#999" }}>
+                      ( Belum ada pegawai dipilih )
+                    </div>
+                  ) : (
+                    selectedEmployees.map((emp, idx) => (
+                      <div
+                        className="employee-entry"
+                        key={emp.id}
+                        style={{
+                          display: "grid",
+                          gridTemplateColumns: "24px 1fr",
+                          padding: idx === 0 ? "0 0 4px" : "4px 0",
+                          breakInside: "avoid",
+                        }}
+                      >
+                        <div style={{ padding: "2px 0" }}>{idx + 1}.</div>
+                        <div>
+                          <div style={{ display: "grid", gridTemplateColumns: "70px 20px 1fr" }}>
+                            <div style={{ padding: "1px 0" }}>Nama</div>
+                            <div style={{ padding: "1px 0" }}>:</div>
+                            <div style={{ padding: "1px 0", fontWeight: "bold" }}>{emp.nama_lengkap || emp.name}</div>
+                          </div>
+                          <div style={{ display: "grid", gridTemplateColumns: "70px 20px 1fr" }}>
+                            <div style={{ padding: "1px 0" }}>NIP</div>
+                            <div style={{ padding: "1px 0" }}>:</div>
+                            <div style={{ padding: "1px 0" }}>{formatNIP(emp.nip)}</div>
+                          </div>
+                          <div style={{ display: "grid", gridTemplateColumns: "70px 20px 1fr" }}>
+                            <div style={{ padding: "1px 0" }}>Jabatan</div>
+                            <div style={{ padding: "1px 0" }}>:</div>
+                            <div style={{ padding: "1px 0" }}>{emp.jabatan}</div>
+                          </div>
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
 
               {/* === UNTUK === */}
               <table style={{ width: "100%", borderCollapse: "collapse", marginBottom: "8px", marginLeft: "0", tableLayout: "fixed" }}>
@@ -252,15 +254,15 @@ export default function STBuilderPreview({
 
               {/* === PENUTUP === */}
               {isFolu ? (
-                <p style={{ margin: "28px 0 0", textAlign: "justify" }}>
+                <p className="penutup-surat" style={{ margin: "28px 0 0", textAlign: "justify" }}>
                   Demikian Surat Perintah Tugas ini dibuat, untuk dapat dipergunakan sebagaimana mestinya dan kepada instansi yang dikunjungi dimohon bantuan seperlunya demi kelancaran pelaksanaan tugas.
                 </p>
               ) : (
-                <p style={{ margin: "28px 0 0" }}>Demikian untuk dilaksanakan dengan penuh tanggung jawab.</p>
+                <p className="penutup-surat" style={{ margin: "28px 0 0" }}>Demikian untuk dilaksanakan dengan penuh tanggung jawab.</p>
               )}
 
               {/* === TANDA TANGAN + TEMBUSAN === */}
-              <div style={{ pageBreakInside: "avoid" }}>
+              <div className="ttd-tembusan-wrapper" style={{ pageBreakInside: "avoid" }}>
                 {isFolu ? (
                   <>
                     {/* === FOLU TTD Layout — Dikeluarkan sejajar a.n., rata kanan === */}
@@ -292,7 +294,7 @@ export default function STBuilderPreview({
 
                     {/* === FOLU Tembusan — di bawah NIP, full width === */}
                     {tembusanItems.length > 0 && (
-                      <div style={{ marginTop: "16px" }}>
+                      <div className="tembusan-block" style={{ marginTop: "16px" }}>
                         <p style={{ margin: "0 0 4px", fontSize: "10pt" }}>Tembusan Kepada :</p>
                         <table style={{ borderCollapse: "collapse" }}>
                           <tbody>
@@ -324,7 +326,7 @@ export default function STBuilderPreview({
 
                     {/* === Tembusan (kiri) sejajar NIP === */}
                     {tembusanItems.length > 0 && (
-                      <div style={{ marginTop: "-18px", maxWidth: "8cm" }}>
+                      <div className="tembusan-block" style={{ marginTop: "-18px", maxWidth: "8cm" }}>
                         <p style={{ margin: "0 0 4px", fontSize: "10pt" }}>Tembusan:</p>
                         <table style={{ borderCollapse: "collapse" }}>
                           <tbody>
@@ -340,6 +342,7 @@ export default function STBuilderPreview({
                     )}
                   </>
                 )}
+              </div>
               </div>
             </td>
           </tr>

--- a/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx
+++ b/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx
@@ -547,8 +547,8 @@ export default function STBuilderPage() {
       <head>
         <title>ST.${stNumber}-${namaKegiatan.replace(/[/\\?%*:|"<>]/g, '-')}</title>
         <style>
-          @page { size: A4; margin: 2cm 1.5cm 1cm 2.5cm; }
-          @page :first { margin-top: 0; }
+          @page { size: A4; margin: 3cm 1cm 1cm 1.55cm; }
+          @page :first { margin: 0.7cm 1cm 1cm 1.55cm; }
           body { 
             font-family: 'Bookman Old Style', 'Georgia', serif; 
             font-size: 11pt; 
@@ -560,12 +560,18 @@ export default function STBuilderPage() {
           }
           table { width: 100%; border-collapse: collapse; }
           td { vertical-align: top; padding: 2px 0; font-size: 11pt; }
-          tr { page-break-inside: avoid; }
+          tr { page-break-inside: avoid; break-inside: avoid; }
           img { max-width: none !important; }
           .ttd-placeholder { height: 80px; }
-          .kop-surat { margin-left: -1cm; margin-right: -0.5cm; }
-          .kop-surat img { width: 100% !important; height: auto !important; }
+          /* First page gets its own safe letterhead area; page 2+ keeps the 3cm @page margin. */
+          .kop-surat { margin-left: 0 !important; margin-right: -0.95cm !important; margin-top: -0.25cm !important; margin-bottom: 2px !important; overflow: visible !important; }
+          .kop-surat img { width: 18.8cm !important; height: auto !important; }
+          .surat-content { margin-left: 1.25cm !important; width: calc(100% - 2.2cm) !important; margin-right: 0.95cm !important; }
+          .field-section, .kepada-section, .kepada-list { break-inside: auto !important; page-break-inside: auto !important; }
+          .employee-entry { break-inside: avoid !important; page-break-inside: avoid !important; }
           div[style*="page-break-inside"] { page-break-inside: avoid; }
+          /* thead spacer: hidden, not needed with @page margin */
+          thead.page-spacer td { height: 0; padding: 0; line-height: 0; font-size: 0; }
         </style>
       </head>
       <body>${printContent.innerHTML}</body>


### PR DESCRIPTION
﻿Closes #312

## Summary
- Isolate the page-1 KOP from the main letter content so it no longer crops or shifts body margins.
- Wrap the letter body in a consistent `.surat-content` margin container for stable page 1/2/3 alignment.
- Refactor the `Kepada` employee list from a single large table row to block/grid entries so employees paginate one-by-one instead of moving the whole list to the next page.
- Update `HANDOFF.md` and `progress.md` with the final Phase 38 / issue #312 state.

## Validation
- PASS: `npx eslint "src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx"`
- PASS: `npx eslint "src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx"`
- PASS: `npx tsc --noEmit`
- PASS: `npm run build`
- KNOWN BLOCKER: `npm run lint -- --max-warnings=0` still fails in unrelated pre-existing files: `AssignmentLetterHistory.tsx`, `EmployeeAccessSheet.tsx`, `portal/page.tsx`, `portal/surat-tugas/[id]/page.tsx`.
