### PR TITLE
fix(bmn): widen TTD spacing in BA and SK documents (#346)

### DIFF
--- a/frontend/src/app/bmn/auction-candidates/_components/BaKoreksiDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/BaKoreksiDocument.tsx
@@ -101,8 +101,9 @@ export function handlePrintBa(orderedSelectedAssets: AuctionAsset[]) {
           .signature { width: 20rem; margin-left: auto; break-inside: avoid; page-break-inside: avoid; }
           .attachment-signature { margin-top: 1.5rem; }
           .signature p { margin: 0; padding: 0; line-height: 1.15; }
-          .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; }
-          .attachment-signature .ttd-placeholder { height: 92px; padding-top: 30px; }
+          .signature p.ttd-spacer-top { margin-top: 2rem !important; }
+          .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; margin-top: 2rem; margin-bottom: 2rem; }
+          .attachment-signature .ttd-placeholder { height: 92px; padding-top: 30px; margin-top: 2rem; margin-bottom: 2rem; }
           .ba-editable { outline: none; border-bottom: none !important; }
           .ba-measurement { display: none !important; }
         </style>
@@ -223,8 +224,8 @@ function AttachmentSignature() {
   return (
     <div className="signature attachment-signature mt-6 ml-auto w-80">
       <p className="m-0">Kepala Balai,</p>
-      <div className="ttd-placeholder mt-4 h-[92px] box-border pt-[30px] pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
-      <p className="m-0">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>
+      <div className="ttd-placeholder mt-8 h-[92px] box-border pt-[30px] pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+      <p className="m-0 mt-8">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>
       <p className="m-0">NIP. 19740514 199903 1 001</p>
     </div>
   );
@@ -532,6 +533,8 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
         .attachment-signature .ttd-placeholder {
           height: 92px;
           padding-top: 30px;
+          margin-top: 2rem;
+          margin-bottom: 2rem;
         }
         .ba-measurement {
           position: absolute;
@@ -606,7 +609,8 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
           .ba-asset-table tr { break-inside: avoid; page-break-inside: avoid; }
           .ba-continuation-spacer { height: 8mm; }
           .attachment-signature { margin-top: 1.5rem !important; break-inside: avoid; page-break-inside: avoid; }
-          .attachment-signature .ttd-placeholder { height: 92px !important; padding-top: 30px !important; }
+          .attachment-signature .ttd-placeholder { height: 92px !important; padding-top: 30px !important; margin-top: 2rem !important; margin-bottom: 2rem !important; }
+          .signature .ttd-placeholder { margin-top: 2rem !important; margin-bottom: 2rem !important; }
           .ba-measurement { display: none !important; }
         }
       `}</style>
@@ -706,11 +710,11 @@ export function CorrectionDocument({ assets, baNumber, baKap }: { assets: Auctio
           >
             Kepala Balai,
           </p>
-          <div className="ttd-placeholder mt-4 h-28 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+          <div className="ttd-placeholder mt-8 h-28 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
           <p
             contentEditable="true"
             suppressContentEditableWarning
-            className="ba-editable m-0"
+            className="ba-editable m-0 mt-8"
           >
             M. ARI WIBAWANTO, S.Hut., M.Sc.
           </p>

--- a/frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx
@@ -107,7 +107,7 @@ export function handlePrintSk(orderedSelectedAssets: AuctionAsset[], _skNumber: 
           .sk-ttd, .sk-ttd p { font-weight: normal !important; text-align: left !important; }
           .sk-ttd p { margin: 0; padding: 0; line-height: 1.3; }
           .sk-signature-name { font-weight: bold !important; }
-          .ttd-placeholder { height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; font-weight: normal !important; text-align: left !important; }
+          .ttd-placeholder { height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; font-weight: normal !important; text-align: left !important; margin-top: 2rem; margin-bottom: 2rem; }
           /* Tembusan */
           .sk-tembusan { margin-top: 2rem; }
           .sk-tembusan, .sk-tembusan p { font-weight: normal !important; text-align: left !important; }
@@ -127,7 +127,7 @@ export function handlePrintSk(orderedSelectedAssets: AuctionAsset[], _skNumber: 
           .sk-asset-table td.text-right { text-align: right; }
           .sk-lampiran-ttd { width: 20rem; margin-left: auto; margin-top: 1rem; break-inside: avoid; page-break-inside: avoid; }
           .sk-lampiran-ttd p { margin: 0; padding: 0; line-height: 1.15; }
-          .sk-lampiran-ttd .ttd-placeholder { height: 86px !important; padding-top: 28px !important; }
+          .sk-lampiran-ttd .ttd-placeholder { height: 86px !important; padding-top: 28px !important; margin-top: 2rem !important; margin-bottom: 2rem !important; }
         </style>
       </head>
       <body>${printContent.innerHTML}</body>
@@ -313,8 +313,8 @@ export function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAss
   const renderAttachmentSignature = (measure = false) => (
     <div className="sk-lampiran-ttd signature mt-10 ml-auto w-80" data-sk-measure={measure ? "signature" : undefined}>
       <p className="m-0">Kepala Balai,</p>
-      <div className="ttd-placeholder mt-4 h-28 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
-      <p className="m-0 font-bold">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>
+      <div className="ttd-placeholder mt-8 h-28 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+      <p className="m-0 mt-8 font-bold">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>
       <p className="m-0">NIP. 19740514 199903 1 001</p>
     </div>
   );
@@ -377,8 +377,8 @@ export function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAss
           .sk-ttd, .sk-ttd p { font-weight: normal !important; text-align: left !important; }
           .signature p { margin: 0; padding: 0; line-height: 1.15; }
           .sk-signature-name { font-weight: bold !important; }
-          .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; font-weight: normal !important; text-align: left !important; }
-          .sk-lampiran-ttd .ttd-placeholder { height: 86px !important; padding-top: 28px !important; }
+          .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; font-weight: normal !important; text-align: left !important; margin-top: 2rem !important; margin-bottom: 2rem !important; }
+          .sk-lampiran-ttd .ttd-placeholder { height: 86px !important; padding-top: 28px !important; margin-top: 2rem !important; margin-bottom: 2rem !important; }
           .sk-tembusan, .sk-tembusan p { font-weight: normal !important; text-align: left !important; }
         }
         .sk-print-root .sk-attachment-document {
@@ -511,6 +511,8 @@ export function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAss
           color: #94a3b8;
           font-weight: normal !important;
           text-align: left !important;
+          margin-top: 2rem;
+          margin-bottom: 2rem;
         }
         .sk-print-root .sk-tembusan {
           margin-top: 2rem;
@@ -580,6 +582,8 @@ export function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAss
         .sk-print-root .sk-lampiran-ttd .ttd-placeholder {
           height: 86px !important;
           padding-top: 28px !important;
+          margin-top: 2rem !important;
+          margin-bottom: 2rem !important;
         }
       `}</style>
 
@@ -685,8 +689,8 @@ export function SkPenghentianDocument({ assets, skNumber }: { assets: AuctionAss
             <p className="m-0">Ditetapkan di : Samarinda</p>
             <p className="m-0">Pada tanggal : {formatDateLong(today)}</p>
             <p className="m-0 mt-3">Kepala Balai,</p>
-            <div className="ttd-placeholder mt-4 h-28 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
-            <p className="sk-signature-name m-0 font-bold">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>
+            <div className="ttd-placeholder mt-8 h-28 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+            <p className="sk-signature-name m-0 mt-8 font-bold">M. ARI WIBAWANTO, S.Hut., M.Sc.</p>
             <p className="m-0">NIP. 19740514 199903 1 001</p>
           </div>
 


### PR DESCRIPTION
Closes #346. Widen vertical spacing around \ placeholder in BA Koreksi (page 1 + attachment) and SK Penghentian (page 2 + attachment). Horizontal position unchanged.