### PR TITLE
fix(bmn): use employee full name in dashboard stats (#322)

### DIFF
--- a/backend/app/Modules/Bmn/Controllers/DashboardController.php
+++ b/backend/app/Modules/Bmn/Controllers/DashboardController.php
@@ -51,7 +51,7 @@ class DashboardController extends Controller
             ]);
 
         // Transaksi terakhir (peminjaman + pemeliharaan)
-        $recentLoans = AssetLoan::with('asset:id,nama_barang,kode_barang', 'borrower:id,nama')
+        $recentLoans = AssetLoan::with('asset:id,nama_barang,kode_barang', 'borrower:id,nama_lengkap')
             ->latest()
             ->limit(5)
             ->get()
@@ -59,7 +59,7 @@ class DashboardController extends Controller
                 'type' => 'loan',
                 'id' => $loan->id,
                 'asset' => $loan->asset?->nama_barang,
-                'borrower' => $loan->borrower?->nama,
+                'borrower' => $loan->borrower?->nama_lengkap,
                 'tanggal' => $loan->tanggal_pinjam?->toDateString(),
                 'status' => $loan->status,
             ]);


### PR DESCRIPTION
Closes #322

## Summary
- Fix BMN dashboard stats eager-load to select `kpg_employees.nama_lengkap` instead of the non-existent `nama` column.
- Return borrower names from `nama_lengkap` in recent loan activity.

## Validation
- `php -l backend/app/Modules/Bmn/Controllers/DashboardController.php`
- `php artisan tinker` dashboard controller status returned `200`
- `php artisan tinker` dashboard payload returned real local BMN stats (`total_asset` 1613)
- `npx eslint src/app/bmn/page.tsx --max-warnings=0`
- `npx tsc --noEmit`
- `npm run build`

Note: full frontend lint still has pre-existing unrelated errors/warnings in portal/kepegawaian files.