### PR TITLE
fix(surat-tugas): allow Untuk print pagination (#316)

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -57,13 +57,48 @@ git push origin main
 | Field | Value |
 |-------|-------|
 | **Issue Terakhir Selesai** | Issue #314: ST Builder FOLU funding normalization (PR #315 MERGED + DEPLOYED) |
-| **Issue Selanjutnya** | Import BMN Excel in production, then continue public sub-pages styling |
-| **Branch Aktif** | `main` |
-| **Commit Terakhir** | Merge pull request #315 from tegaranugrah1/issue/314-folu-funding-builder |
+| **Issue Selanjutnya** | Review/merge/deploy PR #317 for Issue #316, then import BMN Excel in production |
+| **Branch Aktif** | `issue/316-untuk-print-pagination` |
+| **Commit Terakhir** | fix(surat-tugas): allow Untuk print pagination (#316) |
 | **Model Terakhir** | GPT-5 Codex |
-| **Timestamp** | 2026-05-18T18:01:19+08:00 |
+| **Timestamp** | 2026-05-18T18:05:48+08:00 |
 
 ---
+
+---
+
+**UPDATE SESI CODEX (2026-05-18 - Issue #316: ST Builder Untuk Print Pagination):**
+- **Objective**: Fix FOLU print layout where the entire `Untuk` section moves to the next page when there are 2 employees, leaving unused space on the previous page.
+- **Status**: PR OPEN - PR #317 is clean and ready for review/merge/deploy.
+- **GitHub**:
+  - Issue: #316 `fix(surat-tugas): allow Untuk section to paginate in FOLU print`
+  - PR: #317 `fix(surat-tugas): allow Untuk print pagination (#316)`
+  - Branch: `issue/316-untuk-print-pagination`
+  - Commit: `43c6c92 fix(surat-tugas): allow Untuk print pagination (#316)`
+- **Root Cause**:
+  - The `Untuk` section was still rendered as nested table rows.
+  - Print CSS has global `tr { page-break-inside: avoid; break-inside: avoid; }`, so Chrome treated the outer `Untuk` row as one unbreakable block and pushed it fully to page 2.
+- **Accomplishments**:
+  - Refactored `Untuk` from nested table rows to grid/block layout, matching the previous `Kepada` pagination fix.
+  - Added `.untuk-section` and `.untuk-list` to print CSS with `break-inside: auto`.
+  - Added `.untuk-entry` with `break-inside: avoid` so each numbered item stays intact while the list can paginate between items.
+  - Verified build path locally for the changed files.
+- **Key Files Modified**:
+  - `frontend/src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx`
+  - `frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx`
+- **Validation**:
+  - `npx eslint "src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx" "src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx"` clean.
+  - `npx tsc --noEmit` clean.
+  - `npm run build` clean.
+- **Known Issues / Risks**:
+  - Untracked local helper/credential files still exist and were intentionally not staged (`bksda-superapp.pem`, `service-account.json`, import/deploy test scripts).
+  - Production deploy has not yet been done for Issue #316 at the moment this note was written.
+- **Next Steps**:
+  - [ ] Merge PR #317.
+  - [ ] Deploy merged frontend fix to production server via SSH.
+  - [ ] Re-test FOLU print preview with 2 employees on production.
+  - [ ] Import BMN Excel in production.
+  - [ ] Continue styling public sub-pages (/kawasan, /tsl, /galeri, /publikasi).
 
 ---
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,7 +1,33 @@
 # Progress - Phase 38: Production Fixes + ST Builder FOLU Template
 
 > Document updated: 2026-05-18
-> Status: **DEPLOYED**
+> Status: **PR OPEN**
+
+---
+
+## Issue #316: ST Builder Untuk Print Pagination
+
+### Completed:
+- [x] **Issue Created**: Issue #316 tracks the `Untuk` section print pagination bug.
+- [x] **PR Created**: PR #317 opened from `issue/316-untuk-print-pagination` to `main`.
+- [x] **Root Cause Identified**: `Untuk` still used nested table rows, and global `tr { break-inside: avoid }` made the whole section move to page 2.
+- [x] **Untuk Layout Refactor**: Replaced nested table markup with grid/block layout so the section can paginate naturally.
+- [x] **Print CSS Updated**: `.untuk-section` and `.untuk-list` can break across pages; `.untuk-entry` avoids splitting each numbered item.
+- [x] **FOLU 2-Employee Scenario Targeted**: Fix targets the case where 2 FOLU employees leave blank space and push all `Untuk` items to the next page.
+
+### Key Files:
+- `frontend/src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx`
+- `frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx`
+
+### Validation:
+- [x] `npx eslint "src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx" "src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx"`
+- [x] `npx tsc --noEmit`
+- [x] `npm run build`
+
+### Pending:
+- [ ] Merge PR #317.
+- [ ] Deploy Issue #316 fix to production via SSH.
+- [ ] Re-test production FOLU print preview with 2 employees.
 
 ---
 

--- a/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx
+++ b/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx
@@ -219,38 +219,39 @@ export default function STBuilderPreview({
               </div>
 
               {/* === UNTUK === */}
-              <table style={{ width: "100%", borderCollapse: "collapse", marginBottom: "8px", marginLeft: "0", tableLayout: "fixed" }}>
-                <tbody>
-                  <tr>
-                    <td style={{ width: "110px", verticalAlign: "top", padding: "2px 0" }}>Untuk</td>
-                    <td style={{ width: "12px", verticalAlign: "top", padding: "2px 0" }}>:</td>
-                    <td style={{ verticalAlign: "top", padding: "2px 0" }}>
-                      <table style={{ width: "100%", borderCollapse: "collapse", tableLayout: "fixed" }}>
-                        <tbody>
-                          <tr>
-                            <td style={{ width: "24px", verticalAlign: "top", padding: "2px 0" }}>1.</td>
-                            <td style={{ verticalAlign: "top", padding: "2px 0", textAlign: "justify" }}>
-                              {buildUntukText()}
-                            </td>
-                          </tr>
-                          <tr>
-                            <td style={{ width: "24px", verticalAlign: "top", padding: "2px 0" }}>2.</td>
-                            <td style={{ verticalAlign: "top", padding: "2px 0", textAlign: "justify" }}>
-                              {buildBiayaText()}
-                            </td>
-                          </tr>
-                          <tr>
-                            <td style={{ width: "24px", verticalAlign: "top", padding: "2px 0" }}>3.</td>
-                            <td style={{ verticalAlign: "top", padding: "2px 0", textAlign: "justify" }}>
-                              Membuat laporan tertulis paling lambat 7 (tujuh) hari kerja setelah selesainya kegiatan tersebut.
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+              <div
+                className="field-section untuk-section"
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "110px 12px 1fr",
+                  columnGap: 0,
+                  marginBottom: "8px",
+                }}
+              >
+                <div style={{ padding: "2px 0" }}>Untuk</div>
+                <div style={{ padding: "2px 0" }}>:</div>
+                <div className="untuk-list" style={{ padding: "2px 0" }}>
+                  {[
+                    buildUntukText(),
+                    buildBiayaText(),
+                    "Membuat laporan tertulis paling lambat 7 (tujuh) hari kerja setelah selesainya kegiatan tersebut.",
+                  ].map((item, idx) => (
+                    <div
+                      className="untuk-entry"
+                      key={idx}
+                      style={{
+                        display: "grid",
+                        gridTemplateColumns: "24px 1fr",
+                        padding: "2px 0",
+                        breakInside: "avoid",
+                      }}
+                    >
+                      <div style={{ padding: "0" }}>{idx + 1}.</div>
+                      <div style={{ padding: "0", textAlign: "justify" }}>{item}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
 
               {/* === PENUTUP === */}
               {isFolu ? (

--- a/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx
+++ b/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx
@@ -638,8 +638,8 @@ export default function STBuilderPage() {
           .kop-surat { margin-left: 0 !important; margin-right: -0.95cm !important; margin-top: -0.25cm !important; margin-bottom: 2px !important; overflow: visible !important; }
           .kop-surat img { width: 18.8cm !important; height: auto !important; }
           .surat-content { margin-left: 1.25cm !important; width: calc(100% - 2.2cm) !important; margin-right: 0.95cm !important; }
-          .field-section, .kepada-section, .kepada-list { break-inside: auto !important; page-break-inside: auto !important; }
-          .employee-entry { break-inside: avoid !important; page-break-inside: avoid !important; }
+          .field-section, .kepada-section, .kepada-list, .untuk-section, .untuk-list { break-inside: auto !important; page-break-inside: auto !important; }
+          .employee-entry, .untuk-entry { break-inside: avoid !important; page-break-inside: avoid !important; }
           div[style*="page-break-inside"] { page-break-inside: avoid; }
           /* thead spacer: hidden, not needed with @page margin */
           thead.page-spacer td { height: 0; padding: 0; line-height: 0; font-size: 0; }


### PR DESCRIPTION
Closes #316

## Summary
- Refactor the `Untuk` section in ST Builder preview from table rows to a grid/block layout.
- Allow the `Untuk` section/list to paginate naturally like `Kepada`.
- Keep each numbered `Untuk` item from splitting in the middle during print.

## Validation
- `npx eslint src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx`
- `npx tsc --noEmit`
- `npm run build`