### PR TITLE
fix(surat-tugas): normalize FOLU funding in builder (#314)

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -56,16 +56,59 @@ git push origin main
 
 | Field | Value |
 |-------|-------|
-| **Issue Terakhir Selesai** | Issue #312: ST Builder print layout stabilization (READY FOR PR) |
-| **Issue Selanjutnya** | Deploy ST Builder print fix to production, then import BMN Excel and continue public sub-pages styling |
-| **Branch Aktif** | `issue/312-st-builder-print-layout` |
-| **Commit Terakhir** | fix(surat-tugas): stabilize ST Builder print layout (#312) |
+| **Issue Terakhir Selesai** | Issue #312: ST Builder print layout stabilization (PR #313 MERGED) |
+| **Issue Selanjutnya** | Review/merge PR #315 for Issue #314, deploy ST Builder fixes to production, then import BMN Excel |
+| **Branch Aktif** | `issue/314-folu-funding-builder` |
+| **Commit Terakhir** | fix(surat-tugas): normalize FOLU funding in builder (#314) |
 | **Model Terakhir** | GPT-5 Codex |
-| **Timestamp** | 2026-05-18T18:00:00+08:00 |
+| **Timestamp** | 2026-05-18T17:55:43+08:00 |
 
 ---
 
 ---
+
+**UPDATE SESI CODEX (2026-05-18 - Issue #314: ST Builder FOLU Funding Normalization):**
+- **Objective**: Fix ST Builder edit mode so Surat Tugas submitted from `/surat-tugas` with `Dana Kerjasama FOLU` opens as FOLU instead of falling back to DIPA.
+- **Status**: PR OPEN - PR #315 is clean and ready for review/merge.
+- **GitHub**:
+  - Issue: #314 `fix(surat-tugas): normalize FOLU funding in ST Builder`
+  - PR: #315 `fix(surat-tugas): normalize FOLU funding in builder (#314)`
+  - Branch: `issue/314-folu-funding-builder`
+  - Commit: `b7720de fix(surat-tugas): normalize FOLU funding in builder (#314)`
+- **Accomplishments**:
+  - Added source-funding normalization in ST Builder so saved labels like `Dana Kerjasama FOLU`, `Dana Kerjasama FOLU NC 2&3`, and internal value `folu` all map to the Builder option `folu`.
+  - Fixed the user-reported case where Inbox detail showed `Dana Kerjasama FOLU`, but clicking **Edit Surat Tugas** showed `DIPA`.
+  - Added FOLU Menimbang helper that extracts kawasan names from `Tempat Spesifik` or from activity text containing `di ...`.
+  - FOLU Menimbang now becomes: `bahwa dalam upaya menjaga kelestarian keanekaragaman hayati di [kawasan], perlu dilakukan kegiatan pengamanan dan perlindungan melalui Patroli SMART;` when the activity contains Smart Patrol/Patroli.
+  - Applied the same FOLU Menimbang sync to direct ST create page and ST Builder edit flow.
+  - Preserved manually edited Menimbang text by only auto-updating default/generated FOLU text.
+- **Example Covered**:
+  - `Melaksanakan perjalanan dinas dari Samarinda ke Kabupaten Kutai Barat dalam rangka melaksanakan Smart Patrol/Patroli Perlindungan Kawasan Konservasi di Suaka Margasatwa Kelian` + FOLU now generates Menimbang with `di Suaka Margasatwa Kelian`.
+  - `Melaksanakan Smart Patrol/Patroli Perlindungan dan Pengamanan Kawasan Konservasi di Cagar Alam Muara Kaman Sedulang` + FOLU now generates Menimbang with `di Cagar Alam Muara Kaman Sedulang`.
+- **Key Files Modified**:
+  - `frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx`
+  - `frontend/src/app/kepegawaian/surat-tugas/create/page.tsx`
+  - `frontend/src/lib/letter-utils.ts`
+- **Validation**:
+  - `npx eslint "src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx" "src/app/kepegawaian/surat-tugas/create/page.tsx" "src/lib/letter-utils.ts"` clean.
+  - `npx tsc --noEmit` clean.
+  - `npm run build` clean.
+- **Known Issues / Risks**:
+  - Untracked local helper/credential files still exist and were intentionally not staged (`bksda-superapp.pem`, `service-account.json`, import/deploy test scripts).
+  - Full deploy to SSH/production has not been done for Issue #314 yet; do it after PR #315 is merged.
+- **Next Steps**:
+  - [ ] Review and merge PR #315.
+  - [ ] Deploy merged ST Builder fixes to production server via SSH.
+  - [ ] Re-test Inbox -> Edit Surat Tugas for submitted FOLU letters on production.
+  - [ ] Import BMN Excel in production.
+  - [ ] Continue styling public sub-pages (/kawasan, /tsl, /galeri, /publikasi).
+
+---
+
+**UPDATE SESI CODEX (2026-05-18 - Issue #312 Merge):**
+- PR #313 for Issue #312 was merged into `main`.
+- Merge commit: `f17c1049378f9b86b92c4cf2ff9e29982995adec`.
+- Branch cleanup was handled by GitHub CLI.
 
 **UPDATE SESI CODEX (2026-05-18 - Issue #312: ST Builder Print Layout Stabilization):**
 - **Objective**: Stabilize ST Builder print output for FOLU and DIPA letters after production fixes.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,13 +1,52 @@
 # Progress - Phase 38: Production Fixes + ST Builder FOLU Template
 
 > Document updated: 2026-05-18
-> Status: **READY FOR PR**
+> Status: **PR OPEN**
+
+---
+
+## Issue #314: ST Builder FOLU Funding Normalization
+
+### Completed:
+- [x] **PR Created**: PR #315 opened from `issue/314-folu-funding-builder` to `main`.
+- [x] **Issue Created**: Issue #314 tracks the FOLU funding fallback bug.
+- [x] **Funding Normalization**: ST Builder now maps submitted labels such as `Dana Kerjasama FOLU` and `Dana Kerjasama FOLU NC 2&3` to the internal `folu` option.
+- [x] **Inbox Edit Bug Fixed**: Letters that show `Dana Kerjasama FOLU` in Inbox no longer open as `DIPA` when clicking **Edit Surat Tugas**.
+- [x] **FOLU Menimbang Helper**: Added shared helper to extract kawasan from `Tempat Spesifik` or from activity text containing `di ...`.
+- [x] **Patroli SMART Template**: FOLU activities containing `Smart Patrol` or `Patroli` now generate `Menimbang` with `melalui Patroli SMART`.
+- [x] **Create + Builder Sync**: Direct ST create and Builder edit flows both sync generated FOLU Menimbang when activity/place changes.
+- [x] **Manual Text Safety**: Auto-sync only touches default/generated FOLU Menimbang text and does not overwrite manually customized Menimbang text.
+
+### Example Output:
+```text
+bahwa dalam upaya menjaga kelestarian keanekaragaman hayati di Suaka Margasatwa Kelian, perlu dilakukan kegiatan pengamanan dan perlindungan melalui Patroli SMART;
+```
+
+```text
+bahwa dalam upaya menjaga kelestarian keanekaragaman hayati di Cagar Alam Muara Kaman Sedulang, perlu dilakukan kegiatan pengamanan dan perlindungan melalui Patroli SMART;
+```
+
+### Key Files:
+- `frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx`
+- `frontend/src/app/kepegawaian/surat-tugas/create/page.tsx`
+- `frontend/src/lib/letter-utils.ts`
+
+### Validation:
+- [x] `npx eslint "src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx" "src/app/kepegawaian/surat-tugas/create/page.tsx" "src/lib/letter-utils.ts"`
+- [x] `npx tsc --noEmit`
+- [x] `npm run build`
+
+### Pending:
+- [ ] Review/merge PR #315.
+- [ ] Deploy Issue #314 fix to production via SSH after merge.
+- [ ] Re-test production Inbox -> Edit Surat Tugas for submitted FOLU letters.
 
 ---
 
 ## Issue #312: ST Builder Print Layout Stabilization
 
 ### Completed:
+- [x] **PR Merged**: PR #313 merged into `main` (`f17c1049378f9b86b92c4cf2ff9e29982995adec`).
 - [x] **Production**: SSL active, login works, employee import works, API URL fixed to `bksdakaltim.net/api`.
 - [x] **ST Builder FOLU Template**: FOLU header, nomor prefix, menimbang/dasar defaults, TTD wording, penutup, and tembusan are implemented.
 - [x] **KOP Print**: KOP only appears on page 1 and no longer crops in Chrome print preview.
@@ -36,7 +75,6 @@
 - [ ] Full `npm run lint -- --max-warnings=0` still blocked by unrelated pre-existing lint errors in portal/kepegawaian files.
 
 ### Pending:
-- [ ] PR review/merge for #312.
 - [ ] Deploy ST Builder print fix to production.
 - [ ] Import BMN Excel in production.
 - [ ] Style public sub-pages (/kawasan, /tsl, /galeri, /publikasi).

--- a/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx
+++ b/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx
@@ -24,6 +24,8 @@ import {
   daysBetween,
   numberToWords,
   indexToLetter,
+  buildFoluMenimbangText,
+  isGeneratedFoluMenimbangText,
 } from "@/lib/letter-utils";
 
 // --- Types ---
@@ -95,6 +97,30 @@ const SUMBER_DANA_OPTIONS: SumberDanaOption[] = [
     biayaText: ''
   },
 ];
+
+function normalizeSumberDana(value: string | null | undefined): string {
+  if (!value) return "dipa";
+
+  const normalized = value.toLowerCase().replace(/\s+/g, " ").trim();
+  const exactId = SUMBER_DANA_OPTIONS.find(option => option.id === normalized);
+  if (exactId) return exactId.id;
+
+  const exactLabel = SUMBER_DANA_OPTIONS.find(option => option.label.toLowerCase() === normalized);
+  if (exactLabel) return exactLabel.id;
+
+  if (normalized.includes("folu")) return "folu";
+  if (normalized.includes("dipa")) return "dipa";
+  if (normalized.includes("kja")) return "kja";
+  if (normalized.includes("mja")) return "mja";
+  if (normalized.includes("cop")) return "cop";
+  if (normalized.includes("tjiwi")) return "tjiwi_kimia";
+  if (normalized.includes("bosf")) return "bosf";
+  if (normalized.includes("can")) return "can";
+  if (normalized.includes("alert")) return "alert";
+  if (normalized.includes("dl 1") || normalized.includes("tidak ada biaya")) return "dl1";
+
+  return "other";
+}
 
 export default function STBuilderPage() {
   const params = useParams();
@@ -208,7 +234,7 @@ export default function STBuilderPage() {
       // Auto-set klasifikasi with FOLU.NC-23 prefix
       setKlasifikasi(prev => prev.startsWith("FOLU.NC-23/") ? prev : "FOLU.NC-23/" + prev);
       setMenimbangItems([
-        { id: "folu-1", text: "bahwa dalam upaya menjaga kelestarian keanekaragaman hayati, perlu dilakukan kegiatan pengamanan dan perlindungan;" },
+        { id: "folu-1", text: buildFoluMenimbangText(namaKegiatan, tempatKegiatan) },
         { id: "folu-2", text: "bahwa dalam rangka kelancaran tugas Project Management Unit FOLU-NC 2 dan 3 maka dipandang perlu menugaskan pegawai dimaksud;" },
         { id: "folu-3", text: "bahwa untuk maksud tersebut (poin a dan b) perlu diterbitkan Surat Tugas." },
       ]);
@@ -318,7 +344,7 @@ export default function STBuilderPage() {
         setTanggalMulai(data.tanggal_mulai?.split("T")[0] || "");
         setTanggalSelesai(data.tanggal_selesai?.split("T")[0] || "");
         
-        const funding = data.sumber_dana || "dipa";
+        const funding = normalizeSumberDana(data.sumber_dana);
         setSumberDana(funding);
         if (data.sumber_dana_other) setSumberDanaOther(data.sumber_dana_other);
         
@@ -373,6 +399,31 @@ export default function STBuilderPage() {
           updateDasarFromFunding(funding, new Date().toISOString().substring(0, 10));
         }
 
+        if (funding === "folu") {
+          const currentMenimbang = data.menimbang && Array.isArray(data.menimbang) ? data.menimbang : [];
+          const firstMenimbang = currentMenimbang[0];
+          const shouldUseFoluTemplate = currentMenimbang.length === 0 ||
+            firstMenimbang?.id === "folu-1" ||
+            isGeneratedFoluMenimbangText(firstMenimbang?.text);
+
+          if (shouldUseFoluTemplate) {
+            setMenimbangItems(prev => {
+              const nextItems = prev.length >= 3 ? [...prev] : [
+                { id: "folu-1", text: "" },
+                { id: "folu-2", text: "bahwa dalam rangka kelancaran tugas Project Management Unit FOLU-NC 2 dan 3 maka dipandang perlu menugaskan pegawai dimaksud;" },
+                { id: "folu-3", text: "bahwa untuk maksud tersebut (poin a dan b) perlu diterbitkan Surat Tugas." },
+              ];
+
+              nextItems[0] = {
+                ...nextItems[0],
+                id: "folu-1",
+                text: buildFoluMenimbangText(cleanedActivity),
+              };
+              return nextItems;
+            });
+          }
+        }
+
         // Auto-fill klasifikasi & menimbang if kegiatan contains "konflik"
         const parsedKegiatan = cleanedActivity.toLowerCase();
         if (parsedKegiatan.includes("konflik")) {
@@ -410,8 +461,28 @@ export default function STBuilderPage() {
   }, [id]);
 
   // Auto-fill klasifikasi & menimbang based on nama kegiatan keywords
+  const updateFoluMenimbang = (activity: string, place: string) => {
+    setMenimbangItems(prev => {
+      if (prev.length === 0) return prev;
+      const first = prev[0];
+      const isDefaultText = first.text === "bahwa dalam rangka , perlu ;";
+      if (first.id !== "folu-1" && !isDefaultText && !isGeneratedFoluMenimbangText(first.text)) return prev;
+
+      const nextText = buildFoluMenimbangText(activity, place);
+      if (first.text === nextText && first.id === "folu-1") return prev;
+
+      const nextItems = [...prev];
+      nextItems[0] = { ...first, id: "folu-1", text: nextText };
+      return nextItems;
+    });
+  };
+
   const handleNamaKegiatanChange = (value: string) => {
     setNamaKegiatan(value);
+    if (sumberDana === "folu") {
+      updateFoluMenimbang(value, tempatKegiatan);
+    }
+
     const lower = value.toLowerCase();
     if (lower.includes("konflik")) {
       setKlasifikasi("KSA.03.01");
@@ -747,7 +818,13 @@ export default function STBuilderPage() {
                 <input value={kotaTujuan} onChange={e => setKotaTujuan(e.target.value)} placeholder="Tujuan" className="px-3 py-2 bg-zinc-50 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm outline-none text-zinc-900 dark:text-white" />
               </div>
               <textarea value={namaKegiatan} onChange={e => handleNamaKegiatanChange(e.target.value)} placeholder="Kegiatan..." className="w-full px-3 py-2 bg-zinc-50 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm min-h-[60px] outline-none text-zinc-900 dark:text-white" />
-              <input value={tempatKegiatan} onChange={e => setTempatKegiatan(e.target.value)} placeholder="Tempat Spesifik" className="w-full px-3 py-2 bg-zinc-50 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm outline-none text-zinc-900 dark:text-white" />
+              <input value={tempatKegiatan} onChange={e => {
+                const nextPlace = e.target.value;
+                setTempatKegiatan(nextPlace);
+                if (sumberDana === "folu") {
+                  updateFoluMenimbang(namaKegiatan, nextPlace);
+                }
+              }} placeholder="Tempat Spesifik" className="w-full px-3 py-2 bg-zinc-50 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm outline-none text-zinc-900 dark:text-white" />
               <div className="grid grid-cols-2 gap-2">
                 <input type="date" value={tanggalMulai} onChange={e => setTanggalMulai(e.target.value)} className="px-3 py-2 bg-zinc-50 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm outline-none text-zinc-900 dark:text-white" />
                 <input type="date" value={tanggalSelesai} onChange={e => setTanggalSelesai(e.target.value)} className="px-3 py-2 bg-zinc-50 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm outline-none text-zinc-900 dark:text-white" />

--- a/frontend/src/app/kepegawaian/surat-tugas/create/page.tsx
+++ b/frontend/src/app/kepegawaian/surat-tugas/create/page.tsx
@@ -24,6 +24,8 @@ import {
   daysBetween,
   numberToWords,
   indexToLetter,
+  buildFoluMenimbangText,
+  isGeneratedFoluMenimbangText,
 } from "@/lib/letter-utils";
 
 // --- Types ---
@@ -202,8 +204,28 @@ export default function STCreatePremiumPage() {
   };
 
   // Auto-fill klasifikasi & menimbang based on nama kegiatan keywords
+  const updateFoluMenimbang = (activity: string, place: string) => {
+    setMenimbangItems(prev => {
+      if (prev.length === 0) return prev;
+      const first = prev[0];
+      const isDefaultText = first.text === "bahwa dalam rangka , perlu ;";
+      if (first.id !== "folu-1" && !isDefaultText && !isGeneratedFoluMenimbangText(first.text)) return prev;
+
+      const nextText = buildFoluMenimbangText(activity, place);
+      if (first.text === nextText && first.id === "folu-1") return prev;
+
+      const nextItems = [...prev];
+      nextItems[0] = { ...first, id: "folu-1", text: nextText };
+      return nextItems;
+    });
+  };
+
   const handleNamaKegiatanChange = (value: string) => {
     setNamaKegiatan(value);
+    if (sumberDana === "folu") {
+      updateFoluMenimbang(value, tempatKegiatan);
+    }
+
     const lower = value.toLowerCase();
     if (lower.includes("konflik")) {
       setKlasifikasi("KSA.03.01");
@@ -330,6 +352,9 @@ export default function STCreatePremiumPage() {
                   const newFunding = e.target.value;
                   setSumberDana(newFunding);
                   updateDasarFromFunding(newFunding, tanggalSurat);
+                  if (newFunding === "folu") {
+                    updateFoluMenimbang(namaKegiatan, tempatKegiatan);
+                  }
                 }} 
                 className="w-full px-3 py-2 bg-slate-50 dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 rounded-xl text-sm outline-none cursor-pointer text-zinc-900 dark:text-white"
               >
@@ -428,7 +453,13 @@ export default function STCreatePremiumPage() {
                 <input value={kotaTujuan} onChange={e => setKotaTujuan(e.target.value)} placeholder="Tujuan" className="px-3 py-2 bg-slate-50 dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 rounded-xl text-sm outline-none text-zinc-900 dark:text-white" />
               </div>
               <textarea value={namaKegiatan} onChange={e => handleNamaKegiatanChange(e.target.value)} placeholder="Kegiatan..." className="w-full px-3 py-2 bg-slate-50 dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 rounded-xl text-sm min-h-[60px] outline-none text-zinc-900 dark:text-white" />
-              <input value={tempatKegiatan} onChange={e => setTempatKegiatan(e.target.value)} placeholder="Tempat Spesifik" className="w-full px-3 py-2 bg-slate-50 dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 rounded-xl text-sm outline-none text-zinc-900 dark:text-white" />
+              <input value={tempatKegiatan} onChange={e => {
+                const nextPlace = e.target.value;
+                setTempatKegiatan(nextPlace);
+                if (sumberDana === "folu") {
+                  updateFoluMenimbang(namaKegiatan, nextPlace);
+                }
+              }} placeholder="Tempat Spesifik" className="w-full px-3 py-2 bg-slate-50 dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 rounded-xl text-sm outline-none text-zinc-900 dark:text-white" />
               <div className="grid grid-cols-2 gap-2">
                 <input type="date" value={tanggalMulai} onChange={e => setTanggalMulai(e.target.value)} className="px-3 py-2 bg-slate-50 dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 rounded-xl text-sm outline-none text-zinc-900 dark:text-white" />
                 <input type="date" value={tanggalSelesai} onChange={e => setTanggalSelesai(e.target.value)} className="px-3 py-2 bg-slate-50 dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 rounded-xl text-sm outline-none text-zinc-900 dark:text-white" />

--- a/frontend/src/lib/letter-utils.ts
+++ b/frontend/src/lib/letter-utils.ts
@@ -75,3 +75,29 @@ export function formatNIP(nip: string | null | undefined): string {
     if (cleaned.length !== 18) return cleaned;
     return `${cleaned.substring(0, 8)} ${cleaned.substring(8, 14)} ${cleaned.substring(14, 15)} ${cleaned.substring(15)}`;
 }
+
+export function extractFoluKawasan(namaKegiatan: string, tempatKegiatan?: string): string {
+    const explicitPlace = tempatKegiatan?.trim().replace(/[;,.]$/, '');
+    if (explicitPlace) return explicitPlace;
+
+    const normalized = namaKegiatan.replace(/\s+/g, ' ').trim();
+    const diMatch = normalized.match(/\bdi\s+(.+?)(?:[,;.]|$)/i);
+    return diMatch?.[1]?.trim().replace(/[;,.]$/, '') || '';
+}
+
+export function buildFoluMenimbangText(namaKegiatan: string, tempatKegiatan?: string): string {
+    const kawasan = extractFoluKawasan(namaKegiatan, tempatKegiatan);
+    const lower = namaKegiatan.toLowerCase();
+    const isSmartPatrol = lower.includes('smart patrol') || lower.includes('patroli');
+    const locationText = kawasan ? ` di ${kawasan}` : '';
+    const patrolText = isSmartPatrol ? ' melalui Patroli SMART' : '';
+
+    return `bahwa dalam upaya menjaga kelestarian keanekaragaman hayati${locationText}, perlu dilakukan kegiatan pengamanan dan perlindungan${patrolText};`;
+}
+
+export function isGeneratedFoluMenimbangText(text: string | null | undefined): boolean {
+    return Boolean(
+        text?.startsWith('bahwa dalam upaya menjaga kelestarian keanekaragaman hayati') &&
+        text.includes('perlu dilakukan kegiatan pengamanan dan perlindungan')
+    );
+}


### PR DESCRIPTION
Closes #314

## Summary
- Normalize submitted funding labels like `Dana Kerjasama FOLU` into ST Builder option IDs so Edit no longer falls back to DIPA.
- Add FOLU Menimbang helper that includes kawasan names and Patroli SMART wording.
- Keep FOLU Menimbang synced when activity or specific location changes in builder/create flows.

## Validation
- `npx eslint src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx src/app/kepegawaian/surat-tugas/create/page.tsx src/lib/letter-utils.ts`
- `npx tsc --noEmit`
- `npm run build`