### PR TITLE
fix(bmn): disposal page Invalid Date (#326)

### DIFF
--- a/backend/app/Modules/Bmn/Resources/AssetResource.php
+++ b/backend/app/Modules/Bmn/Resources/AssetResource.php
@@ -136,6 +136,7 @@ class AssetResource extends JsonResource
             ),
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),
+            'deleted_at' => $this->deleted_at?->toIso8601String(),
         ];
     }
 }

--- a/frontend/src/app/bmn/disposal/page.tsx
+++ b/frontend/src/app/bmn/disposal/page.tsx
@@ -203,7 +203,7 @@ export default function BmnDisposalPage() {
                       />
                     </td>
                     <td className="px-4 py-3">
-                      <p className="text-xs font-semibold text-zinc-800 dark:text-zinc-200">{new Date(asset.deleted_at).toLocaleDateString("id-ID")}</p>
+                      <p className="text-xs font-semibold text-zinc-800 dark:text-zinc-200">{asset.deleted_at ? new Date(asset.deleted_at).toLocaleDateString("id-ID", { day: "numeric", month: "short", year: "numeric" }) : "—"}</p>
                     </td>
                     <td className="px-4 py-3">
                       <p className="text-sm font-semibold text-zinc-800 dark:text-zinc-200 max-w-[250px] truncate">{asset.nama_barang}</p>


### PR DESCRIPTION
Closes #326

**Root cause**: deleted_at was not included in AssetResource.php, so the frontend received undefined and 
ew Date(undefined) produced 'Invalid Date'.

**Fix**:
- Backend: Added deleted_at to AssetResource (ISO 8601 format)
- Frontend: Added null safety check with fallback dash