### PR TITLE
feat(bmn): add SK Penghentian BMN document (#338)

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -109,18 +109,42 @@ git push origin main
 - [x] Commit, PR, merge issue #334.
 - [x] Deploy issue #334 to SSH production server.
 - [x] Issue #336: Add reorder panel for selected assets in auction-candidates page (drag-and-drop + ↑↓ buttons, no_polisi shown if available). PR #337 merged to main.
-- [x] Issue #338: Add SK Penghentian Penggunaan BMN document (3 halaman: KOP+Menimbang+Mengingat, MEMUTUSKAN+TTD+Tembusan, Lampiran tabel). Branch `issue/338-sk-penghentian-bmn` aktif, belum PR.
-- [ ] Issue #338 (IN PROGRESS): Fix print layout SK Penghentian — margin bawah semua halaman untuk BSrE footer, Mengingat paginate per nomor (tidak semua turun). Masalah belum selesai, dilanjutkan AI lain.
+- [x] Issue #338: Add SK Penghentian Penggunaan BMN document (KOP+Menimbang+Mengingat, MEMUTUSKAN+TTD+Tembusan, Lampiran tabel). Branch `issue/338-sk-penghentian-bmn` siap PR.
+- [x] Issue #338: Fix print layout SK Penghentian — margin bawah semua halaman untuk BSrE footer, Mengingat paginate per nomor, TTD/tembusan rapi, dan lampiran paginate stabil.
 
 | Field | Value |
 |-------|-------|
-| **Issue Terakhir Selesai** | Issue #336: Reorder selected assets (PR #337 merged) |
-| **Issue Sedang Dikerjakan** | Issue #338: SK Penghentian Penggunaan BMN — branch `issue/338-sk-penghentian-bmn` |
+| **Issue Terakhir Selesai** | Issue #338: SK Penghentian Penggunaan BMN (ready for PR) |
+| **Issue Sedang Dikerjakan** | None — Issue #338 siap dibuat PR |
 | **Branch Aktif** | `issue/338-sk-penghentian-bmn` |
-| **Commit Terakhir di Branch** | 5ffee12 (latest push) |
-| **Status Print SK** | Preview OK, print layout masih bermasalah: (1) margin bawah tidak ke-apply, (2) Mengingat masih turun semua ke halaman baru |
-| **Model Terakhir** | Kiro |
-| **Timestamp** | 2026-05-20T10:00:00+08:00 |
+| **Commit Terakhir di Branch** | see latest branch commit |
+| **Status Print SK** | DONE: preview dan print PDF OK; margin bawah BSrE aman; Mengingat paginate per item; lampiran paginate sesuai aturan 15/17/max-10 |
+| **Model Terakhir** | Codex |
+| **Timestamp** | 2026-05-20T13:00:00+08:00 |
+
+---
+
+**UPDATE SESI CODEX (2026-05-20 - Issue #338: SK Penghentian BMN print layout final):**
+- **Objective**: Finalisasi dokumen SK Penghentian Penggunaan BMN di halaman `/bmn/auction-candidates`, terutama print/PDF dengan ruang footer BSrE/BSSN.
+- **Status Issue #338**: DONE, siap PR dari branch `issue/338-sk-penghentian-bmn`.
+- **Accomplishments**:
+  - Struktur Menimbang/Mengingat diubah dari tabel bersarang menjadi grid/block agar halaman cetak memecah per item, bukan menurunkan seluruh bagian.
+  - Margin bawah untuk footer BSrE/BSSN dijaga pada halaman utama dan lampiran.
+  - Blok TTD dan tembusan dirapikan: tidak ikut bold, rata kiri, dan spacing lebih stabil.
+  - Lampiran dipaginate eksplisit: halaman pertama maksimal 15 aset, halaman tengah maksimal 17 aset, halaman terakhir maksimal 10 aset dan boleh kurang dari 10.
+  - Angka kolom 1-10 hanya tampil di halaman lampiran lanjutan, bukan halaman lampiran pertama.
+  - Preview layar SK di `/bmn/auction-candidates` disamakan dengan style print agar tidak rusak saat generate dokumen.
+- **Key Files Modified**:
+  - `frontend/src/app/bmn/auction-candidates/page.tsx`
+  - `docs/HANDOFF.md`
+  - `docs/progress.md`
+- **Validation**:
+  - `npx eslint "src/app/bmn/auction-candidates/page.tsx" --max-warnings=0` clean
+  - `npx tsc --noEmit` clean
+  - `npm run build` clean
+- **Next Steps**:
+  - Create PR for issue #338.
+  - Deploy ke SSH setelah PR merged dan disetujui.
 
 ---
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -108,18 +108,56 @@ git push origin main
 - [x] Align ST Builder NIP and tembusan font size with the main letter font for FOLU and non-FOLU layouts.
 - [x] Commit, PR, merge issue #334.
 - [x] Deploy issue #334 to SSH production server.
-- [x] Issue #336: Add reorder panel for selected assets in auction-candidates page (drag-and-drop + ↑↓ buttons, no_polisi shown if available). PR #337 opened — deploy ditunda, masih ada fitur lanjutan.
+- [x] Issue #336: Add reorder panel for selected assets in auction-candidates page (drag-and-drop + ↑↓ buttons, no_polisi shown if available). PR #337 merged to main.
+- [x] Issue #338: Add SK Penghentian Penggunaan BMN document (3 halaman: KOP+Menimbang+Mengingat, MEMUTUSKAN+TTD+Tembusan, Lampiran tabel). Branch `issue/338-sk-penghentian-bmn` aktif, belum PR.
+- [ ] Issue #338 (IN PROGRESS): Fix print layout SK Penghentian — margin bawah semua halaman untuk BSrE footer, Mengingat paginate per nomor (tidak semua turun). Masalah belum selesai, dilanjutkan AI lain.
 
 | Field | Value |
 |-------|-------|
-| **Issue Terakhir Selesai** | Issue #336: Reorder selected assets in auction-candidates (PR #337, belum deploy) |
-| **Issue Selanjutnya** | Lanjut fitur di /bmn/auction-candidates |
-| **Branch Aktif** | `main` (PR #337 pending merge) |
-| **Commit Terakhir** | ea09e83 feat(bmn): show no_polisi in reorder panel if available (#336) |
+| **Issue Terakhir Selesai** | Issue #336: Reorder selected assets (PR #337 merged) |
+| **Issue Sedang Dikerjakan** | Issue #338: SK Penghentian Penggunaan BMN — branch `issue/338-sk-penghentian-bmn` |
+| **Branch Aktif** | `issue/338-sk-penghentian-bmn` |
+| **Commit Terakhir di Branch** | 5ffee12 (latest push) |
+| **Status Print SK** | Preview OK, print layout masih bermasalah: (1) margin bawah tidak ke-apply, (2) Mengingat masih turun semua ke halaman baru |
 | **Model Terakhir** | Kiro |
-| **Timestamp** | 2026-05-20T00:00:00+08:00 |
+| **Timestamp** | 2026-05-20T10:00:00+08:00 |
 
 ---
+
+**UPDATE SESI KIRO (2026-05-20 - Issue #336 + #338: Reorder Panel & SK Penghentian BMN):**
+- **Objective**: Tambah fitur reorder aset terpilih (#336) dan dokumen SK Penghentian Penggunaan BMN (#338) di halaman `/bmn/auction-candidates`.
+- **Status Issue #336**: MERGED (PR #337) ke `main`. Deploy ke SSH ditunda.
+- **Status Issue #338**: Branch `issue/338-sk-penghentian-bmn` aktif, **BELUM PR**. Preview OK, print layout masih bermasalah.
+- **GitHub**:
+  - Issue #336: `feat(bmn): reorder selected assets before generating BA Koreksi`
+  - PR #337: merged ke `main`
+  - Issue #338: `feat(bmn): add SK Penghentian Penggunaan BMN document`
+  - Branch: `issue/338-sk-penghentian-bmn`
+- **Accomplishments Issue #336**:
+  - Ganti state `selectedIds` (Set) → `orderedIds` (array) untuk menjaga urutan
+  - Panel "Urutan Aset Terpilih" dengan drag-and-drop native + tombol ↑↓
+  - Nomor urut merah (1, 2, 3, ...) per aset
+  - Tampilkan `no_polisi` jika ada
+  - Dokumen BA Koreksi menggunakan urutan dari panel
+- **Accomplishments Issue #338**:
+  - Tambah input Nomor SK (format `SK.____/K.18/TU/KAP.05/MM/YYYY`)
+  - Tombol "Generate SK Penghentian" (amber) di action bar dan banner
+  - Preview SK 3 halaman: KOP+Judul+Menimbang+Mengingat → MEMUTUSKAN+TTD+Tembusan → Lampiran tabel
+  - KOP pakai `header-new.png` (sama dengan ST Builder)
+  - Tabel lampiran: No, Kode Barang, NUP, Nama, Merk/Type, No Polisi, Tahun, Nilai, Kondisi, Keterangan + baris Jumlah
+  - Print window pakai CSS eksplisit (tidak bergantung Tailwind)
+  - Label Menimbang/Mengingat/Menetapkan/KESATU/KEDUA/KETIGA: tidak bold (sesuai dokumen resmi)
+  - Halaman 1+2 digabung jadi satu artikel agar Menimbang+Mengingat+MEMUTUSKAN mengalir natural
+  - `sk-mengingat-row { break-inside: avoid }` agar tiap item Mengingat tidak terpotong di tengah
+- **Known Issues / Masalah Belum Selesai**:
+  - **Mengingat masih turun semua ke halaman baru** saat cetak — `break-inside: avoid` pada `sk-mengingat-row` belum efektif di print window. Perlu investigasi lebih lanjut mengapa `break-inside` tidak berlaku.
+  - **Margin bawah** (`@page { margin-bottom: 28mm }`) sudah ditambahkan tapi belum terverifikasi efektif karena masalah Mengingat belum selesai.
+- **Key Files Modified**:
+  - `frontend/src/app/bmn/auction-candidates/page.tsx`
+- **Validation**:
+  - `npx eslint --max-warnings=0` clean
+  - `npx tsc --noEmit` clean
+  - `npm run build` clean (terakhir dijalankan sebelum perubahan print CSS terbaru)
 
 ---
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,7 +1,7 @@
-# Progress - Phase 44: SK Penghentian Penggunaan BMN (IN PROGRESS)
+# Progress - Phase 44: SK Penghentian Penggunaan BMN (READY FOR PR)
 
 > Document updated: 2026-05-20
-> Status: **IN PROGRESS** 🔄
+> Status: **READY FOR PR** ✅
 
 ---
 
@@ -19,20 +19,24 @@
 - [x] **Halaman 1+2 digabung**: Satu artikel agar konten mengalir natural tanpa page break buatan.
 - [x] **`sk-mengingat-row { break-inside: avoid }`**: Tiap item Mengingat tidak terpotong di tengah.
 - [x] **`@page { margin-bottom: 28mm }`**: Margin bawah semua halaman untuk BSrE footer.
+- [x] **Print Mengingat fixed**: Struktur Menimbang/Mengingat diubah dari tabel bersarang menjadi grid/block sehingga hanya item berikutnya yang turun, bukan seluruh bagian.
+- [x] **TTD/Tembusan fixed**: Blok tanda tangan dan tembusan tidak lagi ikut bold, rata kiri, dan spacing lebih rapi.
+- [x] **Lampiran pagination fixed**: Halaman pertama lampiran maksimal 15 aset, halaman tengah maksimal 17 aset, halaman terakhir maksimal 10 aset dan boleh kurang dari 10.
+- [x] **Lampiran continuation header**: Angka kolom 1-10 hanya muncul di halaman lampiran lanjutan, bukan halaman lampiran pertama.
+- [x] **Footer BSrE safe area**: Halaman utama dan lampiran menjaga margin bawah untuk teks footer elektronik BSrE/BSSN.
+- [x] **Preview screen fixed**: Preview SK di `/bmn/auction-candidates` disamakan dengan CSS print agar layout layar tidak rusak.
 
 ### Pending / Known Issues:
-- [ ] **Mengingat masih turun semua ke halaman baru** saat cetak — `break-inside: avoid` belum efektif di print window. Perlu investigasi lebih lanjut.
-- [ ] **Verifikasi margin bawah** — `@page { margin-bottom: 28mm }` sudah ditambahkan tapi belum terverifikasi karena masalah Mengingat belum selesai.
-- [ ] **PR belum dibuat** — menunggu print layout selesai.
+- [ ] **PR belum dibuat** — siap dibuat dari branch `issue/338-sk-penghentian-bmn`.
 - [ ] **Deploy ke SSH** — ditunda sampai semua fitur di halaman ini selesai.
 
 ### Key Files:
 - `frontend/src/app/bmn/auction-candidates/page.tsx`
 
 ### Validation:
-- [x] `npx eslint --max-warnings=0` clean
+- [x] `npx eslint "src/app/bmn/auction-candidates/page.tsx" --max-warnings=0` clean
 - [x] `npx tsc --noEmit` clean
-- [x] `npm run build` clean (sebelum perubahan print CSS terbaru)
+- [x] `npm run build` clean
 
 ---
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,67 @@
+# Progress - Phase 44: SK Penghentian Penggunaan BMN (IN PROGRESS)
+
+> Document updated: 2026-05-20
+> Status: **IN PROGRESS** 🔄
+
+---
+
+## Issue #338: SK Penghentian Penggunaan BMN
+
+### Completed:
+- [x] **Issue Created**: Issue #338 tracks SK Penghentian Penggunaan BMN document.
+- [x] **Branch**: `issue/338-sk-penghentian-bmn` aktif.
+- [x] **Input Nomor SK**: Format `SK.____/K.18/TU/KAP.05/MM/YYYY` (bulan+tahun otomatis).
+- [x] **Tombol Generate SK**: Tombol amber "Generate SK Penghentian" di action bar dan banner.
+- [x] **Preview SK**: 3 halaman — KOP+Judul+Menimbang+Mengingat, MEMUTUSKAN+TTD+Tembusan, Lampiran tabel.
+- [x] **KOP**: Pakai `header-new.png` (sama dengan ST Builder).
+- [x] **Tabel Lampiran**: No, Kode Barang, NUP, Nama, Merk/Type, No Polisi, Tahun, Nilai, Kondisi, Keterangan + baris Jumlah + TTD.
+- [x] **Label tidak bold**: Menimbang, Mengingat, Menetapkan, KESATU, KEDUA, KETIGA tidak bold (sesuai dokumen resmi).
+- [x] **Halaman 1+2 digabung**: Satu artikel agar konten mengalir natural tanpa page break buatan.
+- [x] **`sk-mengingat-row { break-inside: avoid }`**: Tiap item Mengingat tidak terpotong di tengah.
+- [x] **`@page { margin-bottom: 28mm }`**: Margin bawah semua halaman untuk BSrE footer.
+
+### Pending / Known Issues:
+- [ ] **Mengingat masih turun semua ke halaman baru** saat cetak — `break-inside: avoid` belum efektif di print window. Perlu investigasi lebih lanjut.
+- [ ] **Verifikasi margin bawah** — `@page { margin-bottom: 28mm }` sudah ditambahkan tapi belum terverifikasi karena masalah Mengingat belum selesai.
+- [ ] **PR belum dibuat** — menunggu print layout selesai.
+- [ ] **Deploy ke SSH** — ditunda sampai semua fitur di halaman ini selesai.
+
+### Key Files:
+- `frontend/src/app/bmn/auction-candidates/page.tsx`
+
+### Validation:
+- [x] `npx eslint --max-warnings=0` clean
+- [x] `npx tsc --noEmit` clean
+- [x] `npm run build` clean (sebelum perubahan print CSS terbaru)
+
+---
+
+# Progress - Phase 43: BMN Reorder Selected Assets
+
+> Document updated: 2026-05-20
+> Status: **MERGED** ✅
+
+---
+
+## Issue #336: Reorder Selected Assets in Auction Candidates
+
+### Completed:
+- [x] **Issue Created**: Issue #336.
+- [x] **PR Created/Merged**: PR #337 merged ke `main`.
+- [x] **State Refactor**: `selectedIds` (Set) → `orderedIds` (array) untuk menjaga urutan.
+- [x] **Panel Reorder**: "Urutan Aset Terpilih" dengan drag-and-drop native HTML5 + tombol ↑↓.
+- [x] **Nomor Urut**: Badge merah (1, 2, 3, ...) per aset di panel.
+- [x] **No Polisi**: Ditampilkan di panel jika aset memilikinya.
+- [x] **Dokumen BA Koreksi**: Menggunakan urutan dari panel (bukan urutan API).
+
+### Key Files:
+- `frontend/src/app/bmn/auction-candidates/page.tsx`
+
+### Note:
+- Deploy ke SSH ditunda — masih ada fitur lanjutan di halaman ini.
+
+---
+
 # Progress - Phase 42: BMN Auction Candidates & BA Koreksi Kondisi
 
 > Document updated: 2026-05-19

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -114,7 +114,8 @@ function getBaNumberSuffix(date = new Date()) {
 }
 
 function getSkNumberSuffix(date = new Date()) {
-  return `K.18/TU/KAP.05/${date.getFullYear()}`;
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  return `K.18/TU/KAP.05/${month}/${date.getFullYear()}`;
 }
 
 function shortenLokasi(value?: string | null) {
@@ -353,7 +354,8 @@ export default function BmnAuctionCandidatesPage() {
         <head>
           <title>SK Penghentian Penggunaan BMN</title>
           <style>
-            @page { size: A4; margin: 0; }
+            @page { size: A4; margin: 3cm 1cm 1.9cm 1.55cm; }
+            @page :first { margin: 0.7cm 1cm 1.9cm 1.55cm; }
             body {
               margin: 0; padding: 0; background: white; color: black;
               font-family: 'Bookman Old Style', Georgia, serif;
@@ -361,35 +363,23 @@ export default function BmnAuctionCandidatesPage() {
             }
             .sk-page {
               width: 210mm; min-height: 297mm; box-sizing: border-box;
-              margin: 0 auto; padding: 5mm 20mm 14mm;
+              margin: 0 auto; padding: 0;
               page-break-after: always;
             }
             .sk-page:last-child { page-break-after: auto; }
-            .sk-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; text-align: center; }
-            .sk-header img { width: 196mm !important; max-width: 196mm !important; height: auto !important; }
-            .sk-body { width: 166mm; margin-left: auto; margin-right: auto; }
-            .sk-title { margin-top: 0.5rem; text-align: center; font-weight: 700; }
-            .sk-title p { margin: 0; line-height: 1.3; }
+            .sk-kop { margin-top: -0.25cm; margin-left: 0; margin-right: -0.95cm; margin-bottom: 2px; overflow: visible; }
+            .sk-kop img { width: 18.8cm !important; height: auto !important; display: block; }
+            .sk-body { }
             table { border-collapse: collapse; }
             .sk-section-table { width: 100%; }
-            .sk-section-table td { vertical-align: top; padding: 0.15rem 0; }
-            .sk-label { width: 28mm; font-weight: bold; }
-            .sk-colon { width: 8mm; text-align: center; }
-            .sk-value { }
-            .sk-sub-table { width: 100%; }
-            .sk-sub-table td { vertical-align: top; padding: 0.1rem 0; }
-            .sk-sub-label { width: 6mm; }
-            .sk-sub-colon { width: 6mm; text-align: center; }
+            .sk-section-table td { vertical-align: top; padding: 0.1rem 0; }
             .asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
             .asset-table th, .asset-table td { border: 1px solid #000; padding: 0.25rem; }
             .asset-table td.text-left { text-align: left; }
             .asset-table td.text-right { text-align: right; }
-            .attachment-meta { width: 109mm; margin-left: auto; text-align: left; }
             .attachment-meta .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
             .attachment-meta .meta-label { white-space: nowrap; }
             .attachment-meta .meta-colon { text-align: center; }
-            .attachment-meta .meta-value { min-width: 0; }
-            .signature { width: 20rem; margin-left: auto; }
             .signature p { margin: 0; padding: 0; line-height: 1.15; }
             .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; }
           </style>
@@ -945,6 +935,7 @@ function AssetConditionTable({ title, assets, mode }: { title: string; assets: A
   );
 }
 
+
 function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; skNumber: string }) {
   const today = new Date();
   const skNumberText = `SK.${skNumber.trim() || "____"}/${getSkNumberSuffix(today)}`;
@@ -962,11 +953,11 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
     "Peraturan Menteri Lingkungan Hidup dan Kehutanan Nomor P.11/MENLHK/SETJEN/KAP.3/4/2018 tentang Tata Cara Pelaksanaan Pemindahtanganan Barang Milik Negara Lingkup Kementerian Lingkungan Hidup dan Kehutanan.",
   ];
 
-  const pageStyle = {
+  const pageStyle: React.CSSProperties = {
     fontFamily: "'Bookman Old Style', Georgia, serif",
     fontSize: "11pt",
     lineHeight: "1.4",
-  } as React.CSSProperties;
+  };
 
   return (
     <div id="sk-penghentian-print-root" className="sk-print-root space-y-6">
@@ -990,13 +981,13 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
           .sk-header img { max-width: 196mm !important; }
           .sk-body { width: 166mm; margin-left: auto; margin-right: auto; }
           .sk-no-print { display: none !important; }
-          .asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
-          .asset-table th, .asset-table td { border: 1px solid #000; padding: 0.25rem; }
-          .asset-table td.text-left { text-align: left; }
-          .asset-table td.text-right { text-align: right; }
-          .attachment-meta .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
-          .attachment-meta .meta-label { white-space: nowrap; }
-          .attachment-meta .meta-colon { text-align: center; }
+          .sk-asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
+          .sk-asset-table th, .sk-asset-table td { border: 1px solid #000; padding: 0.25rem; }
+          .sk-asset-table td.text-left { text-align: left; }
+          .sk-asset-table td.text-right { text-align: right; }
+          .sk-attachment-meta .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
+          .sk-attachment-meta .meta-label { white-space: nowrap; }
+          .sk-attachment-meta .meta-colon { text-align: center; }
           .signature p { margin: 0; padding: 0; line-height: 1.15; }
           .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; }
         }
@@ -1007,14 +998,12 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
         className="sk-page mx-auto min-h-100 max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
         style={pageStyle}
       >
-        {/* KOP */}
         <div className="sk-header -mx-18 text-center">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src="/header-terbaru.png" alt="Kop Surat" className="mx-auto h-auto w-full max-w-[196mm]" />
         </div>
 
-        {/* Judul SK */}
-        <div className="sk-body sk-title mx-auto mt-3 w-[166mm] text-center font-bold leading-snug">
+        <div className="sk-body mx-auto mt-3 w-[166mm] text-center font-bold leading-snug">
           <p className="m-0">KEPUTUSAN KEPALA BALAI</p>
           <p className="m-0">KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR</p>
           <p className="m-0 font-normal">Nomor : {skNumberText}</p>
@@ -1030,24 +1019,24 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR,
           </p>
 
-          {/* Menimbang */}
           <table className="mt-4 w-full" style={{ borderCollapse: "collapse" }}>
             <tbody>
+              {/* Menimbang */}
               <tr>
-                <td className="w-28 align-top font-bold">Menimbang</td>
-                <td className="w-6 text-center align-top">:</td>
-                <td className="align-top">
+                <td style={{ width: "28mm", verticalAlign: "top", fontWeight: "bold" }}>Menimbang</td>
+                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top" }}>:</td>
+                <td style={{ verticalAlign: "top" }}>
                   <table className="w-full" style={{ borderCollapse: "collapse" }}>
                     <tbody>
                       <tr>
-                        <td className="w-5 align-top">a.</td>
-                        <td className="align-top text-justify">
+                        <td style={{ width: "6mm", verticalAlign: "top" }}>a.</td>
+                        <td style={{ verticalAlign: "top", textAlign: "justify" }}>
                           bahwa terdapat Barang Milik Negara pada Balai Konservasi Sumber Daya Alam Kalimantan Timur berupa Alat Angkutan Bermotor dalam keadaan rusak berat dan tidak ekonomis lagi untuk digunakan;
                         </td>
                       </tr>
                       <tr>
-                        <td className="w-5 align-top pt-2">b.</td>
-                        <td className="align-top pt-2 text-justify">
+                        <td style={{ width: "6mm", verticalAlign: "top", paddingTop: "0.5rem" }}>b.</td>
+                        <td style={{ verticalAlign: "top", paddingTop: "0.5rem", textAlign: "justify" }}>
                           bahwa sehubungan dengan hal tersebut diatas, dipandang perlu untuk menerbitkan Keputusan Kepala Balai Konservasi Sumber Daya Alam Kalimantan Timur tentang Penghentian Penggunaan Barang Milik Negara.
                         </td>
                       </tr>
@@ -1055,18 +1044,17 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
                   </table>
                 </td>
               </tr>
-
               {/* Mengingat */}
               <tr>
-                <td className="w-28 align-top pt-3 font-bold">Mengingat</td>
-                <td className="w-6 text-center align-top pt-3">:</td>
-                <td className="align-top pt-3">
+                <td style={{ width: "28mm", verticalAlign: "top", fontWeight: "bold", paddingTop: "0.75rem" }}>Mengingat</td>
+                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.75rem" }}>:</td>
+                <td style={{ verticalAlign: "top", paddingTop: "0.75rem" }}>
                   <table className="w-full" style={{ borderCollapse: "collapse" }}>
                     <tbody>
                       {mengingat.map((item, i) => (
                         <tr key={i}>
-                          <td className="w-5 align-top pt-1">{i + 1}.</td>
-                          <td className="align-top pt-1 text-justify">{item}</td>
+                          <td style={{ width: "6mm", verticalAlign: "top", paddingTop: i > 0 ? "0.35rem" : "0" }}>{i + 1}.</td>
+                          <td style={{ verticalAlign: "top", paddingTop: i > 0 ? "0.35rem" : "0", textAlign: "justify" }}>{item}</td>
                         </tr>
                       ))}
                     </tbody>
@@ -1089,38 +1077,37 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
           <table className="mt-4 w-full" style={{ borderCollapse: "collapse" }}>
             <tbody>
               <tr>
-                <td className="w-28 align-top font-bold">Menetapkan</td>
-                <td className="w-6 text-center align-top">:</td>
-                <td className="align-top font-bold uppercase text-justify">
+                <td style={{ width: "28mm", verticalAlign: "top", fontWeight: "bold" }}>Menetapkan</td>
+                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top" }}>:</td>
+                <td style={{ verticalAlign: "top", fontWeight: "bold", textTransform: "uppercase", textAlign: "justify" }}>
                   KEPUTUSAN KEPALA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR TENTANG PENGHENTIAN PENGGUNAAN BARANG MILIK NEGARA LINGKUP BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR.
                 </td>
               </tr>
               <tr>
-                <td className="w-28 align-top pt-4 font-bold">KESATU</td>
-                <td className="w-6 text-center align-top pt-4">:</td>
-                <td className="align-top pt-4 text-justify">
+                <td style={{ width: "28mm", verticalAlign: "top", fontWeight: "bold", paddingTop: "1rem" }}>KESATU</td>
+                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "1rem" }}>:</td>
+                <td style={{ verticalAlign: "top", paddingTop: "1rem", textAlign: "justify" }}>
                   Menghentikan penggunaan Barang Milik Negara berupa Alat Angkutan Bermotor dalam kondisi rusak berat pada Balai Konservasi Sumber Daya Alam Kalimantan Timur tersebut sebagaimana tercantum dalam lampiran keputusan ini.
                 </td>
               </tr>
               <tr>
-                <td className="w-28 align-top pt-4 font-bold">KEDUA</td>
-                <td className="w-6 text-center align-top pt-4">:</td>
-                <td className="align-top pt-4 text-justify">
+                <td style={{ width: "28mm", verticalAlign: "top", fontWeight: "bold", paddingTop: "1rem" }}>KEDUA</td>
+                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "1rem" }}>:</td>
+                <td style={{ verticalAlign: "top", paddingTop: "1rem", textAlign: "justify" }}>
                   Menghentikan biaya pemeliharaan Alat Angkutan Bermotor tersebut sejak dikeluarkan keputusan ini, untuk dilanjutkan pada proses penghapusan.
                 </td>
               </tr>
               <tr>
-                <td className="w-28 align-top pt-4 font-bold">KETIGA</td>
-                <td className="w-6 text-center align-top pt-4">:</td>
-                <td className="align-top pt-4 text-justify">
+                <td style={{ width: "28mm", verticalAlign: "top", fontWeight: "bold", paddingTop: "1rem" }}>KETIGA</td>
+                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "1rem" }}>:</td>
+                <td style={{ verticalAlign: "top", paddingTop: "1rem", textAlign: "justify" }}>
                   Keputusan ini mulai berlaku sejak tanggal ditetapkan.
                 </td>
               </tr>
             </tbody>
           </table>
 
-          {/* TTD */}
-          <div className="mt-12 ml-auto w-80">
+          <div className="signature mt-12 ml-auto w-80">
             <p className="m-0">Ditetapkan di : Samarinda</p>
             <p className="m-0">Pada tanggal : {formatDateLong(today)}</p>
             <p className="m-0 mt-3">Kepala Balai,</p>
@@ -1129,7 +1116,6 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             <p className="m-0">NIP. 19740514 199903 1 001</p>
           </div>
 
-          {/* Tembusan */}
           <div className="mt-10">
             <p className="m-0">Tembusan :</p>
             <p className="m-0">1.&nbsp; Kepala Biro Umum Kementerian Kehutanan</p>
@@ -1144,8 +1130,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
         style={pageStyle}
       >
         <div className="sk-body mx-auto w-[166mm]">
-          {/* Attachment meta */}
-          <div className="attachment-meta ml-auto w-[109mm]">
+          <div className="sk-attachment-meta ml-auto w-[109mm]">
             <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
               <span className="meta-label whitespace-nowrap">Lampiran</span>
               <span className="meta-colon text-center">:</span>
@@ -1163,14 +1148,12 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             </div>
           </div>
 
-          {/* Judul tabel */}
-          <p className="mt-6 text-center font-bold text-[11pt] leading-snug">
+          <p className="mt-6 text-center font-bold leading-snug">
             DAFTAR PENGHENTIAN PENGGUNAAN BARANG MILIK NEGARA<br />
             PADA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR
           </p>
 
-          {/* Tabel aset */}
-          <table className="asset-table mt-4 w-full border-collapse text-center text-[8.5pt]">
+          <table className="sk-asset-table mt-4 w-full border-collapse text-center" style={{ fontSize: "8.5pt" }}>
             <thead>
               <tr>
                 <th className="border border-black px-1 py-1">No</th>
@@ -1208,7 +1191,6 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             </tbody>
           </table>
 
-          {/* TTD lampiran */}
           <div className="signature mt-10 ml-auto w-80">
             <p className="m-0">Kepala Balai,</p>
             <div className="ttd-placeholder mt-4 h-28 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -390,10 +390,10 @@ export default function BmnAuctionCandidatesPage() {
             /* Tabel Menimbang/Mengingat/Memutuskan */
             .sk-body { width: 166mm; margin-left: auto; margin-right: auto; }
             table { border-collapse: collapse; width: 100%; }
-            td { vertical-align: top; }
+            td { vertical-align: top; padding: 0; }
             /* Halaman 2 */
             .sk-page2-body { width: 166mm; margin-left: auto; margin-right: auto; padding-top: 16mm; }
-            .sk-memutuskan { text-align: center; font-weight: bold; text-decoration: underline; margin-bottom: 12px; }
+            .sk-memutuskan { text-align: center; font-weight: bold; margin-bottom: 12px; }
             /* TTD block */
             .sk-ttd {
               width: 20rem; margin-left: auto; margin-top: 3rem;
@@ -1086,8 +1086,8 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
                     <tbody>
                       {mengingat.map((item, i) => (
                         <tr key={i}>
-                          <td style={{ width: "6mm", verticalAlign: "top", paddingTop: i > 0 ? "0.35rem" : "0" }}>{i + 1}.</td>
-                          <td style={{ verticalAlign: "top", paddingTop: i > 0 ? "0.35rem" : "0", textAlign: "justify" }}>{item}</td>
+                          <td style={{ width: "6mm", verticalAlign: "top", paddingTop: i > 0 ? "0.35rem" : "0", paddingBottom: 0 }}>{i + 1}.</td>
+                          <td style={{ verticalAlign: "top", paddingTop: i > 0 ? "0.35rem" : "0", paddingBottom: 0, textAlign: "justify" }}>{item}</td>
                         </tr>
                       ))}
                     </tbody>
@@ -1105,7 +1105,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
         style={pageStyle}
       >
         <div className="sk-page2-body sk-body mx-auto w-[166mm]" style={{ paddingTop: "16mm" }}>
-          <p className="sk-memutuskan text-center font-bold underline">MEMUTUSKAN</p>
+          <p className="sk-memutuskan text-center font-bold">MEMUTUSKAN</p>
 
           <table className="mt-4 w-full" style={{ borderCollapse: "collapse" }}>
             <tbody>

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -354,7 +354,7 @@ export default function BmnAuctionCandidatesPage() {
         <head>
           <title>SK Penghentian Penggunaan BMN</title>
           <style>
-            @page { size: A4; margin: 0; }
+            @page { size: A4; margin: 0 0 28mm 0; }
             * { box-sizing: border-box; }
             body {
               margin: 0; padding: 0; background: white; color: black;
@@ -364,10 +364,11 @@ export default function BmnAuctionCandidatesPage() {
             p { margin: 0; padding: 0; }
             .sk-page {
               width: 210mm;
-              margin: 0 auto; padding: 5mm 20mm 28mm;
-              page-break-after: always;
+              margin: 0 auto; padding: 5mm 20mm 0;
             }
-            .sk-page:last-child { page-break-after: auto; }
+            .sk-page-ttd { padding-bottom: 0; }
+            article { margin: 0; }
+            .sk-page-break { page-break-after: always; break-after: always; }
             /* KOP */
             .sk-kop {
               margin-top: -5mm; margin-left: -16mm; margin-right: -16mm;
@@ -392,21 +393,19 @@ export default function BmnAuctionCandidatesPage() {
             .sk-body { width: 166mm; margin-left: auto; margin-right: auto; }
             table { border-collapse: collapse; width: 100%; }
             td { vertical-align: top; padding: 0; }
-            /* Label bold: Menimbang, Mengingat, Menetapkan, KESATU, KEDUA, KETIGA */
-            .sk-label-bold { font-weight: bold; }
-            /* Mengingat list — boleh paginate antar item, tapi tiap item tidak terpotong */
+            /* Label bold */
+
+            /* Mengingat list — boleh paginate antar item, tiap item tidak terpotong */
             .sk-mengingat-table { break-inside: auto !important; page-break-inside: auto !important; }
             .sk-mengingat-row { break-inside: avoid !important; page-break-inside: avoid !important; }
             /* Halaman 2 */
             .sk-page2-body { width: 166mm; margin-left: auto; margin-right: auto; padding-top: 16mm; }
             .sk-memutuskan { text-align: center; font-weight: bold; margin-bottom: 12px; }
             /* TTD block */
-            .sk-ttd {
-              width: 20rem; margin-left: auto; margin-top: 3rem;
-            }
+            .sk-ttd { width: 20rem; margin-left: auto; margin-top: 3rem; }
             .sk-ttd p { margin: 0; padding: 0; line-height: 1.3; }
             .ttd-placeholder { height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; }
-            /* Tembusan — tanpa spasi antar item */
+            /* Tembusan */
             .sk-tembusan { margin-top: 2rem; }
             .sk-tembusan p { margin: 0; padding: 0; line-height: 1.5; }
             /* Halaman 3 lampiran */
@@ -999,7 +998,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
   };
 
   return (
-    <div id="sk-penghentian-print-root" className="sk-print-root space-y-6">
+    <div id="sk-penghentian-print-root" className="sk-print-root">
       <style jsx global>{`
         @media print {
           body * { visibility: hidden; }
@@ -1013,13 +1012,12 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
           .sk-page {
             width: 210mm; margin: 0 auto;
             padding: 5mm 20mm 28mm; box-shadow: none !important;
-            page-break-after: always;
           }
-          .sk-page:last-child { page-break-after: auto; }
+          .sk-page-break { page-break-after: always; break-after: always; }
           .sk-kop { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; margin-bottom: 4px; text-align: center; }
           .sk-kop img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
           .sk-body { width: 166mm; margin-left: auto; margin-right: auto; }
-          .sk-label-bold { font-weight: bold; }
+
           .sk-mengingat-table { break-inside: auto !important; page-break-inside: auto !important; }
           .sk-mengingat-row { break-inside: avoid !important; page-break-inside: avoid !important; }
           .sk-no-print { display: none !important; }
@@ -1035,9 +1033,9 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
         }
       `}</style>
 
-      {/* ── HALAMAN 1: KOP + Judul + Menimbang + Mengingat ── */}
+      {/* ── HALAMAN 1+2: KOP + Judul + Menimbang + Mengingat + MEMUTUSKAN + TTD + Tembusan ── */}
       <article
-        className="sk-page mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        className="sk-page sk-page-ttd mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
         style={pageStyle}
       >
         <div className="sk-kop" style={{ marginTop: "-5mm", marginLeft: "-16mm", marginRight: "-16mm", marginBottom: "4px", textAlign: "center" }}>
@@ -1061,11 +1059,11 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR,
           </p>
 
+          {/* Menimbang + Mengingat */}
           <table className="sk-mengingat-table mt-4 w-full" style={{ borderCollapse: "collapse" }}>
             <tbody>
-              {/* Menimbang */}
               <tr className="sk-mengingat-row">
-                <td className="sk-label-bold" style={{ width: "28mm", verticalAlign: "top" }}>Menimbang</td>
+                <td style={{ width: "28mm", verticalAlign: "top" }}>Menimbang</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top" }}>:</td>
                 <td style={{ verticalAlign: "top" }}>
                   <table className="sk-mengingat-table w-full" style={{ borderCollapse: "collapse" }}>
@@ -1086,9 +1084,8 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
                   </table>
                 </td>
               </tr>
-              {/* Mengingat */}
               <tr className="sk-mengingat-row">
-                <td className="sk-label-bold" style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.75rem" }}>Mengingat</td>
+                <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.75rem" }}>Mengingat</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.75rem" }}>:</td>
                 <td style={{ verticalAlign: "top", paddingTop: "0.75rem" }}>
                   <table className="sk-mengingat-table w-full" style={{ borderCollapse: "collapse" }}>
@@ -1105,42 +1102,35 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
               </tr>
             </tbody>
           </table>
-        </div>
-      </article>
 
-      {/* ── HALAMAN 2: MEMUTUSKAN + Menetapkan + KESATU/KEDUA/KETIGA + TTD + Tembusan ── */}
-      <article
-        className="sk-page mx-auto max-w-[210mm] bg-white px-24 py-12 text-black shadow-xl ring-1 ring-zinc-200"
-        style={pageStyle}
-      >
-        <div className="sk-page2-body sk-body mx-auto w-[166mm]" style={{ paddingTop: "16mm" }}>
-          <p className="sk-memutuskan text-center font-bold">MEMUTUSKAN</p>
+          {/* MEMUTUSKAN */}
+          <p className="sk-memutuskan text-center font-bold" style={{ marginTop: "1.5rem" }}>MEMUTUSKAN</p>
 
-          <table className="mt-4 w-full" style={{ borderCollapse: "collapse" }}>
+          <table className="sk-mengingat-table mt-4 w-full" style={{ borderCollapse: "collapse" }}>
             <tbody>
-              <tr>
-                <td className="sk-label-bold" style={{ width: "28mm", verticalAlign: "top" }}>Menetapkan</td>
+              <tr className="sk-mengingat-row">
+                <td style={{ width: "28mm", verticalAlign: "top" }}>Menetapkan</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top" }}>:</td>
-                <td className="sk-label-bold" style={{ verticalAlign: "top", textTransform: "uppercase", textAlign: "justify" }}>
+                <td style={{ verticalAlign: "top", textTransform: "uppercase", textAlign: "justify" }}>
                   KEPUTUSAN KEPALA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR TENTANG PENGHENTIAN PENGGUNAAN BARANG MILIK NEGARA LINGKUP BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR.
                 </td>
               </tr>
-              <tr>
-                <td className="sk-label-bold" style={{ width: "28mm", verticalAlign: "top", paddingTop: "1rem" }}>KESATU</td>
+              <tr className="sk-mengingat-row">
+                <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "1rem" }}>KESATU</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "1rem" }}>:</td>
                 <td style={{ verticalAlign: "top", paddingTop: "1rem", textAlign: "justify" }}>
                   Menghentikan penggunaan Barang Milik Negara berupa Alat Angkutan Bermotor dalam kondisi rusak berat pada Balai Konservasi Sumber Daya Alam Kalimantan Timur tersebut sebagaimana tercantum dalam lampiran keputusan ini.
                 </td>
               </tr>
-              <tr>
-                <td className="sk-label-bold" style={{ width: "28mm", verticalAlign: "top", paddingTop: "1rem" }}>KEDUA</td>
+              <tr className="sk-mengingat-row">
+                <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "1rem" }}>KEDUA</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "1rem" }}>:</td>
                 <td style={{ verticalAlign: "top", paddingTop: "1rem", textAlign: "justify" }}>
                   Menghentikan biaya pemeliharaan Alat Angkutan Bermotor tersebut sejak dikeluarkan keputusan ini, untuk dilanjutkan pada proses penghapusan.
                 </td>
               </tr>
-              <tr>
-                <td className="sk-label-bold" style={{ width: "28mm", verticalAlign: "top", paddingTop: "1rem" }}>KETIGA</td>
+              <tr className="sk-mengingat-row">
+                <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "1rem" }}>KETIGA</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "1rem" }}>:</td>
                 <td style={{ verticalAlign: "top", paddingTop: "1rem", textAlign: "justify" }}>
                   Keputusan ini mulai berlaku sejak tanggal ditetapkan.
@@ -1149,6 +1139,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             </tbody>
           </table>
 
+          {/* TTD */}
           <div className="sk-ttd signature mt-12 ml-auto w-80">
             <p className="m-0">Ditetapkan di : Samarinda</p>
             <p className="m-0">Pada tanggal : {formatDateLong(today)}</p>
@@ -1158,6 +1149,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             <p className="m-0">NIP. 19740514 199903 1 001</p>
           </div>
 
+          {/* Tembusan */}
           <div className="sk-tembusan mt-10">
             <p className="m-0">Tembusan :</p>
             <p className="m-0">1.&nbsp; Kepala Biro Umum Kementerian Kehutanan</p>
@@ -1165,6 +1157,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
           </div>
         </div>
       </article>
+      <div className="sk-page-break" />
 
       {/* ── HALAMAN 3: Lampiran — Tabel Daftar Penghentian ── */}
       <article

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -354,8 +354,7 @@ export default function BmnAuctionCandidatesPage() {
         <head>
           <title>SK Penghentian Penggunaan BMN</title>
           <style>
-            @page { size: A4; margin: 3cm 1cm 1.9cm 1.55cm; }
-            @page :first { margin: 0.7cm 1cm 1.9cm 1.55cm; }
+            @page { size: A4; margin: 0; }
             body {
               margin: 0; padding: 0; background: white; color: black;
               font-family: 'Bookman Old Style', Georgia, serif;
@@ -363,24 +362,22 @@ export default function BmnAuctionCandidatesPage() {
             }
             .sk-page {
               width: 210mm; min-height: 297mm; box-sizing: border-box;
-              margin: 0 auto; padding: 0;
+              margin: 0 auto; padding: 5mm 20mm 14mm;
               page-break-after: always;
             }
             .sk-page:last-child { page-break-after: auto; }
-            .sk-kop { margin-top: -0.25cm; margin-left: 0; margin-right: -0.95cm; margin-bottom: 2px; overflow: visible; }
-            .sk-kop img { width: 18.8cm !important; height: auto !important; display: block; }
-            .sk-body { }
+            .sk-kop {
+              margin-top: -5mm; margin-left: -16mm; margin-right: -16mm;
+              margin-bottom: 4px; text-align: center;
+            }
+            .sk-kop img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
+            .sk-body { width: 166mm; margin-left: auto; margin-right: auto; }
             table { border-collapse: collapse; }
-            .sk-section-table { width: 100%; }
-            .sk-section-table td { vertical-align: top; padding: 0.1rem 0; }
             .sk-asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
             .sk-asset-table th, .sk-asset-table td { border: 1px solid #000; padding: 0.25rem; }
             .sk-asset-table td.text-left { text-align: left; }
             .sk-asset-table td.text-right { text-align: right; }
             .sk-attachment-meta { width: 109mm; margin-left: auto; text-align: left; }
-            .sk-attachment-meta .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
-            .sk-attachment-meta .meta-label { white-space: nowrap; }
-            .sk-attachment-meta .meta-colon { text-align: center; }
             .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
             .meta-label { white-space: nowrap; }
             .meta-colon { text-align: center; }
@@ -982,8 +979,8 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             page-break-after: always;
           }
           .sk-page:last-child { page-break-after: auto; }
-          .sk-kop { margin-top: -0.25cm; margin-left: 0; margin-right: -0.95cm; margin-bottom: 2px; overflow: visible; }
-          .sk-kop img { width: 18.8cm !important; height: auto !important; display: block; }
+          .sk-kop { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; margin-bottom: 4px; text-align: center; }
+          .sk-kop img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
           .sk-body { width: 166mm; margin-left: auto; margin-right: auto; }
           .sk-no-print { display: none !important; }
           .sk-asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
@@ -1003,9 +1000,9 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
         className="sk-page mx-auto min-h-100 max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
         style={pageStyle}
       >
-        <div className="sk-kop" style={{ marginTop: "-10px", marginBottom: "2px", marginLeft: "-1.5cm", marginRight: "-1cm" }}>
+        <div className="sk-kop" style={{ marginTop: "-5mm", marginLeft: "-16mm", marginRight: "-16mm", marginBottom: "4px", textAlign: "center" }}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/header-new.png" alt="Kop Surat" style={{ width: "18.8cm", height: "auto", display: "block" }} />
+          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
         </div>
 
         <div className="sk-body mx-auto mt-3 w-[166mm] text-center font-bold leading-snug">

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -47,6 +47,15 @@ interface AssetResponse {
   total?: number;
 }
 
+interface AttachmentPage {
+  assets: AuctionAsset[];
+  startIndex: number;
+  showColumnNumbers: boolean;
+  includeMeta: boolean;
+  includeTotal: boolean;
+  includeSignature: boolean;
+}
+
 const formatRupiah = (value: number | null | undefined) =>
   new Intl.NumberFormat("id-ID", {
     style: "currency",
@@ -355,6 +364,9 @@ export default function BmnAuctionCandidatesPage() {
           <title>SK Penghentian Penggunaan BMN</title>
           <style>
             @page { size: A4; margin: 0 0 28mm 0; }
+            @page sk-main { size: A4; margin: 12mm 0 28mm 0; }
+            @page sk-main:first { size: A4; margin: 0 0 28mm 0; }
+            @page sk-attachment { size: A4; margin: 0; }
             * { box-sizing: border-box; }
             body {
               margin: 0; padding: 0; background: white; color: black;
@@ -365,6 +377,14 @@ export default function BmnAuctionCandidatesPage() {
             .sk-page {
               width: 210mm;
               margin: 0 auto; padding: 5mm 20mm 0;
+            }
+            .sk-main-document { page: sk-main; }
+            .sk-attachment-document {
+              page: sk-attachment;
+              page-break-before: always;
+              break-before: page;
+              min-height: 297mm;
+              padding: 12mm 20mm 28mm !important;
             }
             .sk-page-ttd { padding-bottom: 0; }
             article { margin: 0; }
@@ -387,26 +407,48 @@ export default function BmnAuctionCandidatesPage() {
               width: 166mm; margin-left: auto; margin-right: auto;
               margin-top: 16px;
             }
-            .sk-subtitle p { text-align: center; font-weight: bold; }
-            .sk-subtitle p + p { margin-top: 6px; }
+            .sk-subtitle > p { text-align: center; font-weight: bold; }
+            .sk-subtitle > p + p { margin-top: 6px; }
             /* Tabel Menimbang/Mengingat/Memutuskan */
             .sk-body { width: 166mm; margin-left: auto; margin-right: auto; }
             table { border-collapse: collapse; width: 100%; }
             td { vertical-align: top; padding: 0; }
-            /* Label bold */
 
-            /* Mengingat list — boleh paginate antar item, tiap item tidak terpotong */
-            .sk-mengingat-table { break-inside: auto !important; page-break-inside: auto !important; }
-            .sk-mengingat-row { break-inside: avoid !important; page-break-inside: avoid !important; }
+            /* Menimbang/Mengingat: parent boleh paginate, item anak tetap utuh */
+            .sk-field-section {
+              display: grid;
+              grid-template-columns: 28mm 8mm minmax(0, 1fr);
+              break-inside: auto !important;
+              page-break-inside: auto !important;
+            }
+            .sk-field-section + .sk-field-section { margin-top: 0.75rem; }
+            .sk-field-label, .sk-field-colon { padding: 0; }
+            .sk-field-colon { text-align: center; }
+            .sk-mengingat-list {
+              break-inside: auto !important;
+              page-break-inside: auto !important;
+            }
+            .sk-mengingat-item {
+              display: grid;
+              grid-template-columns: 6mm minmax(0, 1fr);
+              break-inside: avoid !important;
+              page-break-inside: avoid !important;
+              padding-top: 0.35rem;
+            }
+            .sk-mengingat-item:first-child { padding-top: 0; }
+            .sk-mengingat-text { text-align: justify; }
             /* Halaman 2 */
             .sk-page2-body { width: 166mm; margin-left: auto; margin-right: auto; padding-top: 16mm; }
             .sk-memutuskan { text-align: center; font-weight: bold; margin-bottom: 12px; }
             /* TTD block */
             .sk-ttd { width: 20rem; margin-left: auto; margin-top: 3rem; }
+            .sk-ttd, .sk-ttd p { font-weight: normal !important; text-align: left !important; }
             .sk-ttd p { margin: 0; padding: 0; line-height: 1.3; }
-            .ttd-placeholder { height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; }
+            .sk-signature-name { font-weight: bold !important; }
+            .ttd-placeholder { height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; font-weight: normal !important; text-align: left !important; }
             /* Tembusan */
             .sk-tembusan { margin-top: 2rem; }
+            .sk-tembusan, .sk-tembusan p { font-weight: normal !important; text-align: left !important; }
             .sk-tembusan p { margin: 0; padding: 0; line-height: 1.5; }
             /* Halaman 3 lampiran */
             .sk-attachment-meta { width: 109mm; margin-left: auto; text-align: left; }
@@ -416,10 +458,14 @@ export default function BmnAuctionCandidatesPage() {
             .sk-lampiran-title { text-align: center; font-weight: bold; line-height: 1.3; margin-top: 1.5rem; margin-bottom: 0.75rem; }
             .sk-asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
             .sk-asset-table th, .sk-asset-table td { border: 1px solid #000; padding: 0.25rem; }
+            .sk-asset-table thead { display: table-header-group; }
+            .sk-asset-table tr { break-inside: avoid; page-break-inside: avoid; }
+            .sk-column-number-row th { font-weight: normal; }
             .sk-asset-table td.text-left { text-align: left; }
             .sk-asset-table td.text-right { text-align: right; }
-            .sk-lampiran-ttd { width: 20rem; margin-left: auto; margin-top: 2.5rem; }
-            .sk-lampiran-ttd p { margin: 0; padding: 0; line-height: 1.3; }
+            .sk-lampiran-ttd { width: 20rem; margin-left: auto; margin-top: 1rem; break-inside: avoid; page-break-inside: avoid; }
+            .sk-lampiran-ttd p { margin: 0; padding: 0; line-height: 1.15; }
+            .sk-lampiran-ttd .ttd-placeholder { height: 86px !important; padding-top: 28px !important; }
           </style>
         </head>
         <body>${printContent.innerHTML}</body>
@@ -978,6 +1024,128 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
   const today = new Date();
   const skNumberText = `SK.${skNumber.trim() || "____"}/${getSkNumberSuffix(today)}`;
   const totalNilai = assets.reduce((sum, a) => sum + (a.nilai_perolehan || 0), 0);
+  const attachmentPages = useMemo<AttachmentPage[]>(() => {
+    const firstPageLimit = 15;
+    const continuationPageLimit = 17;
+    const lastPageLimit = 10;
+    const pages: AttachmentPage[] = [];
+    let cursor = 0;
+
+    const pushPage = (pageAssets: AuctionAsset[], startIndex: number, includeMeta: boolean) => {
+      pages.push({
+        assets: pageAssets,
+        startIndex,
+        showColumnNumbers: !includeMeta,
+        includeMeta,
+        includeTotal: false,
+        includeSignature: false,
+      });
+    };
+
+    if (assets.length <= lastPageLimit) {
+      pushPage(assets, 0, true);
+    } else if (assets.length <= firstPageLimit) {
+      const firstChunkSize = assets.length - 1;
+      pushPage(assets.slice(0, firstChunkSize), 0, true);
+      pushPage(assets.slice(firstChunkSize), firstChunkSize, false);
+    } else if (assets.length <= firstPageLimit + lastPageLimit) {
+      pushPage(assets.slice(0, firstPageLimit), 0, true);
+      pushPage(assets.slice(firstPageLimit), firstPageLimit, false);
+    } else {
+      pushPage(assets.slice(0, firstPageLimit), 0, true);
+      const continuationChunks: AuctionAsset[][] = [];
+      let lastPageStart = assets.length;
+
+      for (let i = firstPageLimit; i < assets.length; i += continuationPageLimit) {
+        const remaining = assets.length - i;
+
+        if (remaining <= continuationPageLimit + lastPageLimit) {
+          const previousPageSize = Math.min(continuationPageLimit, Math.max(1, remaining - 1));
+          continuationChunks.push(assets.slice(i, i + previousPageSize));
+          lastPageStart = i + previousPageSize;
+          break;
+        }
+
+        continuationChunks.push(assets.slice(i, i + continuationPageLimit));
+      }
+
+      if (lastPageStart < assets.length) {
+        continuationChunks.push(assets.slice(lastPageStart));
+      }
+
+      cursor = firstPageLimit;
+      for (const chunk of continuationChunks) {
+        pushPage(chunk, cursor, false);
+        cursor += chunk.length;
+      }
+    }
+
+    if (pages.length === 0) {
+      pushPage([], 0, true);
+    }
+
+    const lastPage = pages[pages.length - 1];
+    lastPage.includeTotal = true;
+    lastPage.includeSignature = true;
+
+    return pages;
+  }, [assets]);
+
+  const renderAttachmentTable = (chunk: AuctionAsset[], startIndex: number, showColumnNumbers: boolean, includeTotal: boolean) => (
+    <table className="sk-asset-table mt-4 w-full border-collapse text-center" style={{ fontSize: "8.5pt" }}>
+      <thead>
+        {showColumnNumbers && (
+          <tr className="sk-column-number-row" data-sk-measure="column-number-row">
+            <th className="border border-black px-1 py-1">1</th>
+            <th className="border border-black px-1 py-1">2</th>
+            <th className="border border-black px-1 py-1">3</th>
+            <th className="border border-black px-1 py-1">4</th>
+            <th className="border border-black px-1 py-1">5</th>
+            <th className="border border-black px-1 py-1">6</th>
+            <th className="border border-black px-1 py-1">7</th>
+            <th className="border border-black px-1 py-1">8</th>
+            <th className="border border-black px-1 py-1">9</th>
+            <th className="border border-black px-1 py-1">10</th>
+          </tr>
+        )}
+        <tr data-sk-measure={showColumnNumbers ? "header-numbered" : "header-simple"}>
+          <th className="border border-black px-1 py-1">No</th>
+          <th className="border border-black px-1 py-1">Kode Barang</th>
+          <th className="border border-black px-1 py-1">NUP</th>
+          <th className="border border-black px-1 py-1">Nama Barang</th>
+          <th className="border border-black px-1 py-1">Merk / Type</th>
+          <th className="border border-black px-1 py-1">No Polisi</th>
+          <th className="border border-black px-1 py-1">Tahun Perolehan</th>
+          <th className="border border-black px-1 py-1">Nilai Perolehan (Rp)</th>
+          <th className="border border-black px-1 py-1">Kondisi</th>
+          <th className="border border-black px-1 py-1">Keterangan</th>
+        </tr>
+      </thead>
+      <tbody>
+        {chunk.map((asset, index) => (
+          <tr key={asset.id} data-sk-row-index={startIndex + index}>
+            <td className="border border-black px-1 py-1">{startIndex + index + 1}.</td>
+            <td className="border border-black px-1 py-1">{asset.kode_barang}</td>
+            <td className="border border-black px-1 py-1">{asset.nup}</td>
+            <td className="border border-black px-1 py-1 text-left">{asset.nama_barang}</td>
+            <td className="border border-black px-1 py-1">{asset.merk_tipe || "-"}</td>
+            <td className="border border-black px-1 py-1">{asset.no_polisi || "-"}</td>
+            <td className="border border-black px-1 py-1">{asset.tahun_perolehan || "-"}</td>
+            <td className="border border-black px-1 py-1 text-right">{formatPlainRupiah(asset.nilai_perolehan)}</td>
+            <td className="border border-black px-1 py-1">{asset.kondisi}</td>
+            <td className="border border-black px-1 py-1">Surat Lengkap</td>
+          </tr>
+        ))}
+        {includeTotal && (
+          <tr data-sk-measure="total-row">
+            <td colSpan={7} className="border border-black px-1 py-1 text-center font-bold">Jumlah</td>
+            <td className="border border-black px-1 py-1 text-right font-bold">{formatPlainRupiah(totalNilai)}</td>
+            <td colSpan={2} className="border border-black px-1 py-1"></td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+  );
 
   const mengingat = [
     "Undang-Undang Republik Indonesia Nomor 17 Tahun 2003 tentang Keuangan Negara;",
@@ -997,10 +1165,50 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
     lineHeight: "1.4",
   };
 
+  const renderAttachmentMetaTitle = (measure = false) => (
+    <div data-sk-measure={measure ? "attachment-meta-title" : undefined}>
+      <div className="sk-attachment-meta ml-auto w-[109mm]">
+        <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
+          <span className="meta-label whitespace-nowrap">Lampiran</span>
+          <span className="meta-colon text-center">:</span>
+          <span className="meta-value min-w-0">Keputusan Kepala Balai KSDA KALTIM</span>
+        </div>
+        <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
+          <span className="meta-label whitespace-nowrap">Nomor</span>
+          <span className="meta-colon text-center">:</span>
+          <span className="meta-value min-w-0 whitespace-nowrap">{skNumberText}</span>
+        </div>
+        <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
+          <span className="meta-label whitespace-nowrap">Tanggal</span>
+          <span className="meta-colon text-center">:</span>
+          <span className="meta-value min-w-0">{formatDateLong(today)}</span>
+        </div>
+      </div>
+
+      <p className="sk-lampiran-title mt-6 text-center font-bold leading-snug">
+        DAFTAR PENGHENTIAN PENGGUNAAN BARANG MILIK NEGARA<br />
+        PADA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR
+      </p>
+    </div>
+  );
+
+  const renderAttachmentSignature = (measure = false) => (
+    <div className="sk-lampiran-ttd signature mt-10 ml-auto w-80" data-sk-measure={measure ? "signature" : undefined}>
+      <p className="m-0">Kepala Balai,</p>
+      <div className="ttd-placeholder mt-4 h-28 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+      <p className="m-0 font-bold">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>
+      <p className="m-0">NIP. 19740514 199903 1 001</p>
+    </div>
+  );
+
   return (
     <div id="sk-penghentian-print-root" className="sk-print-root">
       <style jsx global>{`
         @media print {
+          @page { size: A4; margin: 0 0 28mm 0; }
+          @page sk-main { size: A4; margin: 12mm 0 28mm 0; }
+          @page sk-main:first { size: A4; margin: 0 0 28mm 0; }
+          @page sk-attachment { size: A4; margin: 0; }
           body * { visibility: hidden; }
           .sk-print-root, .sk-print-root * { visibility: visible; }
           .sk-print-root {
@@ -1011,7 +1219,15 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
           }
           .sk-page {
             width: 210mm; margin: 0 auto;
-            padding: 5mm 20mm 28mm; box-shadow: none !important;
+            padding: 5mm 20mm 0; box-shadow: none !important;
+          }
+          .sk-main-document { page: sk-main; }
+          .sk-attachment-document {
+            page: sk-attachment;
+            page-break-before: always;
+            break-before: page;
+            min-height: 297mm;
+            padding: 12mm 20mm 28mm !important;
           }
           .sk-page-break { page-break-after: always; break-after: always; }
           .sk-kop { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; margin-bottom: 4px; text-align: center; }
@@ -1020,22 +1236,238 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
 
           .sk-mengingat-table { break-inside: auto !important; page-break-inside: auto !important; }
           .sk-mengingat-row { break-inside: avoid !important; page-break-inside: avoid !important; }
+          .sk-field-section { display: grid; grid-template-columns: 28mm 8mm minmax(0, 1fr); break-inside: auto !important; page-break-inside: auto !important; }
+          .sk-field-section + .sk-field-section { margin-top: 0.75rem; }
+          .sk-field-colon { text-align: center; }
+          .sk-mengingat-list { break-inside: auto !important; page-break-inside: auto !important; }
+          .sk-mengingat-item { display: grid; grid-template-columns: 6mm minmax(0, 1fr); break-inside: avoid !important; page-break-inside: avoid !important; padding-top: 0.35rem; }
+          .sk-mengingat-item:first-child { padding-top: 0; }
+          .sk-mengingat-text { text-align: justify; }
           .sk-no-print { display: none !important; }
           .sk-asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
           .sk-asset-table th, .sk-asset-table td { border: 1px solid #000; padding: 0.25rem; }
+          .sk-asset-table thead { display: table-header-group; }
+          .sk-asset-table tr { break-inside: avoid; page-break-inside: avoid; }
+          .sk-column-number-row th { font-weight: normal; }
           .sk-asset-table td.text-left { text-align: left; }
           .sk-asset-table td.text-right { text-align: right; }
+          .sk-lampiran-ttd { margin-top: 1rem !important; break-inside: avoid; page-break-inside: avoid; }
+          .sk-lampiran-ttd p { line-height: 1.15 !important; }
           .sk-attachment-meta .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
           .sk-attachment-meta .meta-label { white-space: nowrap; }
           .sk-attachment-meta .meta-colon { text-align: center; }
+          .sk-ttd, .sk-ttd p { font-weight: normal !important; text-align: left !important; }
           .signature p { margin: 0; padding: 0; line-height: 1.15; }
-          .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; }
+          .sk-signature-name { font-weight: bold !important; }
+          .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; font-weight: normal !important; text-align: left !important; }
+          .sk-lampiran-ttd .ttd-placeholder { height: 86px !important; padding-top: 28px !important; }
+          .sk-tembusan, .sk-tembusan p { font-weight: normal !important; text-align: left !important; }
+        }
+        .sk-print-root .sk-attachment-document {
+          min-height: 297mm;
+          padding: 12mm 20mm 28mm !important;
+        }
+        .sk-print-root .sk-page {
+          width: 210mm;
+          margin-left: auto;
+          margin-right: auto;
+          box-sizing: border-box;
+        }
+        .sk-print-root .sk-main-document {
+          padding: 5mm 20mm 0 !important;
+        }
+        .sk-print-root .sk-kop {
+          margin-top: -5mm;
+          margin-left: -16mm;
+          margin-right: -16mm;
+          margin-bottom: 4px;
+          text-align: center;
+        }
+        .sk-print-root .sk-kop img {
+          width: 196mm !important;
+          max-width: 196mm !important;
+          height: auto !important;
+          display: block;
+          margin: 0 auto;
+        }
+        .sk-print-root .sk-title,
+        .sk-print-root .sk-subtitle,
+        .sk-print-root .sk-body {
+          width: 166mm;
+          margin-left: auto;
+          margin-right: auto;
+        }
+        .sk-print-root .sk-title {
+          margin-top: 10px;
+          text-align: center;
+          font-weight: bold;
+          line-height: 1.3;
+        }
+        .sk-print-root .sk-title-nomor {
+          font-weight: normal;
+        }
+        .sk-print-root .sk-title-tentang {
+          margin-top: 10px;
+        }
+        .sk-print-root .sk-subtitle {
+          margin-top: 16px;
+        }
+        .sk-print-root .sk-subtitle > p {
+          text-align: center;
+          font-weight: bold;
+        }
+        .sk-print-root .sk-subtitle > p + p {
+          margin-top: 6px;
+        }
+        .sk-print-root p {
+          margin: 0;
+          padding: 0;
+        }
+        .sk-print-root table {
+          border-collapse: collapse;
+          width: 100%;
+        }
+        .sk-print-root td {
+          vertical-align: top;
+          padding: 0;
+        }
+        .sk-print-root .sk-field-section {
+          display: grid;
+          grid-template-columns: 28mm 8mm minmax(0, 1fr);
+          break-inside: auto;
+          page-break-inside: auto;
+        }
+        .sk-print-root .sk-field-section + .sk-field-section {
+          margin-top: 0.75rem;
+        }
+        .sk-print-root .sk-field-colon {
+          text-align: center;
+        }
+        .sk-print-root .sk-mengingat-list {
+          break-inside: auto;
+          page-break-inside: auto;
+        }
+        .sk-print-root .sk-mengingat-item {
+          display: grid;
+          grid-template-columns: 6mm minmax(0, 1fr);
+          break-inside: avoid;
+          page-break-inside: avoid;
+          padding-top: 0.35rem;
+        }
+        .sk-print-root .sk-mengingat-item:first-child {
+          padding-top: 0;
+        }
+        .sk-print-root .sk-mengingat-text {
+          text-align: justify;
+        }
+        .sk-print-root .sk-memutuskan {
+          text-align: center;
+          font-weight: bold;
+          margin-bottom: 12px;
+        }
+        .sk-print-root .sk-ttd {
+          width: 20rem;
+          margin-left: auto;
+          margin-top: 3rem;
+        }
+        .sk-print-root .sk-ttd,
+        .sk-print-root .sk-ttd p,
+        .sk-print-root .sk-tembusan,
+        .sk-print-root .sk-tembusan p {
+          font-weight: normal !important;
+          text-align: left !important;
+        }
+        .sk-print-root .sk-ttd p,
+        .sk-print-root .sk-tembusan p {
+          margin: 0;
+          padding: 0;
+        }
+        .sk-print-root .sk-signature-name {
+          font-weight: bold !important;
+        }
+        .sk-print-root .ttd-placeholder {
+          box-sizing: border-box;
+          height: 112px;
+          padding-top: 40px;
+          padding-left: 1.35cm;
+          color: #94a3b8;
+          font-weight: normal !important;
+          text-align: left !important;
+        }
+        .sk-print-root .sk-tembusan {
+          margin-top: 2rem;
+        }
+        .sk-print-root .sk-tembusan p {
+          line-height: 1.5;
+        }
+        .sk-print-root .sk-attachment-meta {
+          width: 109mm;
+          margin-left: auto;
+          text-align: left;
+        }
+        .sk-print-root .meta-row {
+          display: grid;
+          grid-template-columns: 24mm 5mm minmax(0, 1fr);
+          align-items: start;
+        }
+        .sk-print-root .meta-label {
+          white-space: nowrap;
+        }
+        .sk-print-root .meta-colon {
+          text-align: center;
+        }
+        .sk-print-root .sk-lampiran-title {
+          text-align: center;
+          font-weight: bold;
+          line-height: 1.3;
+          margin-top: 1.5rem;
+          margin-bottom: 0.75rem;
+        }
+        .sk-print-root .sk-asset-table {
+          width: 100%;
+          border-collapse: collapse;
+          text-align: center;
+          font-size: 8.5pt;
+        }
+        .sk-print-root .sk-asset-table th,
+        .sk-print-root .sk-asset-table td {
+          border: 1px solid #000;
+          padding: 0.25rem;
+        }
+        .sk-print-root .sk-asset-table tr {
+          break-inside: avoid;
+          page-break-inside: avoid;
+        }
+        .sk-print-root .sk-column-number-row th {
+          font-weight: normal;
+        }
+        .sk-print-root .sk-asset-table td.text-left {
+          text-align: left;
+        }
+        .sk-print-root .sk-asset-table td.text-right {
+          text-align: right;
+        }
+        .sk-print-root .sk-lampiran-ttd {
+          width: 20rem;
+          margin-left: auto;
+          margin-top: 1rem !important;
+          break-inside: avoid;
+          page-break-inside: avoid;
+        }
+        .sk-print-root .sk-lampiran-ttd p {
+          margin: 0;
+          padding: 0;
+          line-height: 1.15 !important;
+        }
+        .sk-print-root .sk-lampiran-ttd .ttd-placeholder {
+          height: 86px !important;
+          padding-top: 28px !important;
         }
       `}</style>
 
       {/* ── HALAMAN 1+2: KOP + Judul + Menimbang + Mengingat + MEMUTUSKAN + TTD + Tembusan ── */}
       <article
-        className="sk-page sk-page-ttd mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        className="sk-page sk-page-ttd sk-main-document mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
         style={pageStyle}
       >
         <div className="sk-kop" style={{ marginTop: "-5mm", marginLeft: "-16mm", marginRight: "-16mm", marginBottom: "4px", textAlign: "center" }}>
@@ -1060,48 +1492,39 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
           </p>
 
           {/* Menimbang + Mengingat */}
-          <table className="sk-mengingat-table mt-4 w-full" style={{ borderCollapse: "collapse" }}>
-            <tbody>
-              <tr className="sk-mengingat-row">
-                <td style={{ width: "28mm", verticalAlign: "top" }}>Menimbang</td>
-                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top" }}>:</td>
-                <td style={{ verticalAlign: "top" }}>
-                  <table className="sk-mengingat-table w-full" style={{ borderCollapse: "collapse" }}>
-                    <tbody>
-                      <tr className="sk-mengingat-row">
-                        <td style={{ width: "6mm", verticalAlign: "top" }}>a.</td>
-                        <td style={{ verticalAlign: "top", textAlign: "justify" }}>
-                          bahwa terdapat Barang Milik Negara pada Balai Konservasi Sumber Daya Alam Kalimantan Timur berupa Alat Angkutan Bermotor dalam keadaan rusak berat dan tidak ekonomis lagi untuk digunakan;
-                        </td>
-                      </tr>
-                      <tr className="sk-mengingat-row">
-                        <td style={{ width: "6mm", verticalAlign: "top", paddingTop: "0.5rem" }}>b.</td>
-                        <td style={{ verticalAlign: "top", paddingTop: "0.5rem", textAlign: "justify" }}>
-                          bahwa sehubungan dengan hal tersebut diatas, dipandang perlu untuk menerbitkan Keputusan Kepala Balai Konservasi Sumber Daya Alam Kalimantan Timur tentang Penghentian Penggunaan Barang Milik Negara.
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </td>
-              </tr>
-              <tr className="sk-mengingat-row">
-                <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.75rem" }}>Mengingat</td>
-                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.75rem" }}>:</td>
-                <td style={{ verticalAlign: "top", paddingTop: "0.75rem" }}>
-                  <table className="sk-mengingat-table w-full" style={{ borderCollapse: "collapse" }}>
-                    <tbody>
-                      {mengingat.map((item, i) => (
-                        <tr className="sk-mengingat-row" key={i}>
-                          <td style={{ width: "6mm", verticalAlign: "top", paddingTop: i > 0 ? "0.35rem" : "0", paddingBottom: 0 }}>{i + 1}.</td>
-                          <td style={{ verticalAlign: "top", paddingTop: i > 0 ? "0.35rem" : "0", paddingBottom: 0, textAlign: "justify" }}>{item}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+          <div className="mt-4">
+            <div className="sk-field-section">
+              <div className="sk-field-label">Menimbang</div>
+              <div className="sk-field-colon">:</div>
+              <div className="sk-mengingat-list">
+                <div className="sk-mengingat-item">
+                  <div>a.</div>
+                  <div className="sk-mengingat-text">
+                    bahwa terdapat Barang Milik Negara pada Balai Konservasi Sumber Daya Alam Kalimantan Timur berupa Alat Angkutan Bermotor dalam keadaan rusak berat dan tidak ekonomis lagi untuk digunakan;
+                  </div>
+                </div>
+                <div className="sk-mengingat-item" style={{ paddingTop: "0.5rem" }}>
+                  <div>b.</div>
+                  <div className="sk-mengingat-text">
+                    bahwa sehubungan dengan hal tersebut diatas, dipandang perlu untuk menerbitkan Keputusan Kepala Balai Konservasi Sumber Daya Alam Kalimantan Timur tentang Penghentian Penggunaan Barang Milik Negara.
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="sk-field-section">
+              <div className="sk-field-label">Mengingat</div>
+              <div className="sk-field-colon">:</div>
+              <div className="sk-mengingat-list">
+                {mengingat.map((item, i) => (
+                  <div className="sk-mengingat-item" key={i}>
+                    <div>{i + 1}.</div>
+                    <div className="sk-mengingat-text">{item}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
 
           {/* MEMUTUSKAN */}
           <p className="sk-memutuskan text-center font-bold" style={{ marginTop: "1.5rem" }}>MEMUTUSKAN</p>
@@ -1145,7 +1568,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             <p className="m-0">Pada tanggal : {formatDateLong(today)}</p>
             <p className="m-0 mt-3">Kepala Balai,</p>
             <div className="ttd-placeholder mt-4 h-28 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
-            <p className="m-0 font-bold">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>
+            <p className="sk-signature-name m-0 font-bold">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>
             <p className="m-0">NIP. 19740514 199903 1 001</p>
           </div>
 
@@ -1157,83 +1580,22 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
           </div>
         </div>
       </article>
-      <div className="sk-page-break" />
 
-      {/* ── HALAMAN 3: Lampiran — Tabel Daftar Penghentian ── */}
-      <article
-        className="sk-page mx-auto max-w-[210mm] bg-white px-24 py-12 text-black shadow-xl ring-1 ring-zinc-200"
-        style={pageStyle}
-      >
-        <div className="sk-body mx-auto w-[166mm]">
-          <div className="sk-attachment-meta ml-auto w-[109mm]">
-            <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
-              <span className="meta-label whitespace-nowrap">Lampiran</span>
-              <span className="meta-colon text-center">:</span>
-              <span className="meta-value min-w-0">Keputusan Kepala Balai KSDA KALTIM</span>
-            </div>
-            <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
-              <span className="meta-label whitespace-nowrap">Nomor</span>
-              <span className="meta-colon text-center">:</span>
-              <span className="meta-value min-w-0 whitespace-nowrap">{skNumberText}</span>
-            </div>
-            <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
-              <span className="meta-label whitespace-nowrap">Tanggal</span>
-              <span className="meta-colon text-center">:</span>
-              <span className="meta-value min-w-0">{formatDateLong(today)}</span>
-            </div>
+      {/* ── HALAMAN 3 DST: Lampiran — Tabel Daftar Penghentian ── */}
+      {attachmentPages.map((page, index) => (
+        <article
+          className="sk-page sk-attachment-document mx-auto max-w-[210mm] bg-white px-24 py-12 text-black shadow-xl ring-1 ring-zinc-200"
+          style={pageStyle}
+          key={`sk-attachment-${index}`}
+        >
+          <div className="sk-body mx-auto w-[166mm]">
+            {page.includeMeta && renderAttachmentMetaTitle()}
+            {renderAttachmentTable(page.assets, page.startIndex, page.showColumnNumbers, page.includeTotal)}
+            {page.includeSignature && renderAttachmentSignature()}
           </div>
+        </article>
+      ))}
 
-          <p className="sk-lampiran-title mt-6 text-center font-bold leading-snug">
-            DAFTAR PENGHENTIAN PENGGUNAAN BARANG MILIK NEGARA<br />
-            PADA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR
-          </p>
-
-          <table className="sk-asset-table mt-4 w-full border-collapse text-center" style={{ fontSize: "8.5pt" }}>
-            <thead>
-              <tr>
-                <th className="border border-black px-1 py-1">No</th>
-                <th className="border border-black px-1 py-1">Kode Barang</th>
-                <th className="border border-black px-1 py-1">NUP</th>
-                <th className="border border-black px-1 py-1">Nama Barang</th>
-                <th className="border border-black px-1 py-1">Merk / Type</th>
-                <th className="border border-black px-1 py-1">No Polisi</th>
-                <th className="border border-black px-1 py-1">Tahun Perolehan</th>
-                <th className="border border-black px-1 py-1">Nilai Perolehan (Rp)</th>
-                <th className="border border-black px-1 py-1">Kondisi</th>
-                <th className="border border-black px-1 py-1">Keterangan</th>
-              </tr>
-            </thead>
-            <tbody>
-              {assets.map((asset, index) => (
-                <tr key={asset.id}>
-                  <td className="border border-black px-1 py-1">{index + 1}.</td>
-                  <td className="border border-black px-1 py-1">{asset.kode_barang}</td>
-                  <td className="border border-black px-1 py-1">{asset.nup}</td>
-                  <td className="border border-black px-1 py-1 text-left">{asset.nama_barang}</td>
-                  <td className="border border-black px-1 py-1">{asset.merk_tipe || "-"}</td>
-                  <td className="border border-black px-1 py-1">{asset.no_polisi || "-"}</td>
-                  <td className="border border-black px-1 py-1">{asset.tahun_perolehan || "-"}</td>
-                  <td className="border border-black px-1 py-1 text-right">{formatPlainRupiah(asset.nilai_perolehan)}</td>
-                  <td className="border border-black px-1 py-1">{asset.kondisi}</td>
-                  <td className="border border-black px-1 py-1">Surat Lengkap</td>
-                </tr>
-              ))}
-              <tr>
-                <td colSpan={7} className="border border-black px-1 py-1 text-center font-bold">Jumlah</td>
-                <td className="border border-black px-1 py-1 text-right font-bold">{formatPlainRupiah(totalNilai)}</td>
-                <td colSpan={2} className="border border-black px-1 py-1"></td>
-              </tr>
-            </tbody>
-          </table>
-
-          <div className="sk-lampiran-ttd signature mt-10 ml-auto w-80">
-            <p className="m-0">Kepala Balai,</p>
-            <div className="ttd-placeholder mt-4 h-28 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
-            <p className="m-0 font-bold">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>
-            <p className="m-0">NIP. 19740514 199903 1 001</p>
-          </div>
-        </div>
-      </article>
     </div>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -363,7 +363,7 @@ export default function BmnAuctionCandidatesPage() {
             }
             p { margin: 0; padding: 0; }
             .sk-page {
-              width: 210mm; min-height: 297mm;
+              width: 210mm;
               margin: 0 auto; padding: 5mm 20mm 28mm;
               page-break-after: always;
             }
@@ -392,6 +392,8 @@ export default function BmnAuctionCandidatesPage() {
             .sk-body { width: 166mm; margin-left: auto; margin-right: auto; }
             table { border-collapse: collapse; width: 100%; }
             td { vertical-align: top; padding: 0; }
+            /* Label bold: Menimbang, Mengingat, Menetapkan, KESATU, KEDUA, KETIGA */
+            .sk-label-bold { font-weight: bold; }
             /* Halaman 2 */
             .sk-page2-body { width: 166mm; margin-left: auto; margin-right: auto; padding-top: 16mm; }
             .sk-memutuskan { text-align: center; font-weight: bold; margin-bottom: 12px; }
@@ -1057,7 +1059,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             <tbody>
               {/* Menimbang */}
               <tr>
-                <td style={{ width: "28mm", verticalAlign: "top", fontWeight: "bold" }}>Menimbang</td>
+                <td className="sk-label-bold" style={{ width: "28mm", verticalAlign: "top" }}>Menimbang</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top" }}>:</td>
                 <td style={{ verticalAlign: "top" }}>
                   <table className="w-full" style={{ borderCollapse: "collapse" }}>
@@ -1080,7 +1082,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
               </tr>
               {/* Mengingat */}
               <tr>
-                <td style={{ width: "28mm", verticalAlign: "top", fontWeight: "bold", paddingTop: "0.75rem" }}>Mengingat</td>
+                <td className="sk-label-bold" style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.75rem" }}>Mengingat</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.75rem" }}>:</td>
                 <td style={{ verticalAlign: "top", paddingTop: "0.75rem" }}>
                   <table className="w-full" style={{ borderCollapse: "collapse" }}>
@@ -1111,28 +1113,28 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
           <table className="mt-4 w-full" style={{ borderCollapse: "collapse" }}>
             <tbody>
               <tr>
-                <td style={{ width: "28mm", verticalAlign: "top", fontWeight: "bold" }}>Menetapkan</td>
+                <td className="sk-label-bold" style={{ width: "28mm", verticalAlign: "top" }}>Menetapkan</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top" }}>:</td>
-                <td style={{ verticalAlign: "top", fontWeight: "bold", textTransform: "uppercase", textAlign: "justify" }}>
+                <td className="sk-label-bold" style={{ verticalAlign: "top", textTransform: "uppercase", textAlign: "justify" }}>
                   KEPUTUSAN KEPALA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR TENTANG PENGHENTIAN PENGGUNAAN BARANG MILIK NEGARA LINGKUP BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR.
                 </td>
               </tr>
               <tr>
-                <td style={{ width: "28mm", verticalAlign: "top", fontWeight: "bold", paddingTop: "1rem" }}>KESATU</td>
+                <td className="sk-label-bold" style={{ width: "28mm", verticalAlign: "top", paddingTop: "1rem" }}>KESATU</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "1rem" }}>:</td>
                 <td style={{ verticalAlign: "top", paddingTop: "1rem", textAlign: "justify" }}>
                   Menghentikan penggunaan Barang Milik Negara berupa Alat Angkutan Bermotor dalam kondisi rusak berat pada Balai Konservasi Sumber Daya Alam Kalimantan Timur tersebut sebagaimana tercantum dalam lampiran keputusan ini.
                 </td>
               </tr>
               <tr>
-                <td style={{ width: "28mm", verticalAlign: "top", fontWeight: "bold", paddingTop: "1rem" }}>KEDUA</td>
+                <td className="sk-label-bold" style={{ width: "28mm", verticalAlign: "top", paddingTop: "1rem" }}>KEDUA</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "1rem" }}>:</td>
                 <td style={{ verticalAlign: "top", paddingTop: "1rem", textAlign: "justify" }}>
                   Menghentikan biaya pemeliharaan Alat Angkutan Bermotor tersebut sejak dikeluarkan keputusan ini, untuk dilanjutkan pada proses penghapusan.
                 </td>
               </tr>
               <tr>
-                <td style={{ width: "28mm", verticalAlign: "top", fontWeight: "bold", paddingTop: "1rem" }}>KETIGA</td>
+                <td className="sk-label-bold" style={{ width: "28mm", verticalAlign: "top", paddingTop: "1rem" }}>KETIGA</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "1rem" }}>:</td>
                 <td style={{ verticalAlign: "top", paddingTop: "1rem", textAlign: "justify" }}>
                   Keputusan ini mulai berlaku sejak tanggal ditetapkan.

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -113,6 +113,10 @@ function getBaNumberSuffix(date = new Date()) {
   return `K.18/TU/KAP.06.01/B/${month}/${date.getFullYear()}`;
 }
 
+function getSkNumberSuffix(date = new Date()) {
+  return `K.18/TU/KAP.05/${date.getFullYear()}`;
+}
+
 function shortenLokasi(value?: string | null) {
   if (!value) return "-";
   return value
@@ -129,7 +133,9 @@ export default function BmnAuctionCandidatesPage() {
   // orderedIds keeps the user-defined order for the document
   const [orderedIds, setOrderedIds] = useState<string[]>([]);
   const [showDocument, setShowDocument] = useState(false);
+  const [showSkDocument, setShowSkDocument] = useState(false);
   const [baNumber, setBaNumber] = useState("");
+  const [skNumber, setSkNumber] = useState("");
   const debouncedSearch = useDebounce(searchTerm, 400);
 
   // drag-and-drop refs
@@ -250,6 +256,17 @@ export default function BmnAuctionCandidatesPage() {
     }, 50);
   };
 
+  const handleProcessSk = () => {
+    if (orderedIds.length === 0) {
+      toast.error("Pilih minimal satu aset untuk diproses.");
+      return;
+    }
+    setShowSkDocument(true);
+    setTimeout(() => {
+      document.getElementById("sk-penghentian-preview")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 50);
+  };
+
   const handlePrint = () => {
     if (orderedSelectedAssets.length === 0) {
       toast.error("Tidak ada aset terpilih untuk dicetak.");
@@ -321,6 +338,70 @@ export default function BmnAuctionCandidatesPage() {
     setTimeout(() => printWindow.print(), 500);
   };
 
+  const handlePrintSk = () => {
+    if (orderedSelectedAssets.length === 0) {
+      toast.error("Tidak ada aset terpilih untuk dicetak.");
+      return;
+    }
+    const printContent = document.getElementById("sk-penghentian-print-root");
+    if (!printContent) return;
+    const printWindow = window.open("", "_blank");
+    if (!printWindow) return;
+
+    printWindow.document.write(`
+      <html>
+        <head>
+          <title>SK Penghentian Penggunaan BMN</title>
+          <style>
+            @page { size: A4; margin: 0; }
+            body {
+              margin: 0; padding: 0; background: white; color: black;
+              font-family: 'Bookman Old Style', Georgia, serif;
+              font-size: 11pt; line-height: 1.4;
+            }
+            .sk-page {
+              width: 210mm; min-height: 297mm; box-sizing: border-box;
+              margin: 0 auto; padding: 5mm 20mm 14mm;
+              page-break-after: always;
+            }
+            .sk-page:last-child { page-break-after: auto; }
+            .sk-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; text-align: center; }
+            .sk-header img { width: 196mm !important; max-width: 196mm !important; height: auto !important; }
+            .sk-body { width: 166mm; margin-left: auto; margin-right: auto; }
+            .sk-title { margin-top: 0.5rem; text-align: center; font-weight: 700; }
+            .sk-title p { margin: 0; line-height: 1.3; }
+            table { border-collapse: collapse; }
+            .sk-section-table { width: 100%; }
+            .sk-section-table td { vertical-align: top; padding: 0.15rem 0; }
+            .sk-label { width: 28mm; font-weight: bold; }
+            .sk-colon { width: 8mm; text-align: center; }
+            .sk-value { }
+            .sk-sub-table { width: 100%; }
+            .sk-sub-table td { vertical-align: top; padding: 0.1rem 0; }
+            .sk-sub-label { width: 6mm; }
+            .sk-sub-colon { width: 6mm; text-align: center; }
+            .asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
+            .asset-table th, .asset-table td { border: 1px solid #000; padding: 0.25rem; }
+            .asset-table td.text-left { text-align: left; }
+            .asset-table td.text-right { text-align: right; }
+            .attachment-meta { width: 109mm; margin-left: auto; text-align: left; }
+            .attachment-meta .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
+            .attachment-meta .meta-label { white-space: nowrap; }
+            .attachment-meta .meta-colon { text-align: center; }
+            .attachment-meta .meta-value { min-width: 0; }
+            .signature { width: 20rem; margin-left: auto; }
+            .signature p { margin: 0; padding: 0; line-height: 1.15; }
+            .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; }
+          </style>
+        </head>
+        <body>${printContent.innerHTML}</body>
+      </html>
+    `);
+    printWindow.document.close();
+    printWindow.focus();
+    setTimeout(() => printWindow.print(), 500);
+  };
+
   return (
     <div className="p-6 md:p-10 space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
@@ -359,6 +440,15 @@ export default function BmnAuctionCandidatesPage() {
           >
             <FileText className="h-3.5 w-3.5" />
             Proses BA Koreksi
+          </Button>
+          <Button
+            size="sm"
+            className="rounded-xl gap-2 bg-amber-600 text-xs hover:bg-amber-500"
+            onClick={handleProcessSk}
+            disabled={orderedIds.length === 0}
+          >
+            <FileText className="h-3.5 w-3.5" />
+            Proses SK Penghentian
           </Button>
         </div>
       </div>
@@ -416,6 +506,29 @@ export default function BmnAuctionCandidatesPage() {
         </div>
       </div>
 
+      <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+        <label htmlFor="sk-number" className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">
+          Nomor SK Penghentian
+        </label>
+        <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
+          <div className="flex h-11 items-center rounded-xl border border-zinc-200 bg-white px-3 text-sm text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-white">
+            <span className="font-semibold">SK.</span>
+            <input
+              id="sk-number"
+              type="text"
+              value={skNumber}
+              onChange={(event) => setSkNumber(event.target.value)}
+              placeholder="____"
+              className="mx-1 w-20 bg-transparent text-center font-semibold outline-none"
+            />
+            <span>/{getSkNumberSuffix()}</span>
+          </div>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+            Tahun otomatis mengikuti tanggal generate dokumen.
+          </p>
+        </div>
+      </div>
+
       {orderedIds.length > 0 && (
         <div className="flex flex-col gap-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 dark:border-red-500/20 dark:bg-red-500/10 sm:flex-row sm:items-center sm:justify-between">
           <div>
@@ -425,12 +538,22 @@ export default function BmnAuctionCandidatesPage() {
           <div className="flex flex-wrap gap-2">
             <Button size="sm" className="rounded-lg bg-red-600 text-xs hover:bg-red-500" onClick={handleProcess}>
               <FileText className="mr-1 h-3.5 w-3.5" />
-              Generate Dokumen
+              Generate BA Koreksi
+            </Button>
+            <Button size="sm" className="rounded-lg bg-amber-600 text-xs hover:bg-amber-500" onClick={handleProcessSk}>
+              <FileText className="mr-1 h-3.5 w-3.5" />
+              Generate SK Penghentian
             </Button>
             {showDocument && (
               <Button size="sm" variant="outline" className="rounded-lg text-xs" onClick={handlePrint}>
                 <Printer className="mr-1 h-3.5 w-3.5" />
-                Cetak
+                Cetak BA
+              </Button>
+            )}
+            {showSkDocument && (
+              <Button size="sm" variant="outline" className="rounded-lg text-xs" onClick={handlePrintSk}>
+                <Printer className="mr-1 h-3.5 w-3.5" />
+                Cetak SK
               </Button>
             )}
           </div>
@@ -615,6 +738,22 @@ export default function BmnAuctionCandidatesPage() {
             </Button>
           </div>
           <CorrectionDocument assets={orderedSelectedAssets} baNumber={baNumber} />
+        </section>
+      )}
+
+      {showSkDocument && orderedSelectedAssets.length > 0 && (
+        <section id="sk-penghentian-preview" className="space-y-4">
+          <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
+            <div>
+              <h2 className="text-lg font-bold text-zinc-900 dark:text-white">Preview SK Penghentian Penggunaan BMN</h2>
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">Keputusan Kepala Balai tentang penghentian penggunaan aset terpilih.</p>
+            </div>
+            <Button className="rounded-xl gap-2 bg-amber-600 text-xs hover:bg-amber-500" onClick={handlePrintSk}>
+              <Printer className="h-3.5 w-3.5" />
+              Cetak / Save PDF
+            </Button>
+          </div>
+          <SkPenghentianDocument assets={orderedSelectedAssets} skNumber={skNumber} />
         </section>
       )}
     </div>
@@ -802,6 +941,282 @@ function AssetConditionTable({ title, assets, mode }: { title: string; assets: A
           ))}
         </tbody>
       </table>
+    </div>
+  );
+}
+
+function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; skNumber: string }) {
+  const today = new Date();
+  const skNumberText = `SK.${skNumber.trim() || "____"}/${getSkNumberSuffix(today)}`;
+  const totalNilai = assets.reduce((sum, a) => sum + (a.nilai_perolehan || 0), 0);
+
+  const mengingat = [
+    "Undang-Undang Republik Indonesia Nomor 17 Tahun 2003 tentang Keuangan Negara;",
+    "Undang-Undang Republik Indonesia Nomor 1 Tahun 2004 tentang Perbendaharaan Negara;",
+    "Peraturan Pemerintah Nomor 27 Tahun 2014 tentang Pengelolaan Barang Milik Negara/Daerah sebagaimana telah diubah dengan Peraturan Pemerintah Nomor 28 Tahun 2020;",
+    "Peraturan Presiden Nomor 175 Tahun 2024 tentang Kementerian Kehutanan;",
+    "Peraturan Menteri Keuangan Nomor 4/PMK.06/2015 tentang Pendelegasian Kewenangan dan Tanggung Jawab Tertentu Dari Pengelola Barang kepada Pengguna Barang;",
+    "Peraturan Menteri Keuangan Nomor 83/PMK.06/2016 tentang Tata Cara Pelaksanaan Pemusnahan dan Penghapusan Barang Milik Negara;",
+    "Peraturan Menteri Keuangan Nomor 111/PMK.06/2016 tentang Tata Cara Pelaksanaan Pemindahtanganan Barang Milik Negara sebagaimana telah diubah dengan Peraturan Menteri Keuangan Nomor 165/PMK.06/2021;",
+    "Peraturan Menteri Keuangan Nomor 181/PMK.06/2016 tentang Penatausahaan Barang Milik Negara;",
+    "Peraturan Menteri Lingkungan Hidup dan Kehutanan Nomor P.11/MENLHK/SETJEN/KAP.3/4/2018 tentang Tata Cara Pelaksanaan Pemindahtanganan Barang Milik Negara Lingkup Kementerian Lingkungan Hidup dan Kehutanan.",
+  ];
+
+  const pageStyle = {
+    fontFamily: "'Bookman Old Style', Georgia, serif",
+    fontSize: "11pt",
+    lineHeight: "1.4",
+  } as React.CSSProperties;
+
+  return (
+    <div id="sk-penghentian-print-root" className="sk-print-root space-y-6">
+      <style jsx global>{`
+        @media print {
+          body * { visibility: hidden; }
+          .sk-print-root, .sk-print-root * { visibility: visible; }
+          .sk-print-root {
+            position: absolute; left: 0; top: 0; width: 100%;
+            background: white; color: black;
+            font-family: 'Bookman Old Style', Georgia, serif;
+            font-size: 11pt; line-height: 1.4; margin: 0; padding: 0;
+          }
+          .sk-page {
+            width: 210mm; min-height: 297mm; margin: 0 auto;
+            padding: 5mm 20mm 14mm; box-shadow: none !important;
+            page-break-after: always;
+          }
+          .sk-page:last-child { page-break-after: auto; }
+          .sk-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; }
+          .sk-header img { max-width: 196mm !important; }
+          .sk-body { width: 166mm; margin-left: auto; margin-right: auto; }
+          .sk-no-print { display: none !important; }
+          .asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
+          .asset-table th, .asset-table td { border: 1px solid #000; padding: 0.25rem; }
+          .asset-table td.text-left { text-align: left; }
+          .asset-table td.text-right { text-align: right; }
+          .attachment-meta .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
+          .attachment-meta .meta-label { white-space: nowrap; }
+          .attachment-meta .meta-colon { text-align: center; }
+          .signature p { margin: 0; padding: 0; line-height: 1.15; }
+          .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; }
+        }
+      `}</style>
+
+      {/* ── HALAMAN 1: KOP + Judul + Menimbang + Mengingat ── */}
+      <article
+        className="sk-page mx-auto min-h-100 max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        style={pageStyle}
+      >
+        {/* KOP */}
+        <div className="sk-header -mx-18 text-center">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/header-terbaru.png" alt="Kop Surat" className="mx-auto h-auto w-full max-w-[196mm]" />
+        </div>
+
+        {/* Judul SK */}
+        <div className="sk-body sk-title mx-auto mt-3 w-[166mm] text-center font-bold leading-snug">
+          <p className="m-0">KEPUTUSAN KEPALA BALAI</p>
+          <p className="m-0">KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR</p>
+          <p className="m-0 font-normal">Nomor : {skNumberText}</p>
+          <p className="m-0 mt-2">TENTANG</p>
+          <p className="m-0">PENGHENTIAN PENGGUNAAN BARANG MILIK NEGARA</p>
+          <p className="m-0">PADA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR,</p>
+        </div>
+
+        <div className="sk-body mx-auto mt-5 w-[166mm]">
+          <p className="text-center font-bold">DENGAN RAHMAT TUHAN YANG MAHA ESA</p>
+          <p className="mt-2 text-center font-bold">
+            KEPALA BALAI<br />
+            KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR,
+          </p>
+
+          {/* Menimbang */}
+          <table className="mt-4 w-full" style={{ borderCollapse: "collapse" }}>
+            <tbody>
+              <tr>
+                <td className="w-28 align-top font-bold">Menimbang</td>
+                <td className="w-6 text-center align-top">:</td>
+                <td className="align-top">
+                  <table className="w-full" style={{ borderCollapse: "collapse" }}>
+                    <tbody>
+                      <tr>
+                        <td className="w-5 align-top">a.</td>
+                        <td className="align-top text-justify">
+                          bahwa terdapat Barang Milik Negara pada Balai Konservasi Sumber Daya Alam Kalimantan Timur berupa Alat Angkutan Bermotor dalam keadaan rusak berat dan tidak ekonomis lagi untuk digunakan;
+                        </td>
+                      </tr>
+                      <tr>
+                        <td className="w-5 align-top pt-2">b.</td>
+                        <td className="align-top pt-2 text-justify">
+                          bahwa sehubungan dengan hal tersebut diatas, dipandang perlu untuk menerbitkan Keputusan Kepala Balai Konservasi Sumber Daya Alam Kalimantan Timur tentang Penghentian Penggunaan Barang Milik Negara.
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+
+              {/* Mengingat */}
+              <tr>
+                <td className="w-28 align-top pt-3 font-bold">Mengingat</td>
+                <td className="w-6 text-center align-top pt-3">:</td>
+                <td className="align-top pt-3">
+                  <table className="w-full" style={{ borderCollapse: "collapse" }}>
+                    <tbody>
+                      {mengingat.map((item, i) => (
+                        <tr key={i}>
+                          <td className="w-5 align-top pt-1">{i + 1}.</td>
+                          <td className="align-top pt-1 text-justify">{item}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </article>
+
+      {/* ── HALAMAN 2: MEMUTUSKAN + Menetapkan + KESATU/KEDUA/KETIGA + TTD + Tembusan ── */}
+      <article
+        className="sk-page mx-auto min-h-100 max-w-[210mm] bg-white px-24 py-12 text-black shadow-xl ring-1 ring-zinc-200"
+        style={pageStyle}
+      >
+        <div className="sk-body mx-auto w-[166mm]">
+          <p className="text-center font-bold underline">MEMUTUSKAN</p>
+
+          <table className="mt-4 w-full" style={{ borderCollapse: "collapse" }}>
+            <tbody>
+              <tr>
+                <td className="w-28 align-top font-bold">Menetapkan</td>
+                <td className="w-6 text-center align-top">:</td>
+                <td className="align-top font-bold uppercase text-justify">
+                  KEPUTUSAN KEPALA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR TENTANG PENGHENTIAN PENGGUNAAN BARANG MILIK NEGARA LINGKUP BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR.
+                </td>
+              </tr>
+              <tr>
+                <td className="w-28 align-top pt-4 font-bold">KESATU</td>
+                <td className="w-6 text-center align-top pt-4">:</td>
+                <td className="align-top pt-4 text-justify">
+                  Menghentikan penggunaan Barang Milik Negara berupa Alat Angkutan Bermotor dalam kondisi rusak berat pada Balai Konservasi Sumber Daya Alam Kalimantan Timur tersebut sebagaimana tercantum dalam lampiran keputusan ini.
+                </td>
+              </tr>
+              <tr>
+                <td className="w-28 align-top pt-4 font-bold">KEDUA</td>
+                <td className="w-6 text-center align-top pt-4">:</td>
+                <td className="align-top pt-4 text-justify">
+                  Menghentikan biaya pemeliharaan Alat Angkutan Bermotor tersebut sejak dikeluarkan keputusan ini, untuk dilanjutkan pada proses penghapusan.
+                </td>
+              </tr>
+              <tr>
+                <td className="w-28 align-top pt-4 font-bold">KETIGA</td>
+                <td className="w-6 text-center align-top pt-4">:</td>
+                <td className="align-top pt-4 text-justify">
+                  Keputusan ini mulai berlaku sejak tanggal ditetapkan.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          {/* TTD */}
+          <div className="mt-12 ml-auto w-80">
+            <p className="m-0">Ditetapkan di : Samarinda</p>
+            <p className="m-0">Pada tanggal : {formatDateLong(today)}</p>
+            <p className="m-0 mt-3">Kepala Balai,</p>
+            <div className="ttd-placeholder mt-4 h-28 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+            <p className="m-0 font-bold">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>
+            <p className="m-0">NIP. 19740514 199903 1 001</p>
+          </div>
+
+          {/* Tembusan */}
+          <div className="mt-10">
+            <p className="m-0">Tembusan :</p>
+            <p className="m-0">1.&nbsp; Kepala Biro Umum Kementerian Kehutanan</p>
+            <p className="m-0">2.&nbsp; Sekretaris Direktorat Jenderal KSDAE</p>
+          </div>
+        </div>
+      </article>
+
+      {/* ── HALAMAN 3: Lampiran — Tabel Daftar Penghentian ── */}
+      <article
+        className="sk-page mx-auto min-h-100 max-w-[210mm] bg-white px-24 py-12 text-black shadow-xl ring-1 ring-zinc-200"
+        style={pageStyle}
+      >
+        <div className="sk-body mx-auto w-[166mm]">
+          {/* Attachment meta */}
+          <div className="attachment-meta ml-auto w-[109mm]">
+            <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
+              <span className="meta-label whitespace-nowrap">Lampiran</span>
+              <span className="meta-colon text-center">:</span>
+              <span className="meta-value min-w-0">Keputusan Kepala Balai KSDA KALTIM</span>
+            </div>
+            <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
+              <span className="meta-label whitespace-nowrap">Nomor</span>
+              <span className="meta-colon text-center">:</span>
+              <span className="meta-value min-w-0 whitespace-nowrap">{skNumberText}</span>
+            </div>
+            <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
+              <span className="meta-label whitespace-nowrap">Tanggal</span>
+              <span className="meta-colon text-center">:</span>
+              <span className="meta-value min-w-0">{formatDateLong(today)}</span>
+            </div>
+          </div>
+
+          {/* Judul tabel */}
+          <p className="mt-6 text-center font-bold text-[11pt] leading-snug">
+            DAFTAR PENGHENTIAN PENGGUNAAN BARANG MILIK NEGARA<br />
+            PADA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR
+          </p>
+
+          {/* Tabel aset */}
+          <table className="asset-table mt-4 w-full border-collapse text-center text-[8.5pt]">
+            <thead>
+              <tr>
+                <th className="border border-black px-1 py-1">No</th>
+                <th className="border border-black px-1 py-1">Kode Barang</th>
+                <th className="border border-black px-1 py-1">NUP</th>
+                <th className="border border-black px-1 py-1">Nama Barang</th>
+                <th className="border border-black px-1 py-1">Merk / Type</th>
+                <th className="border border-black px-1 py-1">No Polisi</th>
+                <th className="border border-black px-1 py-1">Tahun Perolehan</th>
+                <th className="border border-black px-1 py-1">Nilai Perolehan (Rp)</th>
+                <th className="border border-black px-1 py-1">Kondisi</th>
+                <th className="border border-black px-1 py-1">Keterangan</th>
+              </tr>
+            </thead>
+            <tbody>
+              {assets.map((asset, index) => (
+                <tr key={asset.id}>
+                  <td className="border border-black px-1 py-1">{index + 1}.</td>
+                  <td className="border border-black px-1 py-1">{asset.kode_barang}</td>
+                  <td className="border border-black px-1 py-1">{asset.nup}</td>
+                  <td className="border border-black px-1 py-1 text-left">{asset.nama_barang}</td>
+                  <td className="border border-black px-1 py-1">{asset.merk_tipe || "-"}</td>
+                  <td className="border border-black px-1 py-1">{asset.no_polisi || "-"}</td>
+                  <td className="border border-black px-1 py-1">{asset.tahun_perolehan || "-"}</td>
+                  <td className="border border-black px-1 py-1 text-right">{formatPlainRupiah(asset.nilai_perolehan)}</td>
+                  <td className="border border-black px-1 py-1">{asset.kondisi}</td>
+                  <td className="border border-black px-1 py-1">Surat Lengkap</td>
+                </tr>
+              ))}
+              <tr>
+                <td colSpan={7} className="border border-black px-1 py-1 text-center font-bold">Jumlah</td>
+                <td className="border border-black px-1 py-1 text-right font-bold">{formatPlainRupiah(totalNilai)}</td>
+                <td colSpan={2} className="border border-black px-1 py-1"></td>
+              </tr>
+            </tbody>
+          </table>
+
+          {/* TTD lampiran */}
+          <div className="signature mt-10 ml-auto w-80">
+            <p className="m-0">Kepala Balai,</p>
+            <div className="ttd-placeholder mt-4 h-28 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+            <p className="m-0 font-bold">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>
+            <p className="m-0">NIP. 19740514 199903 1 001</p>
+          </div>
+        </div>
+      </article>
     </div>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -1008,14 +1008,15 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             font-size: 11pt; line-height: 1.4; margin: 0; padding: 0;
           }
           .sk-page {
-            width: 210mm; min-height: 297mm; margin: 0 auto;
-            padding: 5mm 20mm 14mm; box-shadow: none !important;
+            width: 210mm; margin: 0 auto;
+            padding: 5mm 20mm 28mm; box-shadow: none !important;
             page-break-after: always;
           }
           .sk-page:last-child { page-break-after: auto; }
           .sk-kop { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; margin-bottom: 4px; text-align: center; }
           .sk-kop img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
           .sk-body { width: 166mm; margin-left: auto; margin-right: auto; }
+          .sk-label-bold { font-weight: bold; }
           .sk-no-print { display: none !important; }
           .sk-asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
           .sk-asset-table th, .sk-asset-table td { border: 1px solid #000; padding: 0.25rem; }
@@ -1031,7 +1032,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
 
       {/* ── HALAMAN 1: KOP + Judul + Menimbang + Mengingat ── */}
       <article
-        className="sk-page mx-auto min-h-100 max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        className="sk-page mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
         style={pageStyle}
       >
         <div className="sk-kop" style={{ marginTop: "-5mm", marginLeft: "-16mm", marginRight: "-16mm", marginBottom: "4px", textAlign: "center" }}>
@@ -1104,7 +1105,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
 
       {/* ── HALAMAN 2: MEMUTUSKAN + Menetapkan + KESATU/KEDUA/KETIGA + TTD + Tembusan ── */}
       <article
-        className="sk-page mx-auto min-h-100 max-w-[210mm] bg-white px-24 py-12 text-black shadow-xl ring-1 ring-zinc-200"
+        className="sk-page mx-auto max-w-[210mm] bg-white px-24 py-12 text-black shadow-xl ring-1 ring-zinc-200"
         style={pageStyle}
       >
         <div className="sk-page2-body sk-body mx-auto w-[166mm]" style={{ paddingTop: "16mm" }}>
@@ -1162,7 +1163,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
 
       {/* ── HALAMAN 3: Lampiran — Tabel Daftar Penghentian ── */}
       <article
-        className="sk-page mx-auto min-h-100 max-w-[210mm] bg-white px-24 py-12 text-black shadow-xl ring-1 ring-zinc-200"
+        className="sk-page mx-auto max-w-[210mm] bg-white px-24 py-12 text-black shadow-xl ring-1 ring-zinc-200"
         style={pageStyle}
       >
         <div className="sk-body mx-auto w-[166mm]">

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -364,7 +364,7 @@ export default function BmnAuctionCandidatesPage() {
             p { margin: 0; padding: 0; }
             .sk-page {
               width: 210mm; min-height: 297mm;
-              margin: 0 auto; padding: 5mm 20mm 14mm;
+              margin: 0 auto; padding: 5mm 20mm 28mm;
               page-break-after: always;
             }
             .sk-page:last-child { page-break-after: auto; }
@@ -380,6 +380,7 @@ export default function BmnAuctionCandidatesPage() {
               margin-top: 10px; text-align: center; font-weight: bold; line-height: 1.3;
             }
             .sk-title-nomor { font-weight: normal; }
+            .sk-title-tentang { margin-top: 10px; }
             /* Sub-judul (DENGAN RAHMAT, KEPALA BALAI) */
             .sk-subtitle {
               width: 166mm; margin-left: auto; margin-right: auto;
@@ -1040,7 +1041,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
           <p className="m-0">KEPUTUSAN KEPALA BALAI</p>
           <p className="m-0">KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR</p>
           <p className="sk-title-nomor m-0 font-normal">Nomor : {skNumberText}</p>
-          <p className="m-0 mt-2">TENTANG</p>
+          <p className="sk-title-tentang m-0 mt-4">TENTANG</p>
           <p className="m-0">PENGHENTIAN PENGGUNAAN BARANG MILIK NEGARA</p>
           <p className="m-0">PADA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR,</p>
         </div>

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -394,6 +394,9 @@ export default function BmnAuctionCandidatesPage() {
             td { vertical-align: top; padding: 0; }
             /* Label bold: Menimbang, Mengingat, Menetapkan, KESATU, KEDUA, KETIGA */
             .sk-label-bold { font-weight: bold; }
+            /* Mengingat list — boleh paginate antar item, tapi tiap item tidak terpotong */
+            .sk-mengingat-table { break-inside: auto !important; page-break-inside: auto !important; }
+            .sk-mengingat-row { break-inside: avoid !important; page-break-inside: avoid !important; }
             /* Halaman 2 */
             .sk-page2-body { width: 166mm; margin-left: auto; margin-right: auto; padding-top: 16mm; }
             .sk-memutuskan { text-align: center; font-weight: bold; margin-bottom: 12px; }
@@ -1017,6 +1020,8 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
           .sk-kop img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
           .sk-body { width: 166mm; margin-left: auto; margin-right: auto; }
           .sk-label-bold { font-weight: bold; }
+          .sk-mengingat-table { break-inside: auto !important; page-break-inside: auto !important; }
+          .sk-mengingat-row { break-inside: avoid !important; page-break-inside: avoid !important; }
           .sk-no-print { display: none !important; }
           .sk-asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
           .sk-asset-table th, .sk-asset-table td { border: 1px solid #000; padding: 0.25rem; }
@@ -1056,22 +1061,22 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR,
           </p>
 
-          <table className="mt-4 w-full" style={{ borderCollapse: "collapse" }}>
+          <table className="sk-mengingat-table mt-4 w-full" style={{ borderCollapse: "collapse" }}>
             <tbody>
               {/* Menimbang */}
-              <tr>
+              <tr className="sk-mengingat-row">
                 <td className="sk-label-bold" style={{ width: "28mm", verticalAlign: "top" }}>Menimbang</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top" }}>:</td>
                 <td style={{ verticalAlign: "top" }}>
-                  <table className="w-full" style={{ borderCollapse: "collapse" }}>
+                  <table className="sk-mengingat-table w-full" style={{ borderCollapse: "collapse" }}>
                     <tbody>
-                      <tr>
+                      <tr className="sk-mengingat-row">
                         <td style={{ width: "6mm", verticalAlign: "top" }}>a.</td>
                         <td style={{ verticalAlign: "top", textAlign: "justify" }}>
                           bahwa terdapat Barang Milik Negara pada Balai Konservasi Sumber Daya Alam Kalimantan Timur berupa Alat Angkutan Bermotor dalam keadaan rusak berat dan tidak ekonomis lagi untuk digunakan;
                         </td>
                       </tr>
-                      <tr>
+                      <tr className="sk-mengingat-row">
                         <td style={{ width: "6mm", verticalAlign: "top", paddingTop: "0.5rem" }}>b.</td>
                         <td style={{ verticalAlign: "top", paddingTop: "0.5rem", textAlign: "justify" }}>
                           bahwa sehubungan dengan hal tersebut diatas, dipandang perlu untuk menerbitkan Keputusan Kepala Balai Konservasi Sumber Daya Alam Kalimantan Timur tentang Penghentian Penggunaan Barang Milik Negara.
@@ -1082,14 +1087,14 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
                 </td>
               </tr>
               {/* Mengingat */}
-              <tr>
+              <tr className="sk-mengingat-row">
                 <td className="sk-label-bold" style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.75rem" }}>Mengingat</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.75rem" }}>:</td>
                 <td style={{ verticalAlign: "top", paddingTop: "0.75rem" }}>
-                  <table className="w-full" style={{ borderCollapse: "collapse" }}>
+                  <table className="sk-mengingat-table w-full" style={{ borderCollapse: "collapse" }}>
                     <tbody>
                       {mengingat.map((item, i) => (
-                        <tr key={i}>
+                        <tr className="sk-mengingat-row" key={i}>
                           <td style={{ width: "6mm", verticalAlign: "top", paddingTop: i > 0 ? "0.35rem" : "0", paddingBottom: 0 }}>{i + 1}.</td>
                           <td style={{ verticalAlign: "top", paddingTop: i > 0 ? "0.35rem" : "0", paddingBottom: 0, textAlign: "justify" }}>{item}</td>
                         </tr>

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -373,13 +373,18 @@ export default function BmnAuctionCandidatesPage() {
             table { border-collapse: collapse; }
             .sk-section-table { width: 100%; }
             .sk-section-table td { vertical-align: top; padding: 0.1rem 0; }
-            .asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
-            .asset-table th, .asset-table td { border: 1px solid #000; padding: 0.25rem; }
-            .asset-table td.text-left { text-align: left; }
-            .asset-table td.text-right { text-align: right; }
-            .attachment-meta .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
-            .attachment-meta .meta-label { white-space: nowrap; }
-            .attachment-meta .meta-colon { text-align: center; }
+            .sk-asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
+            .sk-asset-table th, .sk-asset-table td { border: 1px solid #000; padding: 0.25rem; }
+            .sk-asset-table td.text-left { text-align: left; }
+            .sk-asset-table td.text-right { text-align: right; }
+            .sk-attachment-meta { width: 109mm; margin-left: auto; text-align: left; }
+            .sk-attachment-meta .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
+            .sk-attachment-meta .meta-label { white-space: nowrap; }
+            .sk-attachment-meta .meta-colon { text-align: center; }
+            .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
+            .meta-label { white-space: nowrap; }
+            .meta-colon { text-align: center; }
+            .signature { width: 20rem; margin-left: auto; }
             .signature p { margin: 0; padding: 0; line-height: 1.15; }
             .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; }
           </style>
@@ -977,8 +982,8 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             page-break-after: always;
           }
           .sk-page:last-child { page-break-after: auto; }
-          .sk-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; }
-          .sk-header img { max-width: 196mm !important; }
+          .sk-kop { margin-top: -0.25cm; margin-left: 0; margin-right: -0.95cm; margin-bottom: 2px; overflow: visible; }
+          .sk-kop img { width: 18.8cm !important; height: auto !important; display: block; }
           .sk-body { width: 166mm; margin-left: auto; margin-right: auto; }
           .sk-no-print { display: none !important; }
           .sk-asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
@@ -998,9 +1003,9 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
         className="sk-page mx-auto min-h-100 max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
         style={pageStyle}
       >
-        <div className="sk-header -mx-18 text-center">
+        <div className="sk-kop" style={{ marginTop: "-10px", marginBottom: "2px", marginLeft: "-1.5cm", marginRight: "-1cm" }}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/header-terbaru.png" alt="Kop Surat" className="mx-auto h-auto w-full max-w-[196mm]" />
+          <img src="/header-new.png" alt="Kop Surat" style={{ width: "18.8cm", height: "auto", display: "block" }} />
         </div>
 
         <div className="sk-body mx-auto mt-3 w-[166mm] text-center font-bold leading-snug">

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -355,35 +355,66 @@ export default function BmnAuctionCandidatesPage() {
           <title>SK Penghentian Penggunaan BMN</title>
           <style>
             @page { size: A4; margin: 0; }
+            * { box-sizing: border-box; }
             body {
               margin: 0; padding: 0; background: white; color: black;
               font-family: 'Bookman Old Style', Georgia, serif;
               font-size: 11pt; line-height: 1.4;
             }
+            p { margin: 0; padding: 0; }
             .sk-page {
-              width: 210mm; min-height: 297mm; box-sizing: border-box;
+              width: 210mm; min-height: 297mm;
               margin: 0 auto; padding: 5mm 20mm 14mm;
               page-break-after: always;
             }
             .sk-page:last-child { page-break-after: auto; }
+            /* KOP */
             .sk-kop {
               margin-top: -5mm; margin-left: -16mm; margin-right: -16mm;
-              margin-bottom: 4px; text-align: center;
+              margin-bottom: 6px; text-align: center;
             }
             .sk-kop img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
+            /* Judul SK — halaman 1 */
+            .sk-title {
+              width: 166mm; margin-left: auto; margin-right: auto;
+              margin-top: 10px; text-align: center; font-weight: bold; line-height: 1.3;
+            }
+            .sk-title-nomor { font-weight: normal; }
+            /* Sub-judul (DENGAN RAHMAT, KEPALA BALAI) */
+            .sk-subtitle {
+              width: 166mm; margin-left: auto; margin-right: auto;
+              margin-top: 16px;
+            }
+            .sk-subtitle p { text-align: center; font-weight: bold; }
+            .sk-subtitle p + p { margin-top: 6px; }
+            /* Tabel Menimbang/Mengingat/Memutuskan */
             .sk-body { width: 166mm; margin-left: auto; margin-right: auto; }
-            table { border-collapse: collapse; }
-            .sk-asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
-            .sk-asset-table th, .sk-asset-table td { border: 1px solid #000; padding: 0.25rem; }
-            .sk-asset-table td.text-left { text-align: left; }
-            .sk-asset-table td.text-right { text-align: right; }
+            table { border-collapse: collapse; width: 100%; }
+            td { vertical-align: top; }
+            /* Halaman 2 */
+            .sk-page2-body { width: 166mm; margin-left: auto; margin-right: auto; padding-top: 16mm; }
+            .sk-memutuskan { text-align: center; font-weight: bold; text-decoration: underline; margin-bottom: 12px; }
+            /* TTD block */
+            .sk-ttd {
+              width: 20rem; margin-left: auto; margin-top: 3rem;
+            }
+            .sk-ttd p { margin: 0; padding: 0; line-height: 1.3; }
+            .ttd-placeholder { height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; }
+            /* Tembusan — tanpa spasi antar item */
+            .sk-tembusan { margin-top: 2rem; }
+            .sk-tembusan p { margin: 0; padding: 0; line-height: 1.5; }
+            /* Halaman 3 lampiran */
             .sk-attachment-meta { width: 109mm; margin-left: auto; text-align: left; }
             .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
             .meta-label { white-space: nowrap; }
             .meta-colon { text-align: center; }
-            .signature { width: 20rem; margin-left: auto; }
-            .signature p { margin: 0; padding: 0; line-height: 1.15; }
-            .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; }
+            .sk-lampiran-title { text-align: center; font-weight: bold; line-height: 1.3; margin-top: 1.5rem; margin-bottom: 0.75rem; }
+            .sk-asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
+            .sk-asset-table th, .sk-asset-table td { border: 1px solid #000; padding: 0.25rem; }
+            .sk-asset-table td.text-left { text-align: left; }
+            .sk-asset-table td.text-right { text-align: right; }
+            .sk-lampiran-ttd { width: 20rem; margin-left: auto; margin-top: 2.5rem; }
+            .sk-lampiran-ttd p { margin: 0; padding: 0; line-height: 1.3; }
           </style>
         </head>
         <body>${printContent.innerHTML}</body>
@@ -1005,16 +1036,16 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
           <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
         </div>
 
-        <div className="sk-body mx-auto mt-3 w-[166mm] text-center font-bold leading-snug">
+        <div className="sk-title mx-auto mt-3 w-[166mm] text-center font-bold leading-snug">
           <p className="m-0">KEPUTUSAN KEPALA BALAI</p>
           <p className="m-0">KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR</p>
-          <p className="m-0 font-normal">Nomor : {skNumberText}</p>
+          <p className="sk-title-nomor m-0 font-normal">Nomor : {skNumberText}</p>
           <p className="m-0 mt-2">TENTANG</p>
           <p className="m-0">PENGHENTIAN PENGGUNAAN BARANG MILIK NEGARA</p>
           <p className="m-0">PADA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR,</p>
         </div>
 
-        <div className="sk-body mx-auto mt-5 w-[166mm]">
+        <div className="sk-subtitle sk-body mx-auto mt-5 w-[166mm]">
           <p className="text-center font-bold">DENGAN RAHMAT TUHAN YANG MAHA ESA</p>
           <p className="mt-2 text-center font-bold">
             KEPALA BALAI<br />
@@ -1073,8 +1104,8 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
         className="sk-page mx-auto min-h-100 max-w-[210mm] bg-white px-24 py-12 text-black shadow-xl ring-1 ring-zinc-200"
         style={pageStyle}
       >
-        <div className="sk-body mx-auto w-[166mm]">
-          <p className="text-center font-bold underline">MEMUTUSKAN</p>
+        <div className="sk-page2-body sk-body mx-auto w-[166mm]" style={{ paddingTop: "16mm" }}>
+          <p className="sk-memutuskan text-center font-bold underline">MEMUTUSKAN</p>
 
           <table className="mt-4 w-full" style={{ borderCollapse: "collapse" }}>
             <tbody>
@@ -1109,7 +1140,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             </tbody>
           </table>
 
-          <div className="signature mt-12 ml-auto w-80">
+          <div className="sk-ttd signature mt-12 ml-auto w-80">
             <p className="m-0">Ditetapkan di : Samarinda</p>
             <p className="m-0">Pada tanggal : {formatDateLong(today)}</p>
             <p className="m-0 mt-3">Kepala Balai,</p>
@@ -1118,7 +1149,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             <p className="m-0">NIP. 19740514 199903 1 001</p>
           </div>
 
-          <div className="mt-10">
+          <div className="sk-tembusan mt-10">
             <p className="m-0">Tembusan :</p>
             <p className="m-0">1.&nbsp; Kepala Biro Umum Kementerian Kehutanan</p>
             <p className="m-0">2.&nbsp; Sekretaris Direktorat Jenderal KSDAE</p>
@@ -1150,7 +1181,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             </div>
           </div>
 
-          <p className="mt-6 text-center font-bold leading-snug">
+          <p className="sk-lampiran-title mt-6 text-center font-bold leading-snug">
             DAFTAR PENGHENTIAN PENGGUNAAN BARANG MILIK NEGARA<br />
             PADA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR
           </p>
@@ -1193,7 +1224,7 @@ function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAsset[]; s
             </tbody>
           </table>
 
-          <div className="signature mt-10 ml-auto w-80">
+          <div className="sk-lampiran-ttd signature mt-10 ml-auto w-80">
             <p className="m-0">Kepala Balai,</p>
             <div className="ttd-placeholder mt-4 h-28 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
             <p className="m-0 font-bold">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>


### PR DESCRIPTION
Closes #338

## Summary
- Add/finalize SK Penghentian Penggunaan BMN print workflow on `/bmn/auction-candidates`.
- Fix SK print pagination for Menimbang/Mengingat so continuation happens per item with BSrE footer space.
- Stabilize SK lampiran pagination: first page max 15 assets, continuation max 17 assets, final page max 10 assets with Jumlah + TTD.
- Align screen preview styling with print styling.
- Update docs/HANDOFF.md and docs/progress.md for Issue #338 status.

## Validation
- `npx eslint src/app/bmn/auction-candidates/page.tsx --max-warnings=0`
- `npx tsc --noEmit`
- `npm run build`