### PR TITLE
fix(bmn): clean up files from rustfs on force delete

### DIFF
--- a/backend/app/Modules/Bmn/Controllers/AssetController.php
+++ b/backend/app/Modules/Bmn/Controllers/AssetController.php
@@ -161,8 +161,12 @@ class AssetController extends Controller
     {
         $request->validate(['ids' => 'required|array|min:1', 'ids.*' => 'string']);
 
-        $count = Asset::onlyTrashed()->whereIn('id', $request->ids)->count();
-        Asset::onlyTrashed()->whereIn('id', $request->ids)->forceDelete();
+        $assets = Asset::onlyTrashed()->whereIn('id', $request->ids)->get();
+        $count = $assets->count();
+
+        foreach ($assets as $asset) {
+            $asset->forceDelete();
+        }
 
         return response()->json(['message' => "{$count} aset dihapus permanen."]);
     }

--- a/backend/app/Modules/Bmn/Models/Asset.php
+++ b/backend/app/Modules/Bmn/Models/Asset.php
@@ -74,4 +74,23 @@ class Asset extends Model
     {
         return $this->hasMany(AssetUpdate::class, 'asset_id');
     }
+
+    protected static function booted()
+    {
+        static::forceDeleted(function ($asset) {
+            $paths = [
+                $asset->foto_geotag_path,
+                $asset->foto_belakang_path,
+                $asset->foto_kiri_path,
+                $asset->foto_kanan_path,
+                $asset->foto_lokasi_path,
+            ];
+
+            foreach ($paths as $path) {
+                if ($path && \Illuminate\Support\Facades\Storage::exists($path)) {
+                    \Illuminate\Support\Facades\Storage::delete($path);
+                }
+            }
+        });
+    }
 }


### PR DESCRIPTION
When performing \ulk-force-delete\ (Hapus Permanen) on disposed assets, the database records were deleted but the physical files in RustFS were left orphaned.

This PR fixes it by:
1. Adding a \ooted\ method in the \Asset\ model to listen to the \orceDeleted\ event and properly clean up all 5 photo paths from storage.
2. Updating \AssetController::bulkForceDelete\ to iterate and call \orceDelete()\ on each model instance so that the eloquent model events are actually triggered (unlike bulk query builder deletes).