### PR TITLE
fix(production): proxy storage and employee ST link (#320)

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -81,6 +81,16 @@ http {
             proxy_read_timeout 300;
         }
 
+        location /storage/ {
+            proxy_pass http://rustfs:9000/bksda/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering off;
+            client_max_body_size 20M;
+        }
+
         location / {
             proxy_pass http://frontend:3000;
             proxy_http_version 1.1;

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -60,7 +60,7 @@ services:
       AWS_BUCKET: bksda
       AWS_ENDPOINT: http://rustfs:9000
       AWS_USE_PATH_STYLE_ENDPOINT: "true"
-      AWS_URL: https://storage.bksdakaltim.net
+      AWS_URL: https://bksdakaltim.net/storage
       SESSION_DRIVER: file
       CACHE_STORE: file
       QUEUE_CONNECTION: sync
@@ -87,8 +87,8 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
       args:
-        NEXT_PUBLIC_API_URL: https://api.bksdakaltim.net/api
-        NEXT_PUBLIC_STORAGE_URL: https://storage.bksdakaltim.net/bksda
+        NEXT_PUBLIC_API_URL: https://bksdakaltim.net/api
+        NEXT_PUBLIC_STORAGE_URL: https://bksdakaltim.net/storage
     container_name: bksda-frontend
     restart: always
 

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -82,6 +82,21 @@ const nextConfig: NextConfig = {
             },
             {
                 protocol: 'https',
+                hostname: 'bksdakaltim.net',
+                pathname: '/storage/**',
+            },
+            {
+                protocol: 'https',
+                hostname: 'www.bksdakaltim.net',
+                pathname: '/storage/**',
+            },
+            {
+                protocol: 'https',
+                hostname: 'storage.bksdakaltim.net',
+                pathname: '/**',
+            },
+            {
+                protocol: 'https',
                 hostname: 'iflvjdalryfosgbxvcon.supabase.co',
                 pathname: '/**',
             },

--- a/frontend/src/app/kepegawaian/_components/AssignmentLetterHistory.tsx
+++ b/frontend/src/app/kepegawaian/_components/AssignmentLetterHistory.tsx
@@ -22,6 +22,40 @@ interface AssignmentLetter {
   status: string;
 }
 
+interface PreviewEmployee {
+  id: string | number;
+  nama_lengkap: string;
+  name?: string;
+  nip: string;
+  jabatan?: string;
+  pivot?: { peran?: string };
+}
+
+interface PreviewItem {
+  id?: string;
+  text: string;
+}
+
+interface AssignmentLetterPreviewData {
+  id: string;
+  nomor_surat?: string | null;
+  kode_surat?: string | null;
+  menimbang?: PreviewItem[] | string | null;
+  dasar?: PreviewItem[] | string | null;
+  maksud_tujuan: string;
+  tempat_tujuan?: string | null;
+  tanggal_mulai: string;
+  tanggal_selesai: string;
+  tanggal_surat?: string | null;
+  sumber_dana?: string | null;
+  status: string;
+  keterangan?: string | null;
+  tembusan?: string[] | null;
+  nama_plh?: string | null;
+  employees?: PreviewEmployee[];
+  approver?: { name: string; nip?: string };
+}
+
 interface Meta {
     current_page: number;
     last_page: number;
@@ -35,7 +69,7 @@ interface ApiResponse {
 
 export function AssignmentLetterHistory({ employeeId }: { employeeId: string }) {
   const { canWrite } = useRole();
-  const [previewData, setPreviewData] = useState<any>(null);
+  const [previewData, setPreviewData] = useState<AssignmentLetterPreviewData | null>(null);
 
   const { data, isLoading } = useQuery({
     queryKey: ["employee-assignments", employeeId],
@@ -48,7 +82,7 @@ export function AssignmentLetterHistory({ employeeId }: { employeeId: string }) 
   const handleView = async (stId: string) => {
     try {
       const resp = await api.get(`/surat-tugas/${stId}`);
-      setPreviewData(resp.data.data || resp.data);
+      setPreviewData((resp.data.data || resp.data) as AssignmentLetterPreviewData);
     } catch {
       toast.error("Gagal memuat detail surat tugas.");
     }
@@ -67,7 +101,7 @@ export function AssignmentLetterHistory({ employeeId }: { employeeId: string }) 
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-bold text-zinc-900 dark:text-white">Riwayat Penugasan</h3>
         {canWrite && (
-          <Link href={`/surat-tugas/create?employee_id=${employeeId}`}>
+          <Link href={`/kepegawaian/surat-tugas/create?employee_id=${employeeId}`}>
               <Button size="sm" className="bg-blue-600 hover:bg-blue-500 text-white gap-2">
                   <Plus className="w-4 h-4" />
                   Buat Surat Tugas

--- a/frontend/src/app/kepegawaian/surat-tugas/create/page.tsx
+++ b/frontend/src/app/kepegawaian/surat-tugas/create/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
   FileText,
   Printer,
@@ -11,7 +11,7 @@ import {
   CheckCircle,
   X,
 } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { api } from "@/lib/api";
@@ -100,6 +100,8 @@ const SUMBER_DANA_OPTIONS: SumberDanaOption[] = [
 
 export default function STCreatePremiumPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const initialEmployeeId = searchParams.get("employee_id");
 
   // --- Form State ---
   const [stNumber, setStNumber] = useState("");
@@ -148,6 +150,22 @@ export default function STCreatePremiumPage() {
       (emp.nip?.toLowerCase() || "").includes(searchQuery.toLowerCase())
     )
     .slice(0, 50);
+
+  useEffect(() => {
+    if (!initialEmployeeId || selectedEmployees.length > 0 || allEmployees.length === 0) return;
+
+    const employee = allEmployees.find((emp: Employee) => String(emp.id) === initialEmployeeId);
+    if (!employee) return;
+
+    const normalized = {
+      ...employee,
+      nama_lengkap: employee.nama_lengkap || employee.name || "-",
+      jabatan: employee.jabatan || employee.position || "-",
+    };
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSelectedEmployees([normalized]);
+  }, [allEmployees, initialEmployeeId, selectedEmployees.length]);
 
   // Helper for "Untuk" text
   const buildUntukText = (): string => {


### PR DESCRIPTION
Closes #320

## Summary
- Route production storage URLs through the main domain: `https://bksdakaltim.net/storage`.
- Add nginx HTTPS `/storage/` proxy to RustFS bucket.
- Update backend `AWS_URL` and frontend storage build arg to avoid `storage.bksdakaltim.net` certificate mismatch.
- Fix employee detail history CTA from `/surat-tugas/create` to `/kepegawaian/surat-tugas/create`.
- Auto-select the employee when `employee_id` is present in the create route query.

## Validation
- `npx eslint src/app/kepegawaian/_components/AssignmentLetterHistory.tsx src/app/kepegawaian/surat-tugas/create/page.tsx next.config.ts`
- `npx tsc --noEmit`
- `npm run build`
- `php -l backend/app/Http/Controllers/Api/AuthController.php`
- `php -l backend/app/Modules/Kepegawaian/Controllers/EmployeeController.php`