### PR TITLE
fix(bmn): paginate BA lampiran by measured rows (#344)

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -112,15 +112,19 @@ git push origin main
 - [x] Issue #338: Add SK Penghentian Penggunaan BMN document (KOP+Menimbang+Mengingat, MEMUTUSKAN+TTD+Tembusan, Lampiran tabel). Branch `issue/338-sk-penghentian-bmn` siap PR.
 - [x] Issue #338: Fix print layout SK Penghentian — margin bawah semua halaman untuk BSrE footer, Mengingat paginate per nomor, TTD/tembusan rapi, dan lampiran paginate stabil.
 - [x] Issue #338: PR #339 merged ke `main` (merge commit `1ddfb1a`). Deploy ke SSH ditunda.
+- [x] Issue #340: Refactor auction-candidates page into smaller components. PR #341 merged.
+- [x] Issue #342: Editable BA builder + toggle BA/SK visibility + editable KAP field. PR #343 merged.
+- [ ] Issue #344 (IN PROGRESS): BA Koreksi lampiran pagination + margin bawah. Branch `issue/344-ba-lampiran-pagination`. TTD masih turun ke halaman sendiri — perlu fix.
 
 | Field | Value |
 |-------|-------|
-| **Issue Terakhir Selesai** | Issue #338: SK Penghentian Penggunaan BMN — PR #339 merged |
-| **Issue Selanjutnya** | Lanjut fitur di /bmn/auction-candidates atau deploy ke SSH |
-| **Branch Aktif** | `main` |
-| **Commit Terakhir** | `1ddfb1a` Merge pull request #339 from tegaranugrah1/issue/338-sk-penghentian-bmn |
+| **Issue Terakhir Selesai** | Issue #342: Editable BA builder (PR #343 merged) |
+| **Issue Sedang Dikerjakan** | Issue #344: BA lampiran pagination — branch `issue/344-ba-lampiran-pagination` |
+| **Branch Aktif** | `issue/344-ba-lampiran-pagination` |
+| **Commit Terakhir di Branch** | `f33ab14` |
+| **Status** | Natural browser pagination sudah diterapkan. Masalah: TTD turun ke halaman sendiri karena blok terlalu besar untuk sisa halaman. `break-inside: avoid` sudah dihapus dari signature tapi belum ditest. |
 | **Model Terakhir** | Kiro |
-| **Timestamp** | 2026-05-20T12:00:00+08:00 |
+| **Timestamp** | 2026-05-20T14:00:00+08:00 |
 | **Status Print SK** | DONE: preview dan print PDF OK; margin bawah BSrE aman; Mengingat paginate per item; lampiran paginate sesuai aturan 15/17/max-10 |
 | **Model Terakhir** | Codex |
 | **Timestamp** | 2026-05-20T13:00:00+08:00 |

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,51 @@
+# Progress - Phase 46: BA Koreksi Lampiran Pagination (IN PROGRESS)
+
+> Document updated: 2026-05-20
+> Status: **IN PROGRESS** 🔄
+
+---
+
+## Issue #344: BA Koreksi Lampiran Pagination & Bottom Margin
+
+### Completed:
+- [x] **Issue Created**: Issue #344.
+- [x] **Branch**: `issue/344-ba-lampiran-pagination` aktif.
+- [x] **`@page { margin-bottom: 28mm }`**: Margin bawah semua halaman untuk BSrE footer.
+- [x] **Natural browser pagination**: Hapus explicit pagination logic, biarkan browser paginate tabel secara natural.
+- [x] **`break-inside: avoid` per `<tr>`**: Setiap row tabel tidak terpotong di tengah.
+- [x] **`display: table-header-group`**: Header tabel otomatis repeat di setiap halaman baru.
+- [x] **Sebelum + Sesudah unified**: Satu artikel, mengalir natural tanpa page break buatan.
+- [x] **`break-inside: avoid` dihapus dari signature**: Agar TTD tidak memaksa pindah halaman.
+
+### Pending / Known Issues:
+- [ ] **TTD masih turun ke halaman sendiri** — `break-inside: avoid` sudah dihapus tapi belum ditest apakah fix. Masalah: blok TTD (Kepala Balai + placeholder 112px + nama + NIP) terlalu besar untuk sisa halaman setelah tabel terakhir.
+- [ ] **Solusi alternatif yang mungkin**: Kurangi `margin-top` signature dari `mt-12` ke `mt-6`, atau kurangi tinggi placeholder TTD saat print saja (bukan di preview).
+- [ ] **PR belum dibuat** — menunggu fix TTD selesai.
+
+### Key Files:
+- `frontend/src/app/bmn/auction-candidates/_components/BaKoreksiDocument.tsx`
+
+### Validation:
+- [x] `npx eslint --max-warnings=0` clean
+- [x] `npx tsc --noEmit` clean
+
+---
+
+# Progress - Phase 45: Editable BA Builder + Refactor
+
+> Document updated: 2026-05-20
+> Status: **MERGED** ✅
+
+---
+
+## Issue #340: Refactor Auction Candidates Page
+- [x] PR #341 merged. Split 1518-line page.tsx into 6 files.
+
+## Issue #342: Editable BA Builder + Toggle BA/SK
+- [x] PR #343 merged. BA Koreksi editable (contentEditable), KAP field editable, toggle BA/SK.
+
+---
+
 # Progress - Phase 44: SK Penghentian Penggunaan BMN
 
 > Document updated: 2026-05-20

--- a/frontend/src/app/bmn/auction-candidates/_components/BaKoreksiDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/BaKoreksiDocument.tsx
@@ -13,9 +13,15 @@ const BA_ATTACHMENT_PAGE_HEIGHT_MM = 269;
 const BA_ATTACHMENT_FALLBACK_CHUNK_SIZE = 8;
 const BA_ATTACHMENT_MIN_ROWS_PER_PAGE = 1;
 
-type BaLampiranPage = {
+type BaLampiranSection = {
+  mode: "before" | "after";
+  title: string;
   assets: AuctionAsset[];
   startIndex: number;
+};
+
+type BaLampiranPage = {
+  sections: BaLampiranSection[];
   showMeta: boolean;
   showSignature: boolean;
 };
@@ -208,28 +214,47 @@ function AttachmentSignature() {
   );
 }
 
+function BaLampiranSectionBlock({
+  section,
+  measureKey,
+}: {
+  section: BaLampiranSection;
+  measureKey?: string;
+}) {
+  return (
+    <>
+      <p className="ba-section-title mt-6 mb-2 text-[12px] font-semibold">{section.title}</p>
+      <AssetConditionTable
+        assets={section.assets}
+        mode={section.mode}
+        startIndex={section.startIndex}
+        measureKey={measureKey}
+      />
+    </>
+  );
+}
+
 function BaLampiranPageContent({
-  assets,
-  startIndex,
-  showMeta,
-  showSignature,
+  page,
   baNumberText,
   today,
-}: BaLampiranPage & {
+}: {
+  page: BaLampiranPage;
   baNumberText: string;
   today: Date;
 }) {
   return (
     <>
-      {showMeta ? <AttachmentMeta baNumberText={baNumberText} today={today} /> : <div className="ba-continuation-spacer" />}
+      {page.showMeta ? <AttachmentMeta baNumberText={baNumberText} today={today} /> : <div className="ba-continuation-spacer" />}
 
-      <p className="ba-section-title mt-6 mb-2 text-[12px] font-semibold">I. Sebelum</p>
-      <AssetConditionTable assets={assets} mode="before" startIndex={startIndex} />
+      {page.sections.map((section) => (
+        <BaLampiranSectionBlock
+          key={`${section.mode}-${section.startIndex}`}
+          section={section}
+        />
+      ))}
 
-      <p className="ba-section-title mt-6 mb-2 text-[12px] font-semibold">II. Sesudah</p>
-      <AssetConditionTable assets={assets} mode="after" startIndex={startIndex} />
-
-      {showSignature ? <AttachmentSignature /> : null}
+      {page.showSignature ? <AttachmentSignature /> : null}
     </>
   );
 }
@@ -244,74 +269,124 @@ function getOuterHeight(element: Element | null) {
   return rect.height + marginTop + marginBottom;
 }
 
-function fitAssetCount(rowHeights: number[], startIndex: number, availableHeight: number) {
+function fitAssetCount(rowHeights: number[], startIndex: number, availableHeight: number, allowSingleOverflow = false) {
   let usedHeight = 0;
   let count = 0;
 
   for (let index = startIndex; index < rowHeights.length; index += 1) {
     const nextHeight = rowHeights[index] || 0;
-    if (count >= BA_ATTACHMENT_MIN_ROWS_PER_PAGE && usedHeight + nextHeight > availableHeight) {
+    if (usedHeight + nextHeight > availableHeight) {
+      if (count === 0 && allowSingleOverflow) return BA_ATTACHMENT_MIN_ROWS_PER_PAGE;
       break;
     }
     usedHeight += nextHeight;
     count += 1;
   }
 
-  return Math.max(BA_ATTACHMENT_MIN_ROWS_PER_PAGE, count);
+  return count;
 }
 
 function buildMeasuredLampiranPages({
   assets,
-  rowHeights,
-  firstBaseHeight,
-  continuationBaseHeight,
+  beforeRowHeights,
+  afterRowHeights,
+  metaHeight,
+  continuationSpacerHeight,
+  sectionBaseHeight,
   signatureHeight,
   pageHeight,
 }: {
   assets: AuctionAsset[];
-  rowHeights: number[];
-  firstBaseHeight: number;
-  continuationBaseHeight: number;
+  beforeRowHeights: number[];
+  afterRowHeights: number[];
+  metaHeight: number;
+  continuationSpacerHeight: number;
+  sectionBaseHeight: number;
   signatureHeight: number;
   pageHeight: number;
 }) {
   if (assets.length === 0) return [];
 
   const pages: BaLampiranPage[] = [];
-  let startIndex = 0;
+  let currentPage: BaLampiranPage | null = null;
+  let currentHeight = 0;
 
-  while (startIndex < assets.length) {
-    const isFirstPage = pages.length === 0;
-    const baseHeight = isFirstPage ? firstBaseHeight : continuationBaseHeight;
-    const remainingCount = assets.length - startIndex;
-    const finalAvailableHeight = pageHeight - baseHeight - signatureHeight;
-    const finalFitCount = fitAssetCount(rowHeights, startIndex, finalAvailableHeight);
+  const startPage = () => {
+    const showMeta = pages.length === 0;
+    currentPage = { sections: [], showMeta, showSignature: false };
+    currentHeight = showMeta ? metaHeight : continuationSpacerHeight;
+    pages.push(currentPage);
+  };
 
-    if (finalFitCount >= remainingCount) {
-      pages.push({
-        assets: assets.slice(startIndex),
+  const addSection = (mode: "before" | "after", title: string, rowHeights: number[]) => {
+    let startIndex = 0;
+
+    while (startIndex < assets.length) {
+      if (!currentPage) startPage();
+
+      const page = currentPage!;
+      const isNewSectionOnPage = page.sections.length === 0 || page.sections[page.sections.length - 1]?.mode !== mode;
+      const baseHeight = isNewSectionOnPage ? sectionBaseHeight : 0;
+      const remainingCount = assets.length - startIndex;
+      const isAfterSection = mode === "after";
+      const finalAvailableHeight = pageHeight - currentHeight - baseHeight - signatureHeight;
+      const finalFitCount = isAfterSection
+        ? fitAssetCount(rowHeights, startIndex, finalAvailableHeight, page.sections.length === 0)
+        : 0;
+
+      if (isAfterSection && finalFitCount >= remainingCount) {
+        page.sections.push({
+          mode,
+          title,
+          assets: assets.slice(startIndex),
+          startIndex,
+        });
+        page.showSignature = true;
+        currentPage = null;
+        currentHeight = 0;
+        return;
+      }
+
+      if (isAfterSection && remainingCount <= BA_ATTACHMENT_MIN_ROWS_PER_PAGE && page.sections.length > 0) {
+        currentPage = null;
+        currentHeight = 0;
+        continue;
+      }
+
+      const regularAvailableHeight = pageHeight - currentHeight - baseHeight;
+      let regularFitCount = fitAssetCount(rowHeights, startIndex, regularAvailableHeight, page.sections.length === 0);
+
+      if (regularFitCount === 0 && page.sections.length > 0) {
+        currentPage = null;
+        currentHeight = 0;
+        continue;
+      }
+
+      if (isAfterSection) {
+        regularFitCount = Math.min(remainingCount - BA_ATTACHMENT_MIN_ROWS_PER_PAGE, regularFitCount);
+      } else {
+        regularFitCount = Math.min(remainingCount, regularFitCount);
+      }
+
+      const safeCount = Math.max(BA_ATTACHMENT_MIN_ROWS_PER_PAGE, regularFitCount);
+      page.sections.push({
+        mode,
+        title,
+        assets: assets.slice(startIndex, startIndex + safeCount),
         startIndex,
-        showMeta: isFirstPage,
-        showSignature: true,
       });
-      break;
+      currentHeight += baseHeight + rowHeights.slice(startIndex, startIndex + safeCount).reduce((total, height) => total + height, 0);
+      startIndex += safeCount;
+
+      if (startIndex < assets.length) {
+        currentPage = null;
+        currentHeight = 0;
+      }
     }
+  };
 
-    const regularAvailableHeight = pageHeight - baseHeight;
-    const regularFitCount = Math.min(
-      remainingCount - BA_ATTACHMENT_MIN_ROWS_PER_PAGE,
-      fitAssetCount(rowHeights, startIndex, regularAvailableHeight),
-    );
-    const safeCount = Math.max(BA_ATTACHMENT_MIN_ROWS_PER_PAGE, regularFitCount);
-
-    pages.push({
-      assets: assets.slice(startIndex, startIndex + safeCount),
-      startIndex,
-      showMeta: isFirstPage,
-      showSignature: false,
-    });
-    startIndex += safeCount;
-  }
+  addSection("before", "I. Sebelum", beforeRowHeights);
+  addSection("after", "II. Sesudah", afterRowHeights);
 
   return pages;
 }
@@ -323,8 +398,20 @@ function buildFallbackLampiranPages(assets: AuctionAsset[]) {
   for (let startIndex = 0; startIndex < assets.length; startIndex += BA_ATTACHMENT_FALLBACK_CHUNK_SIZE) {
     const pageAssets = assets.slice(startIndex, startIndex + BA_ATTACHMENT_FALLBACK_CHUNK_SIZE);
     pages.push({
-      assets: pageAssets,
-      startIndex,
+      sections: [
+        {
+          mode: "before",
+          title: "I. Sebelum",
+          assets: pageAssets,
+          startIndex,
+        },
+        {
+          mode: "after",
+          title: "II. Sesudah",
+          assets: pageAssets,
+          startIndex,
+        },
+      ],
       showMeta: startIndex === 0,
       showSignature: startIndex + pageAssets.length >= assets.length,
     });
@@ -353,14 +440,24 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
     }
 
     const pageHeight = root.querySelector("[data-ba-measure='page']")?.getBoundingClientRect().height || 0;
-    const firstBaseHeight = getOuterHeight(root.querySelector("[data-ba-measure='first-base']"));
-    const continuationBaseHeight = getOuterHeight(root.querySelector("[data-ba-measure='continuation-base']"));
+    const metaHeight = getOuterHeight(root.querySelector("[data-ba-measure='meta']"));
+    const continuationSpacerHeight = getOuterHeight(root.querySelector("[data-ba-measure='continuation-spacer']"));
+    const sectionBaseHeight = getOuterHeight(root.querySelector("[data-ba-measure='section-base']"));
     const signatureHeight = getOuterHeight(root.querySelector("[data-ba-measure='signature']"));
     const beforeRows = Array.from(root.querySelectorAll("[data-ba-measure-table='before'] tbody tr"));
     const afterRows = Array.from(root.querySelectorAll("[data-ba-measure-table='after'] tbody tr"));
-    const rowHeights = assets.map((_, index) => getOuterHeight(beforeRows[index]) + getOuterHeight(afterRows[index]));
+    const beforeRowHeights = assets.map((_, index) => getOuterHeight(beforeRows[index]));
+    const afterRowHeights = assets.map((_, index) => getOuterHeight(afterRows[index]));
 
-    if (!pageHeight || !firstBaseHeight || !continuationBaseHeight || !signatureHeight || rowHeights.some((height) => height <= 0)) {
+    if (
+      !pageHeight ||
+      !metaHeight ||
+      !continuationSpacerHeight ||
+      !sectionBaseHeight ||
+      !signatureHeight ||
+      beforeRowHeights.some((height) => height <= 0) ||
+      afterRowHeights.some((height) => height <= 0)
+    ) {
       setLampiranPages(fallbackLampiranPages);
       return;
     }
@@ -368,9 +465,11 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
     setLampiranPages(
       buildMeasuredLampiranPages({
         assets,
-        rowHeights,
-        firstBaseHeight,
-        continuationBaseHeight,
+        beforeRowHeights,
+        afterRowHeights,
+        metaHeight,
+        continuationSpacerHeight,
+        sectionBaseHeight,
         signatureHeight,
         pageHeight,
       }),
@@ -604,50 +703,44 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
         </div>
       </article>
 
-      {/* Lampiran BA: measured pages keep Sebelum/Sesudah pairs and final signature together */}
+      {/* Lampiran BA: measured pages finish Sebelum first, then Sesudah, with final signature kept together */}
       <div ref={measurementRef} className="ba-measurement" aria-hidden="true">
         <div data-ba-measure="page" className="ba-measure-page" />
-        <div className="ba-lampiran-body mx-auto w-[166mm]" data-ba-measure="first-base">
-          <BaLampiranPageContent
-            assets={[]}
-            startIndex={0}
-            showMeta
-            showSignature={false}
-            baNumberText={baNumberText}
-            today={today}
-          />
+        <div data-ba-measure="meta">
+          <AttachmentMeta baNumberText={baNumberText} today={today} />
         </div>
-        <div className="ba-lampiran-body mx-auto w-[166mm]" data-ba-measure="continuation-base">
-          <BaLampiranPageContent
-            assets={[]}
-            startIndex={0}
-            showMeta={false}
-            showSignature={false}
-            baNumberText={baNumberText}
-            today={today}
+        <div data-ba-measure="continuation-spacer">
+          <div className="ba-continuation-spacer" />
+        </div>
+        <div className="ba-lampiran-body mx-auto w-[166mm]" data-ba-measure="section-base">
+          <BaLampiranSectionBlock
+            section={{ mode: "before", title: "I. Sebelum", assets: [], startIndex: 0 }}
           />
         </div>
         <div data-ba-measure="signature">
           <AttachmentSignature />
         </div>
         <div className="ba-lampiran-body mx-auto w-[166mm]">
-          <AssetConditionTable assets={assets} mode="before" measureKey="before" />
-          <AssetConditionTable assets={assets} mode="after" measureKey="after" />
+          <BaLampiranSectionBlock
+            section={{ mode: "before", title: "I. Sebelum", assets, startIndex: 0 }}
+            measureKey="before"
+          />
+          <BaLampiranSectionBlock
+            section={{ mode: "after", title: "II. Sesudah", assets, startIndex: 0 }}
+            measureKey="after"
+          />
         </div>
       </div>
 
-      {lampiranPages.map((page) => (
+      {lampiranPages.map((page, pageIndex) => (
         <article
-          key={`ba-lampiran-${page.startIndex}`}
+          key={`ba-lampiran-${pageIndex}`}
           className="ba-lampiran mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
           style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.25" }}
         >
           <div className="ba-lampiran-body mx-auto w-[166mm]">
             <BaLampiranPageContent
-              assets={page.assets}
-              startIndex={page.startIndex}
-              showMeta={page.showMeta}
-              showSignature={page.showSignature}
+              page={page}
               baNumberText={baNumberText}
               today={today}
             />

--- a/frontend/src/app/bmn/auction-candidates/_components/BaKoreksiDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/BaKoreksiDocument.tsx
@@ -23,7 +23,7 @@ export function handlePrintBa(orderedSelectedAssets: AuctionAsset[]) {
       <head>
         <title>BA Koreksi Kondisi BMN</title>
         <style>
-          @page { size: A4; margin: 0; }
+          @page { size: A4; margin: 0 0 28mm 0; }
           body {
             margin: 0;
             padding: 0;
@@ -33,20 +33,29 @@ export function handlePrintBa(orderedSelectedAssets: AuctionAsset[]) {
             font-size: 11pt;
             line-height: 1.25;
           }
+          p { margin: 0; padding: 0; }
+          article { margin: 0; }
           .ba-page {
             width: 210mm;
-            min-height: 297mm;
             box-sizing: border-box;
             margin: 0 auto;
-            padding: 5mm 20mm 14mm;
+            padding: 5mm 20mm 0;
             page-break-after: always;
           }
           .ba-page:last-child { page-break-after: auto; }
+          .ba-lampiran {
+            width: 210mm;
+            box-sizing: border-box;
+            margin: 0 auto;
+            padding: 5mm 20mm 0;
+            page-break-before: always;
+            break-before: page;
+          }
           .ba-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; text-align: center; }
           .ba-header img { width: 196mm !important; max-width: 196mm !important; height: auto !important; }
           .ba-body { width: 166mm; margin-left: auto; margin-right: auto; text-align: justify; text-justify: inter-word; }
           .ba-body p { text-align: justify; text-justify: inter-word; }
-          .ba-attachment { width: 166mm; margin-left: auto; margin-right: auto; padding-top: 2.5rem; }
+          .ba-lampiran-body { width: 166mm; margin-left: auto; margin-right: auto; }
           .ba-title { margin-top: 0.75rem; text-align: center; font-weight: 700; }
           .ba-title p { margin: 0; line-height: 1.2; }
           .ba-text-block { margin-top: 1rem; }
@@ -55,21 +64,24 @@ export function handlePrintBa(orderedSelectedAssets: AuctionAsset[]) {
           .identity-table td { padding: 0.125rem 0; }
           .identity-table .label-cell { width: 24mm; }
           .identity-table .colon-cell { width: 6mm; text-align: center; }
-          .asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; }
-          .asset-table th, .asset-table td { border: 1px solid #000; padding: 0.25rem; }
-          .asset-table td.text-left { text-align: left; }
-          .asset-table td.text-right { text-align: right; }
+          .ba-asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; break-inside: auto; page-break-inside: auto; }
+          .ba-asset-table thead { display: table-header-group; }
+          .ba-asset-table th, .ba-asset-table td { border: 1px solid #000; padding: 0.25rem; }
+          .ba-asset-table tr { break-inside: avoid; page-break-inside: avoid; }
+          .ba-asset-table td.text-left { text-align: left; }
+          .ba-asset-table td.text-right { text-align: right; }
+          .ba-section-title { font-size: 10pt; font-weight: 600; margin-bottom: 0.5rem; }
           .attachment-meta { width: 109mm; margin-left: auto; text-align: left; }
           .attachment-meta .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
           .attachment-meta .meta-label { white-space: nowrap; }
           .attachment-meta .meta-colon { text-align: center; }
           .attachment-meta .meta-value { min-width: 0; }
           .attachment-meta .lampiran-value { display: inline-block; max-width: 80mm; }
-          .signature { width: 20rem; margin-left: auto; }
+          .signature { width: 20rem; margin-left: auto; break-inside: auto; page-break-inside: auto; }
           .attachment-signature { margin-top: 3rem; }
           .signature p { margin: 0; padding: 0; line-height: 1.15; }
           .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; }
-          .ba-editable { outline: none; border-bottom: 1px dashed transparent; }
+          .ba-editable { outline: none; border-bottom: none !important; }
         </style>
       </head>
       <body>${printContent.innerHTML}</body>
@@ -79,6 +91,48 @@ export function handlePrintBa(orderedSelectedAssets: AuctionAsset[]) {
   printWindow.focus();
   setTimeout(() => printWindow.print(), 500);
 }
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function AssetConditionTable({ assets, mode }: { assets: AuctionAsset[]; mode: "before" | "after" }) {
+  return (
+    <table className="ba-asset-table mt-4 w-full border-collapse text-center" style={{ fontSize: "8.5pt" }}>
+      <thead>
+        <tr>
+          <th rowSpan={2} className="border border-black px-1 py-1">No.</th>
+          <th rowSpan={2} className="border border-black px-1 py-1">Kode Barang</th>
+          <th rowSpan={2} className="border border-black px-1 py-1">NUP</th>
+          <th rowSpan={2} className="border border-black px-1 py-1">Nama Barang</th>
+          <th rowSpan={2} className="border border-black px-1 py-1">Satuan</th>
+          <th rowSpan={2} className="border border-black px-1 py-1">Nilai Perolehan (Rp)</th>
+          <th colSpan={3} className="border border-black px-1 py-1">Kondisi</th>
+        </tr>
+        <tr>
+          <th className="border border-black px-1 py-1">Baik</th>
+          <th className="border border-black px-1 py-1">Rusak Ringan</th>
+          <th className="border border-black px-1 py-1">Rusak Berat</th>
+        </tr>
+      </thead>
+      <tbody>
+        {assets.map((asset, index) => (
+          <tr key={`${mode}-${asset.id}`}>
+            <td className="border border-black px-1 py-1">{index + 1}.</td>
+            <td className="border border-black px-1 py-1">{asset.kode_barang}</td>
+            <td className="border border-black px-1 py-1">{asset.nup}</td>
+            <td className="border border-black px-1 py-1 text-left">{asset.nama_barang}</td>
+            <td className="border border-black px-1 py-1">{asset.satuan || "Unit"}</td>
+            <td className="border border-black px-1 py-1 text-right">{formatPlainRupiah(asset.nilai_perolehan)}</td>
+            <td className="border border-black px-1 py-1">{mode === "before" ? 0 : 0}</td>
+            <td className="border border-black px-1 py-1">{mode === "before" ? 1 : 0}</td>
+            <td className="border border-black px-1 py-1">{mode === "after" ? 1 : 0}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
 
 export function CorrectionDocument({ assets, baNumber, baKap }: { assets: AuctionAsset[]; baNumber: string; baKap: string }) {
   const today = new Date();
@@ -102,6 +156,7 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
           border-bottom-color: #64748b;
         }
         @media print {
+          @page { size: A4; margin: 0 0 28mm 0; }
           body * { visibility: hidden; }
           .ba-print-root, .ba-print-root * { visibility: visible; }
           .ba-print-root {
@@ -119,29 +174,44 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
           }
           .ba-page {
             width: 210mm;
-            min-height: 297mm;
             margin: 0 auto;
-            padding: 5mm 20mm 14mm;
+            padding: 5mm 20mm 0;
             box-shadow: none !important;
             page-break-after: always;
+          }
+          .ba-page:last-child { page-break-after: auto; }
+          .ba-lampiran {
+            width: 210mm;
+            margin: 0 auto;
+            padding: 5mm 20mm 0;
+            box-shadow: none !important;
+            page-break-before: always;
+            break-before: page;
           }
           .ba-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; }
           .ba-header img { max-width: 196mm !important; }
           .ba-body { width: 166mm; margin-left: auto; margin-right: auto; text-align: justify; text-justify: inter-word; }
           .ba-body p { text-align: justify; text-justify: inter-word; }
-          .ba-attachment { width: 166mm; margin-left: auto; margin-right: auto; }
+          .ba-lampiran-body { width: 166mm; margin-left: auto; margin-right: auto; }
           .attachment-meta { width: 109mm; margin-left: auto; text-align: left; }
           .attachment-meta .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
           .attachment-meta .meta-label { white-space: nowrap; }
           .attachment-meta .meta-colon { text-align: center; }
           .attachment-meta .meta-value { min-width: 0; }
           .attachment-meta .lampiran-value { display: inline-block; max-width: 80mm; }
-          .ba-page:last-child { page-break-after: auto; }
           .ba-no-print { display: none !important; }
           .ba-editable { border-bottom: none !important; }
+          .ba-asset-table { break-inside: auto; page-break-inside: auto; }
+          .ba-asset-table thead { display: table-header-group; }
+          .ba-asset-table tr { break-inside: avoid; page-break-inside: avoid; }
         }
       `}</style>
-      <article className="ba-page mx-auto min-h-100 max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200" style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.25" }}>
+
+      {/* ── Article 1: KOP + Body + Signature (page 1) ── */}
+      <article
+        className="ba-page mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.25" }}
+      >
         <DocumentHeader />
         <div className="ba-title mt-1 text-center font-bold leading-tight">
           <p className="m-0">BERITA ACARA</p>
@@ -250,8 +320,13 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
         </div>
       </article>
 
-      <article className="ba-page mx-auto min-h-100 max-w-[210mm] bg-white px-24 py-12 text-black shadow-xl ring-1 ring-zinc-200" style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.25" }}>
-        <div className="ba-attachment mx-auto w-[166mm] pt-10">
+      {/* ── Article 2: Lampiran (ONE article, browser paginates naturally) ── */}
+      <article
+        className="ba-lampiran mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.25" }}
+      >
+        <div className="ba-lampiran-body mx-auto w-[166mm]">
+          {/* Meta header */}
           <div className="attachment-meta ml-auto w-[109mm]">
             <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
               <span className="meta-label whitespace-nowrap">Lampiran</span>
@@ -271,31 +346,21 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
               <span className="meta-value min-w-0">{formatDateLong(today)}</span>
             </div>
           </div>
-          <AssetConditionTable title="I. Sebelum" assets={assets} mode="before" />
-          <AssetConditionTable title="II. Sesudah" assets={assets} mode="after" />
+
+          {/* I. Sebelum */}
+          <p className="ba-section-title mt-6 mb-2 text-[12px] font-semibold">I. Sebelum</p>
+          <AssetConditionTable assets={assets} mode="before" />
+
+          {/* II. Sesudah */}
+          <p className="ba-section-title mt-6 mb-2 text-[12px] font-semibold">II. Sesudah</p>
+          <AssetConditionTable assets={assets} mode="after" />
+
+          {/* Signature block */}
           <div className="signature attachment-signature mt-12 ml-auto w-80">
-            <p
-              contentEditable="true"
-              suppressContentEditableWarning
-              className="ba-editable m-0"
-            >
-              Kepala Balai,
-            </p>
+            <p className="m-0">Kepala Balai,</p>
             <div className="ttd-placeholder mt-4 h-28 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
-            <p
-              contentEditable="true"
-              suppressContentEditableWarning
-              className="ba-editable m-0"
-            >
-              M. ARI WIBAWANTO, S.Hut., M.Sc.
-            </p>
-            <p
-              contentEditable="true"
-              suppressContentEditableWarning
-              className="ba-editable m-0"
-            >
-              NIP. 19740514 199903 1 001
-            </p>
+            <p className="m-0">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>
+            <p className="m-0">NIP. 19740514 199903 1 001</p>
           </div>
         </div>
       </article>
@@ -308,47 +373,6 @@ export function DocumentHeader() {
     <div className="ba-header -mx-18 text-center">
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img src="/header-terbaru.png" alt="Kop Surat" className="mx-auto h-auto w-full max-w-[196mm]" />
-    </div>
-  );
-}
-
-export function AssetConditionTable({ title, assets, mode }: { title: string; assets: AuctionAsset[]; mode: "before" | "after" }) {
-  return (
-    <div className="mt-6">
-      <p className="mb-2 text-[12px] font-semibold">{title}</p>
-      <table className="asset-table w-full border-collapse text-center text-[10px]">
-        <thead>
-          <tr>
-            <th rowSpan={2} className="border border-black px-1 py-1">No.</th>
-            <th rowSpan={2} className="border border-black px-1 py-1">Kode Barang</th>
-            <th rowSpan={2} className="border border-black px-1 py-1">NUP</th>
-            <th rowSpan={2} className="border border-black px-1 py-1">Nama Barang</th>
-            <th rowSpan={2} className="border border-black px-1 py-1">Satuan</th>
-            <th rowSpan={2} className="border border-black px-1 py-1">Nilai Perolehan (Rp)</th>
-            <th colSpan={3} className="border border-black px-1 py-1">Kondisi</th>
-          </tr>
-          <tr>
-            <th className="border border-black px-1 py-1">Baik</th>
-            <th className="border border-black px-1 py-1">Rusak Ringan</th>
-            <th className="border border-black px-1 py-1">Rusak Berat</th>
-          </tr>
-        </thead>
-        <tbody>
-          {assets.map((asset, index) => (
-            <tr key={`${mode}-${asset.id}`}>
-              <td className="border border-black px-1 py-1">{index + 1}.</td>
-              <td className="border border-black px-1 py-1">{asset.kode_barang}</td>
-              <td className="border border-black px-1 py-1">{asset.nup}</td>
-              <td className="border border-black px-1 py-1 text-left">{asset.nama_barang}</td>
-              <td className="border border-black px-1 py-1">{asset.satuan || "Unit"}</td>
-              <td className="border border-black px-1 py-1 text-right">{formatPlainRupiah(asset.nilai_perolehan)}</td>
-              <td className="border border-black px-1 py-1">0</td>
-              <td className="border border-black px-1 py-1">{mode === "before" ? 1 : 0}</td>
-              <td className="border border-black px-1 py-1">{mode === "after" ? 1 : 0}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
     </div>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/_components/BaKoreksiDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/BaKoreksiDocument.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { AuctionAsset } from "../_lib/auction-helpers";
 import {
@@ -7,6 +8,17 @@ import {
   formatDateLong,
   getSpelledDate,
 } from "../_lib/auction-helpers";
+
+const BA_ATTACHMENT_PAGE_HEIGHT_MM = 269;
+const BA_ATTACHMENT_FALLBACK_CHUNK_SIZE = 8;
+const BA_ATTACHMENT_MIN_ROWS_PER_PAGE = 1;
+
+type BaLampiranPage = {
+  assets: AuctionAsset[];
+  startIndex: number;
+  showMeta: boolean;
+  showSignature: boolean;
+};
 
 export function handlePrintBa(orderedSelectedAssets: AuctionAsset[]) {
   if (orderedSelectedAssets.length === 0) {
@@ -48,6 +60,7 @@ export function handlePrintBa(orderedSelectedAssets: AuctionAsset[]) {
             box-sizing: border-box;
             margin: 0 auto;
             padding: 5mm 20mm 0;
+            min-height: ${BA_ATTACHMENT_PAGE_HEIGHT_MM}mm;
             page-break-before: always;
             break-before: page;
           }
@@ -64,24 +77,27 @@ export function handlePrintBa(orderedSelectedAssets: AuctionAsset[]) {
           .identity-table td { padding: 0.125rem 0; }
           .identity-table .label-cell { width: 24mm; }
           .identity-table .colon-cell { width: 6mm; text-align: center; }
-          .ba-asset-table { width: 100%; border-collapse: collapse; text-align: center; font-size: 8.5pt; break-inside: auto; page-break-inside: auto; }
+          .ba-asset-table { width: 100%; table-layout: fixed; border-collapse: collapse; text-align: center; font-size: 8.5pt; break-inside: auto; page-break-inside: auto; }
           .ba-asset-table thead { display: table-header-group; }
-          .ba-asset-table th, .ba-asset-table td { border: 1px solid #000; padding: 0.25rem; }
+          .ba-asset-table th, .ba-asset-table td { border: 1px solid #000; padding: 0.18rem 0.2rem; overflow-wrap: anywhere; word-break: normal; }
           .ba-asset-table tr { break-inside: avoid; page-break-inside: avoid; }
           .ba-asset-table td.text-left { text-align: left; }
           .ba-asset-table td.text-right { text-align: right; }
           .ba-section-title { font-size: 10pt; font-weight: 600; margin-bottom: 0.5rem; }
+          .ba-continuation-spacer { height: 8mm; }
           .attachment-meta { width: 109mm; margin-left: auto; text-align: left; }
           .attachment-meta .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
           .attachment-meta .meta-label { white-space: nowrap; }
           .attachment-meta .meta-colon { text-align: center; }
           .attachment-meta .meta-value { min-width: 0; }
           .attachment-meta .lampiran-value { display: inline-block; max-width: 80mm; }
-          .signature { width: 20rem; margin-left: auto; break-inside: auto; page-break-inside: auto; }
-          .attachment-signature { margin-top: 3rem; }
+          .signature { width: 20rem; margin-left: auto; break-inside: avoid; page-break-inside: avoid; }
+          .attachment-signature { margin-top: 1.5rem; }
           .signature p { margin: 0; padding: 0; line-height: 1.15; }
           .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; }
+          .attachment-signature .ttd-placeholder { height: 92px; padding-top: 30px; }
           .ba-editable { outline: none; border-bottom: none !important; }
+          .ba-measurement { display: none !important; }
         </style>
       </head>
       <body>${printContent.innerHTML}</body>
@@ -94,9 +110,34 @@ export function handlePrintBa(orderedSelectedAssets: AuctionAsset[]) {
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
-function AssetConditionTable({ assets, mode }: { assets: AuctionAsset[]; mode: "before" | "after" }) {
+function AssetConditionTable({
+  assets,
+  mode,
+  startIndex = 0,
+  measureKey,
+}: {
+  assets: AuctionAsset[];
+  mode: "before" | "after";
+  startIndex?: number;
+  measureKey?: string;
+}) {
   return (
-    <table className="ba-asset-table mt-4 w-full border-collapse text-center" style={{ fontSize: "8.5pt" }}>
+    <table
+      className="ba-asset-table mt-4 w-full table-fixed border-collapse text-center"
+      data-ba-measure-table={measureKey}
+      style={{ fontSize: "8.5pt" }}
+    >
+      <colgroup>
+        <col style={{ width: "6%" }} />
+        <col style={{ width: "16%" }} />
+        <col style={{ width: "7%" }} />
+        <col style={{ width: "18%" }} />
+        <col style={{ width: "9%" }} />
+        <col style={{ width: "17%" }} />
+        <col style={{ width: "7%" }} />
+        <col style={{ width: "10%" }} />
+        <col style={{ width: "10%" }} />
+      </colgroup>
       <thead>
         <tr>
           <th rowSpan={2} className="border border-black px-1 py-1">No.</th>
@@ -116,7 +157,7 @@ function AssetConditionTable({ assets, mode }: { assets: AuctionAsset[]; mode: "
       <tbody>
         {assets.map((asset, index) => (
           <tr key={`${mode}-${asset.id}`}>
-            <td className="border border-black px-1 py-1">{index + 1}.</td>
+            <td className="border border-black px-1 py-1">{startIndex + index + 1}.</td>
             <td className="border border-black px-1 py-1">{asset.kode_barang}</td>
             <td className="border border-black px-1 py-1">{asset.nup}</td>
             <td className="border border-black px-1 py-1 text-left">{asset.nama_barang}</td>
@@ -132,14 +173,209 @@ function AssetConditionTable({ assets, mode }: { assets: AuctionAsset[]; mode: "
   );
 }
 
+function AttachmentMeta({ baNumberText, today }: { baNumberText: string; today: Date }) {
+  return (
+    <div className="attachment-meta ml-auto w-[109mm]">
+      <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
+        <span className="meta-label whitespace-nowrap">Lampiran</span>
+        <span className="meta-colon text-center">:</span>
+        <span className="meta-value min-w-0">
+          <span className="lampiran-value inline-block max-w-[80mm]">Berita Acara Koreksi Perubahan Kondisi BMN</span>
+        </span>
+      </div>
+      <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
+        <span className="meta-label whitespace-nowrap">Nomor</span>
+        <span className="meta-colon text-center">:</span>
+        <span className="meta-value min-w-0 whitespace-nowrap">{baNumberText}</span>
+      </div>
+      <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
+        <span className="meta-label whitespace-nowrap">Tanggal</span>
+        <span className="meta-colon text-center">:</span>
+        <span className="meta-value min-w-0">{formatDateLong(today)}</span>
+      </div>
+    </div>
+  );
+}
+
+function AttachmentSignature() {
+  return (
+    <div className="signature attachment-signature mt-6 ml-auto w-80">
+      <p className="m-0">Kepala Balai,</p>
+      <div className="ttd-placeholder mt-4 h-[92px] box-border pt-[30px] pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+      <p className="m-0">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>
+      <p className="m-0">NIP. 19740514 199903 1 001</p>
+    </div>
+  );
+}
+
+function BaLampiranPageContent({
+  assets,
+  startIndex,
+  showMeta,
+  showSignature,
+  baNumberText,
+  today,
+}: BaLampiranPage & {
+  baNumberText: string;
+  today: Date;
+}) {
+  return (
+    <>
+      {showMeta ? <AttachmentMeta baNumberText={baNumberText} today={today} /> : <div className="ba-continuation-spacer" />}
+
+      <p className="ba-section-title mt-6 mb-2 text-[12px] font-semibold">I. Sebelum</p>
+      <AssetConditionTable assets={assets} mode="before" startIndex={startIndex} />
+
+      <p className="ba-section-title mt-6 mb-2 text-[12px] font-semibold">II. Sesudah</p>
+      <AssetConditionTable assets={assets} mode="after" startIndex={startIndex} />
+
+      {showSignature ? <AttachmentSignature /> : null}
+    </>
+  );
+}
+
+function getOuterHeight(element: Element | null) {
+  if (!element) return 0;
+  const rect = element.getBoundingClientRect();
+  const styles = window.getComputedStyle(element);
+  const marginTop = Number.parseFloat(styles.marginTop) || 0;
+  const marginBottom = Number.parseFloat(styles.marginBottom) || 0;
+
+  return rect.height + marginTop + marginBottom;
+}
+
+function fitAssetCount(rowHeights: number[], startIndex: number, availableHeight: number) {
+  let usedHeight = 0;
+  let count = 0;
+
+  for (let index = startIndex; index < rowHeights.length; index += 1) {
+    const nextHeight = rowHeights[index] || 0;
+    if (count >= BA_ATTACHMENT_MIN_ROWS_PER_PAGE && usedHeight + nextHeight > availableHeight) {
+      break;
+    }
+    usedHeight += nextHeight;
+    count += 1;
+  }
+
+  return Math.max(BA_ATTACHMENT_MIN_ROWS_PER_PAGE, count);
+}
+
+function buildMeasuredLampiranPages({
+  assets,
+  rowHeights,
+  firstBaseHeight,
+  continuationBaseHeight,
+  signatureHeight,
+  pageHeight,
+}: {
+  assets: AuctionAsset[];
+  rowHeights: number[];
+  firstBaseHeight: number;
+  continuationBaseHeight: number;
+  signatureHeight: number;
+  pageHeight: number;
+}) {
+  if (assets.length === 0) return [];
+
+  const pages: BaLampiranPage[] = [];
+  let startIndex = 0;
+
+  while (startIndex < assets.length) {
+    const isFirstPage = pages.length === 0;
+    const baseHeight = isFirstPage ? firstBaseHeight : continuationBaseHeight;
+    const remainingCount = assets.length - startIndex;
+    const finalAvailableHeight = pageHeight - baseHeight - signatureHeight;
+    const finalFitCount = fitAssetCount(rowHeights, startIndex, finalAvailableHeight);
+
+    if (finalFitCount >= remainingCount) {
+      pages.push({
+        assets: assets.slice(startIndex),
+        startIndex,
+        showMeta: isFirstPage,
+        showSignature: true,
+      });
+      break;
+    }
+
+    const regularAvailableHeight = pageHeight - baseHeight;
+    const regularFitCount = Math.min(
+      remainingCount - BA_ATTACHMENT_MIN_ROWS_PER_PAGE,
+      fitAssetCount(rowHeights, startIndex, regularAvailableHeight),
+    );
+    const safeCount = Math.max(BA_ATTACHMENT_MIN_ROWS_PER_PAGE, regularFitCount);
+
+    pages.push({
+      assets: assets.slice(startIndex, startIndex + safeCount),
+      startIndex,
+      showMeta: isFirstPage,
+      showSignature: false,
+    });
+    startIndex += safeCount;
+  }
+
+  return pages;
+}
+
+function buildFallbackLampiranPages(assets: AuctionAsset[]) {
+  if (assets.length === 0) return [];
+
+  const pages: BaLampiranPage[] = [];
+  for (let startIndex = 0; startIndex < assets.length; startIndex += BA_ATTACHMENT_FALLBACK_CHUNK_SIZE) {
+    const pageAssets = assets.slice(startIndex, startIndex + BA_ATTACHMENT_FALLBACK_CHUNK_SIZE);
+    pages.push({
+      assets: pageAssets,
+      startIndex,
+      showMeta: startIndex === 0,
+      showSignature: startIndex + pageAssets.length >= assets.length,
+    });
+  }
+
+  return pages;
+}
+
 // ─── Main Component ───────────────────────────────────────────────────────────
 
 export function CorrectionDocument({ assets, baNumber, baKap }: { assets: AuctionAsset[]; baNumber: string; baKap: string }) {
+  const measurementRef = useRef<HTMLDivElement>(null);
+  const fallbackLampiranPages = useMemo(() => buildFallbackLampiranPages(assets), [assets]);
+  const [lampiranPages, setLampiranPages] = useState<BaLampiranPage[]>(fallbackLampiranPages);
   const today = new Date();
   const { day, dateText, month, yearText } = getSpelledDate(today);
   const monthNum = String(today.getMonth() + 1).padStart(2, "0");
   const baNumberText = `BA.${baNumber.trim() || "____"}/K.18/TU/${baKap}/B/${monthNum}/${today.getFullYear()}`;
   const datePhrase = `${dateText} bulan ${month} tahun ${yearText}`;
+
+  useLayoutEffect(() => {
+    const root = measurementRef.current;
+    if (!root || assets.length === 0) {
+      setLampiranPages([]);
+      return;
+    }
+
+    const pageHeight = root.querySelector("[data-ba-measure='page']")?.getBoundingClientRect().height || 0;
+    const firstBaseHeight = getOuterHeight(root.querySelector("[data-ba-measure='first-base']"));
+    const continuationBaseHeight = getOuterHeight(root.querySelector("[data-ba-measure='continuation-base']"));
+    const signatureHeight = getOuterHeight(root.querySelector("[data-ba-measure='signature']"));
+    const beforeRows = Array.from(root.querySelectorAll("[data-ba-measure-table='before'] tbody tr"));
+    const afterRows = Array.from(root.querySelectorAll("[data-ba-measure-table='after'] tbody tr"));
+    const rowHeights = assets.map((_, index) => getOuterHeight(beforeRows[index]) + getOuterHeight(afterRows[index]));
+
+    if (!pageHeight || !firstBaseHeight || !continuationBaseHeight || !signatureHeight || rowHeights.some((height) => height <= 0)) {
+      setLampiranPages(fallbackLampiranPages);
+      return;
+    }
+
+    setLampiranPages(
+      buildMeasuredLampiranPages({
+        assets,
+        rowHeights,
+        firstBaseHeight,
+        continuationBaseHeight,
+        signatureHeight,
+        pageHeight,
+      }),
+    );
+  }, [assets, baNumberText, fallbackLampiranPages]);
 
   return (
     <div id="ba-koreksi-print-root" className="ba-print-root space-y-6">
@@ -154,6 +390,48 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
         }
         .ba-editable:focus {
           border-bottom-color: #64748b;
+        }
+        .ba-lampiran {
+          min-height: 297mm;
+        }
+        .ba-asset-table {
+          table-layout: fixed;
+        }
+        .ba-asset-table th,
+        .ba-asset-table td {
+          overflow-wrap: anywhere;
+          word-break: normal;
+        }
+        .ba-continuation-spacer {
+          height: 8mm;
+        }
+        .attachment-signature {
+          break-inside: avoid;
+          page-break-inside: avoid;
+        }
+        .attachment-signature .ttd-placeholder {
+          height: 92px;
+          padding-top: 30px;
+        }
+        .ba-measurement {
+          position: absolute;
+          left: -10000px;
+          top: 0;
+          z-index: -1;
+          visibility: hidden;
+          pointer-events: none;
+          width: 210mm;
+          background: white;
+          color: black;
+          font-family: 'Bookman Old Style', Georgia, serif;
+          font-size: 11pt;
+          line-height: 1.25;
+        }
+        .ba-measure-page {
+          width: 210mm;
+          box-sizing: border-box;
+          height: ${BA_ATTACHMENT_PAGE_HEIGHT_MM}mm;
+          padding: 5mm 20mm 0;
         }
         @media print {
           @page { size: A4; margin: 0 0 28mm 0; }
@@ -184,6 +462,7 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
             width: 210mm;
             margin: 0 auto;
             padding: 5mm 20mm 0;
+            min-height: ${BA_ATTACHMENT_PAGE_HEIGHT_MM}mm;
             box-shadow: none !important;
             page-break-before: always;
             break-before: page;
@@ -201,9 +480,14 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
           .attachment-meta .lampiran-value { display: inline-block; max-width: 80mm; }
           .ba-no-print { display: none !important; }
           .ba-editable { border-bottom: none !important; }
-          .ba-asset-table { break-inside: auto; page-break-inside: auto; }
+          .ba-asset-table { table-layout: fixed; break-inside: auto; page-break-inside: auto; }
           .ba-asset-table thead { display: table-header-group; }
+          .ba-asset-table th, .ba-asset-table td { padding: 0.18rem 0.2rem; overflow-wrap: anywhere; word-break: normal; }
           .ba-asset-table tr { break-inside: avoid; page-break-inside: avoid; }
+          .ba-continuation-spacer { height: 8mm; }
+          .attachment-signature { margin-top: 1.5rem !important; break-inside: avoid; page-break-inside: avoid; }
+          .attachment-signature .ttd-placeholder { height: 92px !important; padding-top: 30px !important; }
+          .ba-measurement { display: none !important; }
         }
       `}</style>
 
@@ -320,50 +604,56 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
         </div>
       </article>
 
-      {/* ── Article 2: Lampiran (ONE article, browser paginates naturally) ── */}
-      <article
-        className="ba-lampiran mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
-        style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.25" }}
-      >
-        <div className="ba-lampiran-body mx-auto w-[166mm]">
-          {/* Meta header */}
-          <div className="attachment-meta ml-auto w-[109mm]">
-            <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
-              <span className="meta-label whitespace-nowrap">Lampiran</span>
-              <span className="meta-colon text-center">:</span>
-              <span className="meta-value min-w-0">
-                <span className="lampiran-value inline-block max-w-[80mm]">Berita Acara Koreksi Perubahan Kondisi BMN</span>
-              </span>
-            </div>
-            <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
-              <span className="meta-label whitespace-nowrap">Nomor</span>
-              <span className="meta-colon text-center">:</span>
-              <span className="meta-value min-w-0 whitespace-nowrap">{baNumberText}</span>
-            </div>
-            <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
-              <span className="meta-label whitespace-nowrap">Tanggal</span>
-              <span className="meta-colon text-center">:</span>
-              <span className="meta-value min-w-0">{formatDateLong(today)}</span>
-            </div>
-          </div>
-
-          {/* I. Sebelum */}
-          <p className="ba-section-title mt-6 mb-2 text-[12px] font-semibold">I. Sebelum</p>
-          <AssetConditionTable assets={assets} mode="before" />
-
-          {/* II. Sesudah */}
-          <p className="ba-section-title mt-6 mb-2 text-[12px] font-semibold">II. Sesudah</p>
-          <AssetConditionTable assets={assets} mode="after" />
-
-          {/* Signature block */}
-          <div className="signature attachment-signature mt-12 ml-auto w-80">
-            <p className="m-0">Kepala Balai,</p>
-            <div className="ttd-placeholder mt-4 h-28 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
-            <p className="m-0">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>
-            <p className="m-0">NIP. 19740514 199903 1 001</p>
-          </div>
+      {/* Lampiran BA: measured pages keep Sebelum/Sesudah pairs and final signature together */}
+      <div ref={measurementRef} className="ba-measurement" aria-hidden="true">
+        <div data-ba-measure="page" className="ba-measure-page" />
+        <div className="ba-lampiran-body mx-auto w-[166mm]" data-ba-measure="first-base">
+          <BaLampiranPageContent
+            assets={[]}
+            startIndex={0}
+            showMeta
+            showSignature={false}
+            baNumberText={baNumberText}
+            today={today}
+          />
         </div>
-      </article>
+        <div className="ba-lampiran-body mx-auto w-[166mm]" data-ba-measure="continuation-base">
+          <BaLampiranPageContent
+            assets={[]}
+            startIndex={0}
+            showMeta={false}
+            showSignature={false}
+            baNumberText={baNumberText}
+            today={today}
+          />
+        </div>
+        <div data-ba-measure="signature">
+          <AttachmentSignature />
+        </div>
+        <div className="ba-lampiran-body mx-auto w-[166mm]">
+          <AssetConditionTable assets={assets} mode="before" measureKey="before" />
+          <AssetConditionTable assets={assets} mode="after" measureKey="after" />
+        </div>
+      </div>
+
+      {lampiranPages.map((page) => (
+        <article
+          key={`ba-lampiran-${page.startIndex}`}
+          className="ba-lampiran mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+          style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.25" }}
+        >
+          <div className="ba-lampiran-body mx-auto w-[166mm]">
+            <BaLampiranPageContent
+              assets={page.assets}
+              startIndex={page.startIndex}
+              showMeta={page.showMeta}
+              showSignature={page.showSignature}
+              baNumberText={baNumberText}
+              today={today}
+            />
+          </div>
+        </article>
+      ))}
     </div>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/_components/BaKoreksiDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/BaKoreksiDocument.tsx
@@ -18,6 +18,7 @@ type BaLampiranSection = {
   title: string;
   assets: AuctionAsset[];
   startIndex: number;
+  isContinuation: boolean;
 };
 
 type BaLampiranPage = {
@@ -121,11 +122,13 @@ function AssetConditionTable({
   mode,
   startIndex = 0,
   measureKey,
+  showColumnNumbers = false,
 }: {
   assets: AuctionAsset[];
   mode: "before" | "after";
   startIndex?: number;
   measureKey?: string;
+  showColumnNumbers?: boolean;
 }) {
   return (
     <table
@@ -145,6 +148,19 @@ function AssetConditionTable({
         <col style={{ width: "10%" }} />
       </colgroup>
       <thead>
+        {showColumnNumbers ? (
+          <tr className="ba-column-number-row">
+            <th className="border border-black px-1 py-1">1</th>
+            <th className="border border-black px-1 py-1">2</th>
+            <th className="border border-black px-1 py-1">3</th>
+            <th className="border border-black px-1 py-1">4</th>
+            <th className="border border-black px-1 py-1">5</th>
+            <th className="border border-black px-1 py-1">6</th>
+            <th className="border border-black px-1 py-1">7</th>
+            <th className="border border-black px-1 py-1">8</th>
+            <th className="border border-black px-1 py-1">9</th>
+          </tr>
+        ) : null}
         <tr>
           <th rowSpan={2} className="border border-black px-1 py-1">No.</th>
           <th rowSpan={2} className="border border-black px-1 py-1">Kode Barang</th>
@@ -223,12 +239,13 @@ function BaLampiranSectionBlock({
 }) {
   return (
     <>
-      <p className="ba-section-title mt-6 mb-2 text-[12px] font-semibold">{section.title}</p>
+      {section.isContinuation ? null : <p className="ba-section-title mt-6 mb-2 text-[12px] font-semibold">{section.title}</p>}
       <AssetConditionTable
         assets={section.assets}
         mode={section.mode}
         startIndex={section.startIndex}
         measureKey={measureKey}
+        showColumnNumbers={section.isContinuation}
       />
     </>
   );
@@ -340,6 +357,7 @@ function buildMeasuredLampiranPages({
           title,
           assets: assets.slice(startIndex),
           startIndex,
+          isContinuation: startIndex > 0,
         });
         page.showSignature = true;
         currentPage = null;
@@ -374,6 +392,7 @@ function buildMeasuredLampiranPages({
         title,
         assets: assets.slice(startIndex, startIndex + safeCount),
         startIndex,
+        isContinuation: startIndex > 0,
       });
       currentHeight += baseHeight + rowHeights.slice(startIndex, startIndex + safeCount).reduce((total, height) => total + height, 0);
       startIndex += safeCount;
@@ -404,12 +423,14 @@ function buildFallbackLampiranPages(assets: AuctionAsset[]) {
           title: "I. Sebelum",
           assets: pageAssets,
           startIndex,
+          isContinuation: startIndex > 0,
         },
         {
           mode: "after",
           title: "II. Sesudah",
           assets: pageAssets,
           startIndex,
+          isContinuation: startIndex > 0,
         },
       ],
       showMeta: startIndex === 0,
@@ -714,7 +735,7 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
         </div>
         <div className="ba-lampiran-body mx-auto w-[166mm]" data-ba-measure="section-base">
           <BaLampiranSectionBlock
-            section={{ mode: "before", title: "I. Sebelum", assets: [], startIndex: 0 }}
+            section={{ mode: "before", title: "I. Sebelum", assets: [], startIndex: 0, isContinuation: false }}
           />
         </div>
         <div data-ba-measure="signature">
@@ -722,11 +743,11 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
         </div>
         <div className="ba-lampiran-body mx-auto w-[166mm]">
           <BaLampiranSectionBlock
-            section={{ mode: "before", title: "I. Sebelum", assets, startIndex: 0 }}
+            section={{ mode: "before", title: "I. Sebelum", assets, startIndex: 0, isContinuation: false }}
             measureKey="before"
           />
           <BaLampiranSectionBlock
-            section={{ mode: "after", title: "II. Sesudah", assets, startIndex: 0 }}
+            section={{ mode: "after", title: "II. Sesudah", assets, startIndex: 0, isContinuation: false }}
             measureKey="after"
           />
         </div>


### PR DESCRIPTION
Closes #344

## Summary
- paginate BA Koreksi lampiran into explicit measured pages
- keep Sebelum/Sesudah asset pairs on the same page chunk
- reserve final-page signature space and BSrE bottom safe area
- stabilize BA table column widths for long asset names

## Validation
- npx eslint src/app/bmn/auction-candidates/_components/BaKoreksiDocument.tsx --max-warnings=0
- npx tsc --noEmit
- npm run build

Note: full npm run lint -- --max-warnings=0 is still blocked by unrelated pre-existing warnings/errors in portal and EmployeeAccessSheet files, matching the existing project progress notes.