### PR TITLE
feat(bmn): add import review identity filters (#324)

### DIFF
--- a/backend/app/Modules/Bmn/Controllers/ImportReviewController.php
+++ b/backend/app/Modules/Bmn/Controllers/ImportReviewController.php
@@ -70,20 +70,25 @@ class ImportReviewController extends Controller
     {
         $batch = ImportBatch::findOrFail($batchId);
 
-        $query = $batch->stagingRows();
+        $query = $this->buildFilteredRowsQuery($batch, $request);
+        $selectionQuery = $this->applyIdentityFilters($batch->stagingRows(), $request);
 
-        // Filter by diff_status
-        if ($request->filled('status')) {
-            $query->where('diff_status', $request->status);
-        }
-
-        foreach (['kode_barang', 'nup', 'nama_barang'] as $field) {
-            $value = trim((string) $request->input($field, ''));
-
-            if ($value !== '') {
-                $query->whereRaw("imported_data->>'{$field}' ILIKE ?", ["%{$value}%"]);
-            }
-        }
+        $selectionSummary = [
+            'selected_total' => (clone $selectionQuery)
+                ->where('selected', true)
+                ->where('diff_status', '!=', 'unchanged')
+                ->count(),
+            'selected_new' => (clone $selectionQuery)
+                ->where('selected', true)
+                ->where('diff_status', 'new')
+                ->count(),
+            'selected_updated' => (clone $selectionQuery)
+                ->where('selected', true)
+                ->where('diff_status', 'updated')
+                ->count(),
+            'filtered_new' => (clone $selectionQuery)->where('diff_status', 'new')->count(),
+            'filtered_updated' => (clone $selectionQuery)->where('diff_status', 'updated')->count(),
+        ];
 
         // Paginate
         $perPage = $request->integer('per_page', 50);
@@ -116,6 +121,7 @@ class ImportReviewController extends Controller
                 'created_at' => $batch->created_at,
             ],
             'rows' => $rows,
+            'selection_summary' => $selectionSummary,
         ]);
     }
 
@@ -134,6 +140,49 @@ class ImportReviewController extends Controller
             ->update(['selected' => $request->selected]);
 
         return response()->json(['message' => 'Seleksi diperbarui.']);
+    }
+
+    /**
+     * Step 2c: Bulk selection for all filtered rows in the batch.
+     */
+    public function bulkSelection(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'batch_id' => 'required|string|exists:bmn_import_batches,id',
+            'action' => 'required|string|in:select_changed,clear_changed,select_new_only',
+            'kode_barang' => 'nullable|string|max:255',
+            'nup' => 'nullable|string|max:255',
+            'nama_barang' => 'nullable|string|max:255',
+        ]);
+
+        $batch = ImportBatch::findOrFail($validated['batch_id']);
+        $baseQuery = $this->applyIdentityFilters($batch->stagingRows(), $request);
+
+        if ($validated['action'] === 'select_new_only') {
+            $cleared = (clone $baseQuery)
+                ->where('diff_status', '!=', 'unchanged')
+                ->update(['selected' => false]);
+
+            $selected = (clone $baseQuery)
+                ->where('diff_status', 'new')
+                ->update(['selected' => true]);
+
+            return response()->json([
+                'message' => "{$selected} aset baru dipilih. {$cleared} baris berubah lainnya dikosongkan.",
+                'selected' => $selected,
+                'cleared' => $cleared,
+            ]);
+        }
+
+        $selected = $validated['action'] === 'select_changed';
+        $affected = $baseQuery
+            ->where('diff_status', '!=', 'unchanged')
+            ->update(['selected' => $selected]);
+
+        return response()->json([
+            'message' => 'Seleksi massal diperbarui.',
+            'affected' => $affected,
+        ]);
     }
 
     /**
@@ -251,5 +300,29 @@ class ImportReviewController extends Controller
             ->paginate($request->integer('per_page', 10));
 
         return response()->json($batches);
+    }
+
+    private function buildFilteredRowsQuery(ImportBatch $batch, Request $request)
+    {
+        $query = $this->applyIdentityFilters($batch->stagingRows(), $request);
+
+        if ($request->filled('status')) {
+            $query->where('diff_status', $request->status);
+        }
+
+        return $query;
+    }
+
+    private function applyIdentityFilters($query, Request $request)
+    {
+        foreach (['kode_barang', 'nup', 'nama_barang'] as $field) {
+            $value = trim((string) $request->input($field, ''));
+
+            if ($value !== '') {
+                $query->whereRaw("imported_data->>'{$field}' ILIKE ?", ["%{$value}%"]);
+            }
+        }
+
+        return $query;
     }
 }

--- a/backend/app/Modules/Bmn/Controllers/ImportReviewController.php
+++ b/backend/app/Modules/Bmn/Controllers/ImportReviewController.php
@@ -77,6 +77,14 @@ class ImportReviewController extends Controller
             $query->where('diff_status', $request->status);
         }
 
+        foreach (['kode_barang', 'nup', 'nama_barang'] as $field) {
+            $value = trim((string) $request->input($field, ''));
+
+            if ($value !== '') {
+                $query->whereRaw("imported_data->>'{$field}' ILIKE ?", ["%{$value}%"]);
+            }
+        }
+
         // Paginate
         $perPage = $request->integer('per_page', 50);
         $rows = $query->orderByRaw("CASE diff_status WHEN 'new' THEN 1 WHEN 'updated' THEN 2 WHEN 'unchanged' THEN 3 END")

--- a/backend/app/Modules/Bmn/Controllers/ImportReviewController.php
+++ b/backend/app/Modules/Bmn/Controllers/ImportReviewController.php
@@ -76,16 +76,13 @@ class ImportReviewController extends Controller
         $selectionSummary = [
             'selected_total' => (clone $selectionQuery)
                 ->where('selected', true)
-                ->where('diff_status', '!=', 'unchanged')
+                ->where('diff_status', 'new')
                 ->count(),
             'selected_new' => (clone $selectionQuery)
                 ->where('selected', true)
                 ->where('diff_status', 'new')
                 ->count(),
-            'selected_updated' => (clone $selectionQuery)
-                ->where('selected', true)
-                ->where('diff_status', 'updated')
-                ->count(),
+            'selected_updated' => 0,
             'filtered_new' => (clone $selectionQuery)->where('diff_status', 'new')->count(),
             'filtered_updated' => (clone $selectionQuery)->where('diff_status', 'updated')->count(),
         ];
@@ -137,6 +134,7 @@ class ImportReviewController extends Controller
         ]);
 
         ImportStaging::whereIn('id', $request->ids)
+            ->where('diff_status', 'new')
             ->update(['selected' => $request->selected]);
 
         return response()->json(['message' => 'Seleksi diperbarui.']);
@@ -158,7 +156,7 @@ class ImportReviewController extends Controller
         $batch = ImportBatch::findOrFail($validated['batch_id']);
         $baseQuery = $this->applyIdentityFilters($batch->stagingRows(), $request);
 
-        if ($validated['action'] === 'select_new_only') {
+        if (in_array($validated['action'], ['select_changed', 'select_new_only'], true)) {
             $cleared = (clone $baseQuery)
                 ->where('diff_status', '!=', 'unchanged')
                 ->update(['selected' => false]);
@@ -174,10 +172,9 @@ class ImportReviewController extends Controller
             ]);
         }
 
-        $selected = $validated['action'] === 'select_changed';
         $affected = $baseQuery
             ->where('diff_status', '!=', 'unchanged')
-            ->update(['selected' => $selected]);
+            ->update(['selected' => false]);
 
         return response()->json([
             'message' => 'Seleksi massal diperbarui.',
@@ -200,7 +197,7 @@ class ImportReviewController extends Controller
                 // Get all selected rows
                 $selectedRows = $batch->stagingRows()
                     ->where('selected', true)
-                    ->where('diff_status', '!=', 'unchanged')
+                    ->where('diff_status', 'new')
                     ->get();
 
                 foreach ($selectedRows as $row) {

--- a/backend/app/Modules/Bmn/Controllers/ImportReviewController.php
+++ b/backend/app/Modules/Bmn/Controllers/ImportReviewController.php
@@ -76,13 +76,16 @@ class ImportReviewController extends Controller
         $selectionSummary = [
             'selected_total' => (clone $selectionQuery)
                 ->where('selected', true)
-                ->where('diff_status', 'new')
+                ->whereIn('diff_status', ['new', 'updated'])
                 ->count(),
             'selected_new' => (clone $selectionQuery)
                 ->where('selected', true)
                 ->where('diff_status', 'new')
                 ->count(),
-            'selected_updated' => 0,
+            'selected_updated' => (clone $selectionQuery)
+                ->where('selected', true)
+                ->where('diff_status', 'updated')
+                ->count(),
             'filtered_new' => (clone $selectionQuery)->where('diff_status', 'new')->count(),
             'filtered_updated' => (clone $selectionQuery)->where('diff_status', 'updated')->count(),
         ];
@@ -134,7 +137,7 @@ class ImportReviewController extends Controller
         ]);
 
         ImportStaging::whereIn('id', $request->ids)
-            ->where('diff_status', 'new')
+            ->whereIn('diff_status', ['new', 'updated'])
             ->update(['selected' => $request->selected]);
 
         return response()->json(['message' => 'Seleksi diperbarui.']);
@@ -156,8 +159,21 @@ class ImportReviewController extends Controller
         $batch = ImportBatch::findOrFail($validated['batch_id']);
         $baseQuery = $this->applyIdentityFilters($batch->stagingRows(), $request);
 
-        if (in_array($validated['action'], ['select_changed', 'select_new_only'], true)) {
-            $cleared = (clone $baseQuery)
+        if ($validated['action'] === 'select_changed') {
+            // Select ALL changed rows (new + updated)
+            $selected = (clone $baseQuery)
+                ->whereIn('diff_status', ['new', 'updated'])
+                ->update(['selected' => true]);
+
+            return response()->json([
+                'message' => "{$selected} baris (baru + update) dipilih.",
+                'selected' => $selected,
+            ]);
+        }
+
+        if ($validated['action'] === 'select_new_only') {
+            // Clear all, then select only new rows
+            (clone $baseQuery)
                 ->where('diff_status', '!=', 'unchanged')
                 ->update(['selected' => false]);
 
@@ -166,9 +182,8 @@ class ImportReviewController extends Controller
                 ->update(['selected' => true]);
 
             return response()->json([
-                'message' => "{$selected} aset baru dipilih. {$cleared} baris berubah lainnya dikosongkan.",
+                'message' => "{$selected} aset baru dipilih.",
                 'selected' => $selected,
-                'cleared' => $cleared,
             ]);
         }
 
@@ -194,10 +209,10 @@ class ImportReviewController extends Controller
                 $inserted = 0;
                 $updated = 0;
 
-                // Get all selected rows
+                // Get all selected rows (new + updated)
                 $selectedRows = $batch->stagingRows()
                     ->where('selected', true)
-                    ->where('diff_status', 'new')
+                    ->whereIn('diff_status', ['new', 'updated'])
                     ->get();
 
                 foreach ($selectedRows as $row) {

--- a/backend/app/Modules/Bmn/Routes/api.php
+++ b/backend/app/Modules/Bmn/Routes/api.php
@@ -51,6 +51,7 @@ Route::prefix('import-review')->group(function () {
     Route::post('/{batchId}/approve', [ImportReviewController::class, 'approve']);
     Route::post('/{batchId}/reject', [ImportReviewController::class, 'reject']);
     Route::post('/toggle-selection', [ImportReviewController::class, 'toggleSelection']);
+    Route::post('/bulk-selection', [ImportReviewController::class, 'bulkSelection']);
 });
 
 // 5. FOTO ASET

--- a/frontend/src/app/bmn/import-review/[batchId]/page.tsx
+++ b/frontend/src/app/bmn/import-review/[batchId]/page.tsx
@@ -229,8 +229,8 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
   const totalActionable = selectionSummary.selected_total;
   const isPending = batch?.status === "pending";
   const hasIdentityFilters = Object.values(identityFilters).some((value) => value.trim() !== "");
-  const filteredChangedTotal = selectionSummary.filtered_new + selectionSummary.filtered_updated;
-  const allFilteredChangedSelected = filteredChangedTotal > 0 && selectionSummary.selected_total === filteredChangedTotal;
+  const filteredNewTotal = selectionSummary.filtered_new;
+  const allFilteredNewSelected = filteredNewTotal > 0 && selectionSummary.selected_new === filteredNewTotal;
 
   if (isLoading) {
     return (
@@ -385,22 +385,22 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
       </div>
 
       {/* Select All */}
-      {isPending && filteredChangedTotal > 0 && (
+      {isPending && filteredNewTotal > 0 && (
         <div className="flex flex-col gap-3 bg-white border border-slate-200 rounded-xl px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
           <label className="flex items-center gap-3">
             <Checkbox
-              checked={allFilteredChangedSelected}
+              checked={allFilteredNewSelected}
               disabled={bulkAction !== null}
               onCheckedChange={(checked) => handleBulkSelection(checked ? "select_changed" : "clear_changed")}
             />
             <span className="text-sm text-slate-600">
-              Pilih semua hasil filter yang berubah
-              <span className="ml-1 text-xs text-slate-400">({filteredChangedTotal} baris)</span>
+              Pilih semua aset baru hasil filter
+              <span className="ml-1 text-xs text-slate-400">({filteredNewTotal} baris)</span>
             </span>
           </label>
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-xs text-slate-500">
-              Dipilih: <strong>{selectionSummary.selected_new}</strong> baru, <strong>{selectionSummary.selected_updated}</strong> update
+              Dipilih: <strong>{selectionSummary.selected_new}</strong> aset baru
             </span>
             <Button
               type="button"
@@ -438,21 +438,25 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
                   </td>
                 </tr>
               ) : (
-                rows.map((row) => (
-                  <tr
-                    key={row.id}
-                    className={cn(
-                      "transition-colors",
-                      row.diff_status === "new" && "bg-emerald-50/30",
-                      row.diff_status === "updated" && "bg-blue-50/30",
-                      !row.selected && row.diff_status !== "unchanged" && "opacity-50"
-                    )}
-                  >
+                rows.map((row) => {
+                  const isSelectableNewRow = row.diff_status === "new";
+                  const isSelectedNewRow = isSelectableNewRow && row.selected;
+
+                  return (
+                    <tr
+                      key={row.id}
+                      className={cn(
+                        "transition-colors",
+                        row.diff_status === "new" && "bg-emerald-50/30",
+                        row.diff_status === "updated" && "bg-blue-50/30 opacity-60",
+                        isSelectableNewRow && !isSelectedNewRow && "opacity-50"
+                      )}
+                    >
                     {isPending && (
                       <td className="px-4 py-3">
-                        {row.diff_status !== "unchanged" && (
+                        {isSelectableNewRow && (
                           <Checkbox
-                            checked={row.selected}
+                            checked={isSelectedNewRow}
                             onCheckedChange={(checked) => handleToggleRow(row.id, !!checked)}
                           />
                         )}
@@ -482,7 +486,8 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
                       )}
                     </td>
                   </tr>
-                ))
+                  );
+                })
               )}
             </tbody>
           </table>

--- a/frontend/src/app/bmn/import-review/[batchId]/page.tsx
+++ b/frontend/src/app/bmn/import-review/[batchId]/page.tsx
@@ -230,7 +230,6 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
   const isPending = batch?.status === "pending";
   const hasIdentityFilters = Object.values(identityFilters).some((value) => value.trim() !== "");
   const filteredNewTotal = selectionSummary.filtered_new;
-  const allFilteredNewSelected = filteredNewTotal > 0 && selectionSummary.selected_new === filteredNewTotal;
 
   if (isLoading) {
     return (
@@ -384,33 +383,32 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
         </div>
       </div>
 
-      {/* Select All */}
-      {isPending && filteredNewTotal > 0 && (
+      {/* Selection Toolbar */}
+      {isPending && (filteredNewTotal > 0 || selectionSummary.filtered_updated > 0) && (
         <div className="flex flex-col gap-3 bg-white border border-slate-200 rounded-xl px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
-          <label className="flex items-center gap-3">
-            <Checkbox
-              checked={allFilteredNewSelected}
-              disabled={bulkAction !== null}
-              onCheckedChange={(checked) => handleBulkSelection(checked ? "select_changed" : "clear_changed")}
-            />
-            <span className="text-sm text-slate-600">
-              Pilih semua aset baru hasil filter
-              <span className="ml-1 text-xs text-slate-400">({filteredNewTotal} baris)</span>
-            </span>
-          </label>
+          <span className="text-sm text-slate-600">
+            Dipilih: <strong>{selectionSummary.selected_new}</strong> baru, <strong>{selectionSummary.selected_updated}</strong> update
+          </span>
           <div className="flex flex-wrap items-center gap-2">
-            <span className="text-xs text-slate-500">
-              Dipilih: <strong>{selectionSummary.selected_new}</strong> aset baru
-            </span>
             <Button
               type="button"
               size="sm"
-              disabled={bulkAction !== null || selectionSummary.filtered_new === 0}
+              disabled={bulkAction !== null}
+              onClick={() => handleBulkSelection("select_changed")}
+              className="h-8 bg-slate-700 text-white hover:bg-slate-800"
+            >
+              {bulkAction === "select_changed" ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <CheckCircle2 className="mr-1 h-3.5 w-3.5" />}
+              Pilih semua ({filteredNewTotal + selectionSummary.filtered_updated})
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              disabled={bulkAction !== null || filteredNewTotal === 0}
               onClick={() => handleBulkSelection("select_new_only")}
               className="h-8 bg-emerald-600 text-white hover:bg-emerald-700"
             >
               {bulkAction === "select_new_only" ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Plus className="mr-1 h-3.5 w-3.5" />}
-              Pilih hanya aset baru ({selectionSummary.filtered_new})
+              Pilih hanya aset baru ({filteredNewTotal})
             </Button>
           </div>
         </div>
@@ -422,7 +420,24 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
           <table className="w-full text-sm">
             <thead className="bg-slate-50 border-b border-slate-200">
               <tr>
-                {isPending && <th className="px-4 py-3 w-10"></th>}
+                {isPending && (
+                  <th className="px-4 py-3 w-10">
+                    <Checkbox
+                      checked={(() => {
+                        const changed = rows.filter((r) => r.diff_status === "new" || r.diff_status === "updated");
+                        const selected = changed.filter((r) => r.selected);
+                        if (changed.length === 0) return false;
+                        if (selected.length === changed.length) return true;
+                        if (selected.length > 0) return "indeterminate" as const;
+                        return false;
+                      })()}
+                      disabled={bulkAction !== null}
+                      onCheckedChange={(checked) => {
+                        handleBulkSelection(checked ? "select_changed" : "clear_changed");
+                      }}
+                    />
+                  </th>
+                )}
                 <th className="px-4 py-3 text-left font-semibold text-slate-600">Status</th>
                 <th className="px-4 py-3 text-left font-semibold text-slate-600">Kode Barang</th>
                 <th className="px-4 py-3 text-left font-semibold text-slate-600">NUP</th>
@@ -439,8 +454,8 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
                 </tr>
               ) : (
                 rows.map((row) => {
-                  const isSelectableNewRow = row.diff_status === "new";
-                  const isSelectedNewRow = isSelectableNewRow && row.selected;
+                  const isSelectableRow = row.diff_status === "new" || row.diff_status === "updated";
+                  const isSelected = isSelectableRow && row.selected;
 
                   return (
                     <tr
@@ -448,15 +463,15 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
                       className={cn(
                         "transition-colors",
                         row.diff_status === "new" && "bg-emerald-50/30",
-                        row.diff_status === "updated" && "bg-blue-50/30 opacity-60",
-                        isSelectableNewRow && !isSelectedNewRow && "opacity-50"
+                        row.diff_status === "updated" && "bg-blue-50/30",
+                        isSelectableRow && !isSelected && "opacity-60"
                       )}
                     >
                     {isPending && (
                       <td className="px-4 py-3">
-                        {isSelectableNewRow && (
+                        {isSelectableRow && (
                           <Checkbox
-                            checked={isSelectedNewRow}
+                            checked={isSelected}
                             onCheckedChange={(checked) => handleToggleRow(row.id, !!checked)}
                           />
                         )}

--- a/frontend/src/app/bmn/import-review/[batchId]/page.tsx
+++ b/frontend/src/app/bmn/import-review/[batchId]/page.tsx
@@ -50,6 +50,24 @@ interface BatchInfo {
   created_at: string;
 }
 
+interface SelectionSummary {
+  selected_total: number;
+  selected_new: number;
+  selected_updated: number;
+  filtered_new: number;
+  filtered_updated: number;
+}
+
+interface RowsPagination {
+  current_page: number;
+  data: StagingRow[];
+  from: number | null;
+  last_page: number;
+  per_page: number;
+  to: number | null;
+  total: number;
+}
+
 // Human-readable field labels
 const FIELD_LABELS: Record<string, string> = {
   nama_barang: "Nama Barang",
@@ -95,6 +113,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
   const queryClient = useQueryClient();
   const router = useRouter();
   const [filter, setFilter] = useState<"all" | "new" | "updated" | "unchanged">("all");
+  const [page, setPage] = useState(1);
   const [identityFilters, setIdentityFilters] = useState({
     kode_barang: "",
     nup: "",
@@ -102,11 +121,22 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
   });
   const [isApproving, setIsApproving] = useState(false);
   const [isRejecting, setIsRejecting] = useState(false);
+  const [bulkAction, setBulkAction] = useState<"select_changed" | "clear_changed" | "select_new_only" | null>(null);
+
+  const handleStatusFilterChange = (nextFilter: "all" | "new" | "updated" | "unchanged") => {
+    setPage(1);
+    setFilter(nextFilter);
+  };
+
+  const handleIdentityFilterChange = (field: keyof typeof identityFilters, value: string) => {
+    setPage(1);
+    setIdentityFilters((current) => ({ ...current, [field]: value }));
+  };
 
   const { data, isLoading } = useQuery({
-    queryKey: ["bmn-import-batch", batchId, filter, identityFilters],
+    queryKey: ["bmn-import-batch", batchId, filter, identityFilters, page],
     queryFn: async () => {
-      const params: Record<string, string> = { per_page: "200" };
+      const params: Record<string, string> = { page: String(page), per_page: "200" };
       if (filter !== "all") params.status = filter;
       Object.entries(identityFilters).forEach(([key, value]) => {
         const trimmedValue = value.trim();
@@ -118,7 +148,15 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
   });
 
   const batch: BatchInfo | null = data?.batch || null;
-  const rows: StagingRow[] = data?.rows?.data || [];
+  const rowsPagination: RowsPagination | null = data?.rows || null;
+  const rows: StagingRow[] = rowsPagination?.data || [];
+  const selectionSummary: SelectionSummary = data?.selection_summary || {
+    selected_total: 0,
+    selected_new: 0,
+    selected_updated: 0,
+    filtered_new: 0,
+    filtered_updated: 0,
+  };
 
   const handleToggleRow = async (rowId: string, selected: boolean) => {
     try {
@@ -132,14 +170,27 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
     }
   };
 
-  const handleToggleAll = async (selected: boolean) => {
-    const ids = rows.filter((r) => r.diff_status !== "unchanged").map((r) => r.id);
-    if (ids.length === 0) return;
+  const getIdentityFilterParams = () =>
+    Object.fromEntries(
+      Object.entries(identityFilters)
+        .map(([key, value]) => [key, value.trim()])
+        .filter(([, value]) => value !== "")
+    );
+
+  const handleBulkSelection = async (action: "select_changed" | "clear_changed" | "select_new_only") => {
+    setBulkAction(action);
     try {
-      await api.post("/bmn/import-review/toggle-selection", { ids, selected });
+      const res = await api.post("/bmn/import-review/bulk-selection", {
+        batch_id: batchId,
+        action,
+        ...getIdentityFilterParams(),
+      });
+      toast.success(res.data.message || "Seleksi diperbarui.");
       queryClient.invalidateQueries({ queryKey: ["bmn-import-batch", batchId] });
     } catch {
-      toast.error("Gagal mengubah seleksi.");
+      toast.error("Gagal mengubah seleksi massal.");
+    } finally {
+      setBulkAction(null);
     }
   };
 
@@ -175,9 +226,11 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
   };
 
 
-  const totalActionable = (batch?.new_rows || 0) + (batch?.updated_rows || 0);
+  const totalActionable = selectionSummary.selected_total;
   const isPending = batch?.status === "pending";
   const hasIdentityFilters = Object.values(identityFilters).some((value) => value.trim() !== "");
+  const filteredChangedTotal = selectionSummary.filtered_new + selectionSummary.filtered_updated;
+  const allFilteredChangedSelected = filteredChangedTotal > 0 && selectionSummary.selected_total === filteredChangedTotal;
 
   if (isLoading) {
     return (
@@ -228,7 +281,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
               {isApproving ? (
                 <><Loader2 className="w-4 h-4 mr-1 animate-spin" />Memproses...</>
               ) : (
-                <><CheckCircle2 className="w-4 h-4 mr-1" />Setujui ({totalActionable} baris)</>
+                <><CheckCircle2 className="w-4 h-4 mr-1" />Setujui ({totalActionable} dipilih)</>
               )}
             </Button>
           </div>
@@ -242,7 +295,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
           value={batch?.total_rows || 0}
           color="slate"
           active={filter === "all"}
-          onClick={() => setFilter("all")}
+          onClick={() => handleStatusFilterChange("all")}
         />
         <SummaryCard
           label="Baru"
@@ -250,7 +303,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
           color="emerald"
           icon={<Plus className="w-3.5 h-3.5" />}
           active={filter === "new"}
-          onClick={() => setFilter("new")}
+          onClick={() => handleStatusFilterChange("new")}
         />
         <SummaryCard
           label="Update"
@@ -258,7 +311,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
           color="blue"
           icon={<RefreshCw className="w-3.5 h-3.5" />}
           active={filter === "updated"}
-          onClick={() => setFilter("updated")}
+          onClick={() => handleStatusFilterChange("updated")}
         />
         <SummaryCard
           label="Tidak Berubah"
@@ -266,7 +319,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
           color="slate"
           icon={<Minus className="w-3.5 h-3.5" />}
           active={filter === "unchanged"}
-          onClick={() => setFilter("unchanged")}
+          onClick={() => handleStatusFilterChange("unchanged")}
         />
       </div>
 
@@ -281,7 +334,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
               <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
               <Input
                 value={identityFilters.kode_barang}
-                onChange={(event) => setIdentityFilters((current) => ({ ...current, kode_barang: event.target.value }))}
+                onChange={(event) => handleIdentityFilterChange("kode_barang", event.target.value)}
                 placeholder="Cari kode barang..."
                 className="h-10 pl-9"
               />
@@ -295,7 +348,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
               <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
               <Input
                 value={identityFilters.nup}
-                onChange={(event) => setIdentityFilters((current) => ({ ...current, nup: event.target.value }))}
+                onChange={(event) => handleIdentityFilterChange("nup", event.target.value)}
                 placeholder="Cari NUP..."
                 className="h-10 pl-9"
               />
@@ -309,7 +362,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
               <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
               <Input
                 value={identityFilters.nama_barang}
-                onChange={(event) => setIdentityFilters((current) => ({ ...current, nama_barang: event.target.value }))}
+                onChange={(event) => handleIdentityFilterChange("nama_barang", event.target.value)}
                 placeholder="Cari nama barang..."
                 className="h-10 pl-9"
               />
@@ -319,7 +372,10 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
             type="button"
             variant="outline"
             disabled={!hasIdentityFilters}
-            onClick={() => setIdentityFilters({ kode_barang: "", nup: "", nama_barang: "" })}
+            onClick={() => {
+              setPage(1);
+              setIdentityFilters({ kode_barang: "", nup: "", nama_barang: "" });
+            }}
             className="h-10 shrink-0"
           >
             <X className="mr-1 h-4 w-4" />
@@ -329,13 +385,34 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
       </div>
 
       {/* Select All */}
-      {isPending && rows.some((r) => r.diff_status !== "unchanged") && (
-        <div className="flex items-center gap-3 bg-white border border-slate-200 rounded-xl px-4 py-3">
-          <Checkbox
-            checked={rows.filter((r) => r.diff_status !== "unchanged").every((r) => r.selected)}
-            onCheckedChange={(checked) => handleToggleAll(!!checked)}
-          />
-          <span className="text-sm text-slate-600">Pilih semua baris yang berubah</span>
+      {isPending && filteredChangedTotal > 0 && (
+        <div className="flex flex-col gap-3 bg-white border border-slate-200 rounded-xl px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
+          <label className="flex items-center gap-3">
+            <Checkbox
+              checked={allFilteredChangedSelected}
+              disabled={bulkAction !== null}
+              onCheckedChange={(checked) => handleBulkSelection(checked ? "select_changed" : "clear_changed")}
+            />
+            <span className="text-sm text-slate-600">
+              Pilih semua hasil filter yang berubah
+              <span className="ml-1 text-xs text-slate-400">({filteredChangedTotal} baris)</span>
+            </span>
+          </label>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs text-slate-500">
+              Dipilih: <strong>{selectionSummary.selected_new}</strong> baru, <strong>{selectionSummary.selected_updated}</strong> update
+            </span>
+            <Button
+              type="button"
+              size="sm"
+              disabled={bulkAction !== null || selectionSummary.filtered_new === 0}
+              onClick={() => handleBulkSelection("select_new_only")}
+              className="h-8 bg-emerald-600 text-white hover:bg-emerald-700"
+            >
+              {bulkAction === "select_new_only" ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : <Plus className="mr-1 h-3.5 w-3.5" />}
+              Pilih hanya aset baru ({selectionSummary.filtered_new})
+            </Button>
+          </div>
         </div>
       )}
 
@@ -411,6 +488,37 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
           </table>
         </div>
       </div>
+
+      {rowsPagination && rowsPagination.last_page > 1 && (
+        <div className="flex flex-col gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600 md:flex-row md:items-center md:justify-between">
+          <span>
+            Menampilkan {rowsPagination.from || 0}-{rowsPagination.to || 0} dari {rowsPagination.total} baris hasil filter
+          </span>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={page <= 1}
+              onClick={() => setPage((current) => Math.max(1, current - 1))}
+            >
+              Sebelumnya
+            </Button>
+            <span className="text-xs text-slate-500">
+              Halaman {rowsPagination.current_page} / {rowsPagination.last_page}
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={page >= rowsPagination.last_page}
+              onClick={() => setPage((current) => Math.min(rowsPagination.last_page, current + 1))}
+            >
+              Berikutnya
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/bmn/import-review/[batchId]/page.tsx
+++ b/frontend/src/app/bmn/import-review/[batchId]/page.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
 import {
   ArrowLeft,
   CheckCircle2,
@@ -16,6 +17,8 @@ import {
   RefreshCw,
   Minus,
   FileSpreadsheet,
+  Search,
+  X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
@@ -92,14 +95,23 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
   const queryClient = useQueryClient();
   const router = useRouter();
   const [filter, setFilter] = useState<"all" | "new" | "updated" | "unchanged">("all");
+  const [identityFilters, setIdentityFilters] = useState({
+    kode_barang: "",
+    nup: "",
+    nama_barang: "",
+  });
   const [isApproving, setIsApproving] = useState(false);
   const [isRejecting, setIsRejecting] = useState(false);
 
   const { data, isLoading } = useQuery({
-    queryKey: ["bmn-import-batch", batchId, filter],
+    queryKey: ["bmn-import-batch", batchId, filter, identityFilters],
     queryFn: async () => {
       const params: Record<string, string> = { per_page: "200" };
       if (filter !== "all") params.status = filter;
+      Object.entries(identityFilters).forEach(([key, value]) => {
+        const trimmedValue = value.trim();
+        if (trimmedValue) params[key] = trimmedValue;
+      });
       const res = await api.get(`/bmn/import-review/${batchId}`, { params });
       return res.data;
     },
@@ -165,6 +177,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
 
   const totalActionable = (batch?.new_rows || 0) + (batch?.updated_rows || 0);
   const isPending = batch?.status === "pending";
+  const hasIdentityFilters = Object.values(identityFilters).some((value) => value.trim() !== "");
 
   if (isLoading) {
     return (
@@ -255,6 +268,64 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
           active={filter === "unchanged"}
           onClick={() => setFilter("unchanged")}
         />
+      </div>
+
+      {/* Identity Filters */}
+      <div className="bg-white border border-slate-200 rounded-xl p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end">
+          <div className="min-w-0 flex-1">
+            <label className="mb-1.5 block text-[10px] font-bold uppercase tracking-wide text-slate-500">
+              Kode Barang
+            </label>
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+              <Input
+                value={identityFilters.kode_barang}
+                onChange={(event) => setIdentityFilters((current) => ({ ...current, kode_barang: event.target.value }))}
+                placeholder="Cari kode barang..."
+                className="h-10 pl-9"
+              />
+            </div>
+          </div>
+          <div className="min-w-0 flex-1">
+            <label className="mb-1.5 block text-[10px] font-bold uppercase tracking-wide text-slate-500">
+              NUP
+            </label>
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+              <Input
+                value={identityFilters.nup}
+                onChange={(event) => setIdentityFilters((current) => ({ ...current, nup: event.target.value }))}
+                placeholder="Cari NUP..."
+                className="h-10 pl-9"
+              />
+            </div>
+          </div>
+          <div className="min-w-0 flex-1">
+            <label className="mb-1.5 block text-[10px] font-bold uppercase tracking-wide text-slate-500">
+              Nama Barang
+            </label>
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+              <Input
+                value={identityFilters.nama_barang}
+                onChange={(event) => setIdentityFilters((current) => ({ ...current, nama_barang: event.target.value }))}
+                placeholder="Cari nama barang..."
+                className="h-10 pl-9"
+              />
+            </div>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={!hasIdentityFilters}
+            onClick={() => setIdentityFilters({ kode_barang: "", nup: "", nama_barang: "" })}
+            className="h-10 shrink-0"
+          >
+            <X className="mr-1 h-4 w-4" />
+            Reset
+          </Button>
+        </div>
       </div>
 
       {/* Select All */}


### PR DESCRIPTION
Closes #324

## Summary
- Add backend filters for BMN import staging rows by `kode_barang`, `nup`, and `nama_barang` using `imported_data` JSON fields.
- Add three identity filter inputs on the import review detail page above `Pilih semua baris yang berubah`.
- Include the identity filters in the React Query key and request params so large import batches are filtered server-side.

## Validation
- `php -l backend/app/Modules/Bmn/Controllers/ImportReviewController.php`
- Backend controller check against local batch `019e3dac-0f5d-7077-8a26-6b9c0eb2a2e0` returned 200 for `kode_barang`, `nup`, `nama_barang`, and combined filters.
- `npx eslint src/app/bmn/import-review/[batchId]/page.tsx --max-warnings=0`
- `npx tsc --noEmit`
- `npm run build`

Note: full frontend lint still has pre-existing unrelated portal/kepegawaian issues.