### PR TITLE
fix(surat-tugas): reserve bottom print margin (#318)

### DIFF
--- a/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx
+++ b/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx
@@ -618,8 +618,8 @@ export default function STBuilderPage() {
       <head>
         <title>ST.${stNumber}-${namaKegiatan.replace(/[/\\?%*:|"<>]/g, '-')}</title>
         <style>
-          @page { size: A4; margin: 3cm 1cm 1cm 1.55cm; }
-          @page :first { margin: 0.7cm 1cm 1cm 1.55cm; }
+          @page { size: A4; margin: 3cm 1cm 1.9cm 1.55cm; }
+          @page :first { margin: 0.7cm 1cm 1.9cm 1.55cm; }
           body { 
             font-family: 'Bookman Old Style', 'Georgia', serif; 
             font-size: 11pt; 


### PR DESCRIPTION
Closes #318

## Summary
- Remove the temporary BSrE footer test from the final diff.
- Keep the print bottom margin increased to `1.9cm` so the lower footer/signature area has breathing room.

## Validation
- `npx eslint src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx`
- `npx tsc --noEmit`
- `npm run build`