### PR TITLE
fix(bmn): stabilize SK continuation pagination (#352)

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -118,16 +118,25 @@ git push origin main
 - [x] Issue #346: Widen TTD spacing in BA and SK documents (vertical spacing around `${ttd_pengirim}` placeholder). PR #347 merged ke `main` (merge commit `fa24541`).
 - [x] Issue #348: Align colons in SK Ditetapkan/Pada tanggal block. PR #349 merged ke `main` (merge commit `b29e5f5`).
 - [x] Issue #350: Add SK Builder panel beside SK preview (Menimbang/Mengingat/Memutuskan/Tembusan editable + Kepala Balai picker dari kepegawaian). PR #351 merged ke `main` (merge commit `b833a20`).
+- [ ] Issue #352 (IN PROGRESS): Add continuation words at page breaks in SK document. Branch `issue/352-sk-continuation-words`. JavaScript DOM measurement approach — detection belum reliable.
 
 | Field | Value |
 |-------|-------|
 | **Issue Terakhir Selesai** | Issue #350: SK Builder panel (PR #351 merged) |
-| **Issue Sedang Dikerjakan** | None |
-| **Branch Aktif** | `main` |
-| **Commit Terakhir di Main** | `b833a20` |
-| **Status** | Issue #350 DONE: builder panel dengan card Menimbang (a, b, c, ...), Mengingat (1-9 default + add/remove), Memutuskan (Menetapkan/KESATU/KEDUA/KETIGA), Kepala Balai (dropdown dari `/kepegawaian/employees/select`, auto-uppercase nama, format NIP `19740514 199903 1 001`), dan Tembusan (add/remove, single tanpa nomor). KETIGA + TTD halaman 2 grouped `break-inside: avoid`. Mengingat number column 9mm untuk 2-digit. |
+| **Issue Sedang Dikerjakan** | Issue #352: Continuation words at page breaks — branch `issue/352-sk-continuation-words` |
+| **Branch Aktif** | `issue/352-sk-continuation-words` |
+| **Commit Terakhir di Branch** | `ebe94ba` |
+| **Status** | WIP: JavaScript page break detection di print window tidak reliable — boundary calculation salah karena `@page` margin hanya berlaku saat actual print, bukan saat DOM render. Continuation word muncul di posisi yang salah (setelah KEDUA, bukan setelah Mengingat 8). Perlu pendekatan berbeda. |
 | **Model Terakhir** | Kiro |
-| **Timestamp** | 2026-05-21T15:00:00+08:00 |
+| **Timestamp** | 2026-05-21T16:00:00+08:00 |
+
+### TODO Issue #352:
+- [ ] Fix boundary calculation — `getBoundingClientRect()` di print window tidak akurat karena `@page` margin belum diterapkan saat JS measure
+- [ ] Opsi A: Measure di halaman utama (Next.js preview yang sudah 210mm width) sebelum buka print window, lalu inject ke HTML
+- [ ] Opsi B: Manual input — user menambahkan continuation word sendiri via SK Builder (textarea per halaman)
+- [ ] Opsi C: Gunakan CSS `string-set` / `running()` (hanya Firefox, tidak Chrome)
+- [ ] Fix posisi: harus `text-align: right` di pojok kanan bawah halaman
+- [ ] Fix content: harus menunjukkan item berikutnya (nomor + awal teks + ".....")
 | **Status Print SK** | DONE: preview dan print PDF OK; margin bawah BSrE aman; Mengingat paginate per item; lampiran paginate sesuai aturan 15/17/max-10 |
 | **Model Terakhir** | Codex |
 | **Timestamp** | 2026-05-20T13:00:00+08:00 |

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -118,28 +118,47 @@ git push origin main
 - [x] Issue #346: Widen TTD spacing in BA and SK documents (vertical spacing around `${ttd_pengirim}` placeholder). PR #347 merged ke `main` (merge commit `fa24541`).
 - [x] Issue #348: Align colons in SK Ditetapkan/Pada tanggal block. PR #349 merged ke `main` (merge commit `b29e5f5`).
 - [x] Issue #350: Add SK Builder panel beside SK preview (Menimbang/Mengingat/Memutuskan/Tembusan editable + Kepala Balai picker dari kepegawaian). PR #351 merged ke `main` (merge commit `b833a20`).
-- [ ] Issue #352 (IN PROGRESS): Add continuation words at page breaks in SK document. Branch `issue/352-sk-continuation-words`. JavaScript DOM measurement approach — detection belum reliable.
+- [x] Issue #352: Add continuation words at page breaks in SK document. Branch `issue/352-sk-continuation-words` siap PR/merge.
 
 | Field | Value |
 |-------|-------|
-| **Issue Terakhir Selesai** | Issue #350: SK Builder panel (PR #351 merged) |
-| **Issue Sedang Dikerjakan** | Issue #352: Continuation words at page breaks — branch `issue/352-sk-continuation-words` |
+| **Issue Terakhir Selesai** | Issue #352: SK continuation words at page breaks |
+| **Issue Sedang Dikerjakan** | Tidak ada — Issue #352 siap PR/merge |
 | **Branch Aktif** | `issue/352-sk-continuation-words` |
-| **Commit Terakhir di Branch** | `ebe94ba` |
-| **Status** | WIP: JavaScript page break detection di print window tidak reliable — boundary calculation salah karena `@page` margin hanya berlaku saat actual print, bukan saat DOM render. Continuation word muncul di posisi yang salah (setelah KEDUA, bukan setelah Mengingat 8). Perlu pendekatan berbeda. |
-| **Model Terakhir** | Kiro |
-| **Timestamp** | 2026-05-21T16:00:00+08:00 |
-
-### TODO Issue #352:
-- [ ] Fix boundary calculation — `getBoundingClientRect()` di print window tidak akurat karena `@page` margin belum diterapkan saat JS measure
-- [ ] Opsi A: Measure di halaman utama (Next.js preview yang sudah 210mm width) sebelum buka print window, lalu inject ke HTML
-- [ ] Opsi B: Manual input — user menambahkan continuation word sendiri via SK Builder (textarea per halaman)
-- [ ] Opsi C: Gunakan CSS `string-set` / `running()` (hanya Firefox, tidak Chrome)
-- [ ] Fix posisi: harus `text-align: right` di pojok kanan bawah halaman
-- [ ] Fix content: harus menunjukkan item berikutnya (nomor + awal teks + ".....")
-| **Status Print SK** | DONE: preview dan print PDF OK; margin bawah BSrE aman; Mengingat paginate per item; lampiran paginate sesuai aturan 15/17/max-10 |
+| **Commit Terakhir di Branch** | Pending commit final sesi ini |
+| **Status** | DONE: SK utama memakai print-only A4 pagination eksplisit; continuation word kanan bawah stabil; margin bawah BSrE aman; MEMUTUSKAN+Menetapkan dan KETIGA+TTD dijaga sebagai unit; lampiran SK tidak diubah. |
 | **Model Terakhir** | Codex |
-| **Timestamp** | 2026-05-20T13:00:00+08:00 |
+| **Timestamp** | 2026-05-21T23:59:00+08:00 |
+
+### Issue #352 Summary:
+- [x] Ganti pendekatan lama JS page-boundary detection menjadi halaman A4 eksplisit khusus print.
+- [x] Continuation word menampilkan item berikutnya di pojok kanan bawah, contoh `9. Peraturan.....`, `MEMUTUSKAN.....`, `KETIGA.....`.
+- [x] `Mengingat` dipaginate per item, sehingga jumlah peraturan 3, 6, 9, 10, dan 11 tetap stabil.
+- [x] `MEMUTUSKAN + Menetapkan` dibuat satu kesatuan, terpisah dari `KESATU`.
+- [x] `KETIGA + TTD + Tembusan` dibuat satu kesatuan agar TTD tidak terpotong sendiri.
+- [x] Validasi clean: eslint file SK, `npx tsc --noEmit`, dan `git diff --check`.
+
+---
+
+**UPDATE SESI CODEX (2026-05-21 - Issue #352 SELESAI: SK continuation words):**
+- **Objective**: Tambah kata lanjutan di pojok kanan bawah halaman SK saat konten turun halaman, sambil menjaga margin bawah untuk teks BSrE/BSSN otomatis.
+- **Status**: DONE, siap PR/merge dari branch `issue/352-sk-continuation-words`.
+- **Accomplishments**:
+  - SK utama di print window dipaginate menjadi halaman A4 eksplisit agar Chrome print/PDF tidak mengandalkan page break otomatis yang sulit diprediksi.
+  - Unit `Mengingat` diukur per item; item yang turun halaman memunculkan continuation word item berikutnya pada halaman sebelumnya.
+  - `MEMUTUSKAN + Menetapkan` dijaga sebagai satu unit, sedangkan `KESATU`, `KEDUA`, dan `KETIGA` tetap unit terpisah.
+  - `KETIGA + TTD + Tembusan` dijaga sebagai unit agar tanda tangan tidak terpotong halaman.
+  - Margin bawah halaman utama tetap menyediakan ruang untuk teks tanda tangan elektronik BSrE/BSSN.
+- **Key Files Modified**:
+  - `frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx`
+  - `docs/HANDOFF.md`
+  - `docs/progress.md`
+- **Validation**:
+  - `npx eslint "src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx" --max-warnings=0` clean
+  - `npx tsc --noEmit` clean
+  - `git diff --check -- frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx` clean
+- **Next Steps**:
+  - PR, merge ke `main`, hapus branch issue #352.
 
 ---
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,7 +1,7 @@
-# Progress - Phase 50: SK Continuation Words (IN PROGRESS)
+# Progress - Phase 50: SK Continuation Words
 
 > Document updated: 2026-05-21
-> Status: **IN PROGRESS** 🔄
+> Status: **READY TO MERGE** ✅
 
 ---
 
@@ -10,36 +10,23 @@
 ### Objective:
 Saat halaman SK terpotong (misal Mengingat 8 di halaman 1, Mengingat 9 di halaman 2), tampilkan kata penyambung di pojok kanan bawah halaman yang terpotong. Contoh: `9. Peraturan Menteri Lingkungan.....` atau `KESATU.....`.
 
-### Approach Attempted:
-- JavaScript DOM measurement di print window (`handlePrintSk`)
-- Setelah HTML di-inject ke print window, script menghitung posisi vertikal setiap item
-- Membandingkan posisi dengan page boundary (A4 297mm - margin)
-- Inject `<p>` continuation word setelah item terakhir sebelum boundary
-
-### Current State (WIP):
-- [x] **Branch**: `issue/352-sk-continuation-words` aktif, pushed.
-- [x] **Script injected**: `handlePrintSk` sekarang punya logic continuation word injection setelah `document.close()`.
-- [ ] **Detection NOT reliable**: `getBoundingClientRect()` di print window tidak akurat karena `@page` margin hanya berlaku saat actual print, bukan saat DOM render. Boundary calculation salah.
-- [ ] **Wrong position**: Continuation word muncul setelah KEDUA (bukan setelah Mengingat 8 yang sebenarnya terpotong).
-- [ ] **Wrong alignment**: Muncul di kiri, bukan di kanan (parent element layout issue).
-
-### Known Issues:
-1. **Fundamental problem**: Browser print engine menerapkan `@page` margin hanya saat actual print — JavaScript `getBoundingClientRect()` sebelum `print()` mengembalikan posisi tanpa page break.
-2. **Boundary mismatch**: Calculated boundary (264mm first page, 257mm continuation) tidak match dengan actual browser page break position.
-3. **Selector issue**: `.sk-mengingat-row` di tabel MEMUTUSKAN juga ter-select, menyebabkan continuation word di posisi yang salah.
-
-### Possible Solutions:
-- **Opsi A**: Measure di halaman utama (Next.js preview, sudah 210mm width) sebelum buka print window. Preview sudah di-render dengan layout yang benar — measure di sana, lalu inject ke HTML yang dikirim ke print window.
-- **Opsi B**: Manual input — tambah field di SK Builder untuk user mengetik continuation word per halaman.
-- **Opsi C**: CSS `string-set` / `running()` — hanya didukung Firefox, tidak Chrome.
-- **Opsi D**: Render ke hidden iframe dengan exact print dimensions, measure di sana, lalu inject.
+### Completed:
+- [x] **Branch**: `issue/352-sk-continuation-words` aktif.
+- [x] **Print-only pagination**: SK utama dipaginate menjadi halaman A4 eksplisit di `handlePrintSk`, sehingga preview cetak Chrome stabil.
+- [x] **Continuation words**: Kata lanjutan muncul di pojok kanan bawah halaman sebelum item berikutnya turun, misalnya `9. Peraturan.....`, `MEMUTUSKAN.....`, atau `KETIGA.....`.
+- [x] **Mengingat per item**: Setiap peraturan diperlakukan sebagai unit sendiri agar item panjang boleh turun halaman tanpa merusak item sebelumnya.
+- [x] **MEMUTUSKAN + Menetapkan grouped**: Judul `MEMUTUSKAN` dan baris `Menetapkan` tetap satu kesatuan.
+- [x] **KETIGA + TTD grouped**: Jika blok TTD harus turun ke halaman berikutnya, kalimat `KETIGA` ikut turun agar tanda tangan tidak terpotong sendiri.
+- [x] **BSrE safe area**: Halaman utama memakai margin/padding bawah khusus untuk ruang teks tanda tangan elektronik otomatis dari aplikasi lain.
+- [x] **Lampiran untouched**: Pagination lampiran SK tetap mengikuti aturan yang sudah disetujui sebelumnya.
 
 ### Key Files:
 - `frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx`
 
 ### Validation:
-- [x] `npx eslint --max-warnings=0` clean
+- [x] `npx eslint "src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx" --max-warnings=0` clean
 - [x] `npx tsc --noEmit` clean
+- [x] `git diff --check -- frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx` clean
 
 ---
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,48 @@
+# Progress - Phase 50: SK Continuation Words (IN PROGRESS)
+
+> Document updated: 2026-05-21
+> Status: **IN PROGRESS** 🔄
+
+---
+
+## Issue #352: Continuation Words at Page Breaks in SK Document
+
+### Objective:
+Saat halaman SK terpotong (misal Mengingat 8 di halaman 1, Mengingat 9 di halaman 2), tampilkan kata penyambung di pojok kanan bawah halaman yang terpotong. Contoh: `9. Peraturan Menteri Lingkungan.....` atau `KESATU.....`.
+
+### Approach Attempted:
+- JavaScript DOM measurement di print window (`handlePrintSk`)
+- Setelah HTML di-inject ke print window, script menghitung posisi vertikal setiap item
+- Membandingkan posisi dengan page boundary (A4 297mm - margin)
+- Inject `<p>` continuation word setelah item terakhir sebelum boundary
+
+### Current State (WIP):
+- [x] **Branch**: `issue/352-sk-continuation-words` aktif, pushed.
+- [x] **Script injected**: `handlePrintSk` sekarang punya logic continuation word injection setelah `document.close()`.
+- [ ] **Detection NOT reliable**: `getBoundingClientRect()` di print window tidak akurat karena `@page` margin hanya berlaku saat actual print, bukan saat DOM render. Boundary calculation salah.
+- [ ] **Wrong position**: Continuation word muncul setelah KEDUA (bukan setelah Mengingat 8 yang sebenarnya terpotong).
+- [ ] **Wrong alignment**: Muncul di kiri, bukan di kanan (parent element layout issue).
+
+### Known Issues:
+1. **Fundamental problem**: Browser print engine menerapkan `@page` margin hanya saat actual print — JavaScript `getBoundingClientRect()` sebelum `print()` mengembalikan posisi tanpa page break.
+2. **Boundary mismatch**: Calculated boundary (264mm first page, 257mm continuation) tidak match dengan actual browser page break position.
+3. **Selector issue**: `.sk-mengingat-row` di tabel MEMUTUSKAN juga ter-select, menyebabkan continuation word di posisi yang salah.
+
+### Possible Solutions:
+- **Opsi A**: Measure di halaman utama (Next.js preview, sudah 210mm width) sebelum buka print window. Preview sudah di-render dengan layout yang benar — measure di sana, lalu inject ke HTML yang dikirim ke print window.
+- **Opsi B**: Manual input — tambah field di SK Builder untuk user mengetik continuation word per halaman.
+- **Opsi C**: CSS `string-set` / `running()` — hanya didukung Firefox, tidak Chrome.
+- **Opsi D**: Render ke hidden iframe dengan exact print dimensions, measure di sana, lalu inject.
+
+### Key Files:
+- `frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx`
+
+### Validation:
+- [x] `npx eslint --max-warnings=0` clean
+- [x] `npx tsc --noEmit` clean
+
+---
+
 # Progress - Phase 49: SK Builder Panel
 
 > Document updated: 2026-05-21

--- a/frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx
@@ -117,6 +117,7 @@ export function handlePrintSk(orderedSelectedAssets: AuctionAsset[], _skNumber: 
           /* Halaman 2 */
           .sk-page2-body { width: 166mm; margin-left: auto; margin-right: auto; padding-top: 16mm; }
           .sk-memutuskan { text-align: center; font-weight: bold; margin-bottom: 12px; }
+
           /* TTD block */
           .sk-ttd { width: 20rem; margin-left: auto; margin-top: 3rem; }
           .sk-ttd, .sk-ttd p { font-weight: normal !important; text-align: left !important; }
@@ -153,7 +154,109 @@ export function handlePrintSk(orderedSelectedAssets: AuctionAsset[], _skNumber: 
   `);
   printWindow.document.close();
   printWindow.focus();
-  setTimeout(() => printWindow.print(), 500);
+  // Wait for full render, then inject continuation words at page breaks, then print
+  setTimeout(() => {
+    try {
+      const doc = printWindow.document;
+      const body = doc.body;
+      if (!body) { printWindow.print(); return; }
+
+      // Force layout by reading offsetHeight
+      void body.offsetHeight;
+
+      // A4 page usable height calculation
+      // @page margin-bottom: 28mm, page padding-top: 5mm (first page)
+      // Total A4 = 297mm. Usable first page ≈ 297 - 28 - 5 = 264mm
+      // Continuation pages: 297 - 28 - 12 = 257mm (12mm top margin from @page sk-main)
+      const mmToPx = 96 / 25.4; // 1mm = 96/25.4 px at screen resolution
+      const firstPageH = 264 * mmToPx;
+      const contPageH = 257 * mmToPx;
+
+      // Collect all breakable items from the main document section
+      const mainDoc = doc.querySelector(".sk-main-document");
+      if (!mainDoc) { printWindow.print(); return; }
+
+      const allItems: { el: HTMLElement; nextLabel: string }[] = [];
+
+      // Mengingat items
+      const mengItems = mainDoc.querySelectorAll<HTMLElement>(".sk-mengingat-item");
+      mengItems.forEach((el, idx) => {
+        if (idx < mengItems.length - 1) {
+          const nextEl = mengItems[idx + 1];
+          const numEl = nextEl.querySelector("div:first-child");
+          const textEl = nextEl.querySelector(".sk-mengingat-text");
+          const num = numEl?.textContent?.trim() || "";
+          const text = textEl?.textContent?.trim() || "";
+          const preview = text.length > 40 ? text.slice(0, 40) + "....." : text + ".....";
+          allItems.push({ el: el as HTMLElement, nextLabel: `${num} ${preview}` });
+        }
+      });
+
+      // Last mengingat item → next is MEMUTUSKAN
+      if (mengItems.length > 0) {
+        const lastMeng = mengItems[mengItems.length - 1] as HTMLElement;
+        allItems.push({ el: lastMeng, nextLabel: "MEMUTUSKAN :" });
+      }
+
+      // Memutuskan rows
+      const memRows = mainDoc.querySelectorAll<HTMLElement>(".sk-mengingat-row");
+      const rowLabels = ["Menetapkan", "KESATU", "KEDUA", "KETIGA"];
+      memRows.forEach((el, idx) => {
+        if (idx < memRows.length - 1) {
+          const nextLabel = rowLabels[idx + 1] || "";
+          if (nextLabel) {
+            allItems.push({ el: el as HTMLElement, nextLabel: `${nextLabel}.....` });
+          }
+        }
+      });
+
+      // Sort by vertical position
+      const mainTop = mainDoc.getBoundingClientRect().top;
+      allItems.sort((a, b) => {
+        return (a.el.getBoundingClientRect().top - mainTop) - (b.el.getBoundingClientRect().top - mainTop);
+      });
+
+      // Calculate page boundaries
+      const boundaries: number[] = [];
+      let cumH = firstPageH;
+      boundaries.push(cumH);
+      for (let i = 0; i < 10; i++) {
+        cumH += contPageH;
+        boundaries.push(cumH);
+      }
+
+      // For each boundary, find the last item that fits and inject continuation word
+      const injected = new Set<number>();
+      for (const boundary of boundaries) {
+        for (let i = 0; i < allItems.length; i++) {
+          const rect = allItems[i].el.getBoundingClientRect();
+          const itemBottom = rect.bottom - mainTop;
+          const nextTop = i < allItems.length - 1
+            ? allItems[i + 1].el.getBoundingClientRect().top - mainTop
+            : Infinity;
+
+          if (itemBottom <= boundary && nextTop > boundary && !injected.has(i)) {
+            // This item is the last one on this page, next item is on next page
+            const contWord = doc.createElement("p");
+            contWord.style.cssText = "text-align: right; margin: 0.5rem 0 0 0; padding: 0; font-weight: normal; font-size: 11pt;";
+            contWord.textContent = allItems[i].nextLabel;
+
+            // Insert after the item
+            if (allItems[i].el.nextSibling) {
+              allItems[i].el.parentElement?.insertBefore(contWord, allItems[i].el.nextSibling);
+            } else {
+              allItems[i].el.parentElement?.appendChild(contWord);
+            }
+            injected.add(i);
+            break; // Only one continuation word per page boundary
+          }
+        }
+      }
+    } catch {
+      // Silently fail — print without continuation words
+    }
+    setTimeout(() => printWindow.print(), 300);
+  }, 600);
 }
 
 export function SkPenghentianDocument({
@@ -501,6 +604,11 @@ export function SkPenghentianDocument({
           text-align: center;
           font-weight: bold;
           margin-bottom: 12px;
+        }
+        .sk-print-root .sk-continuation-word {
+          text-align: right !important;
+          margin-top: 0.5rem;
+          font-weight: normal !important;
         }
         .sk-print-root .sk-ttd {
           width: 20rem;

--- a/frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx
@@ -55,7 +55,7 @@ export function handlePrintSk(orderedSelectedAssets: AuctionAsset[], _skNumber: 
             width: 210mm;
             margin: 0 auto; padding: 5mm 20mm 0;
           }
-          .sk-main-document { page: sk-main; }
+          .sk-main-document { page: sk-main; position: relative; }
           .sk-attachment-document {
             page: sk-attachment;
             page-break-before: always;
@@ -127,6 +127,7 @@ export function handlePrintSk(orderedSelectedAssets: AuctionAsset[], _skNumber: 
           .sk-ketiga-group { break-inside: avoid !important; page-break-inside: avoid !important; }
           .sk-signature-name { font-weight: normal !important; }
           .ttd-placeholder { height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; font-weight: normal !important; text-align: left !important; margin-top: 2rem; margin-bottom: 2rem; }
+          .sk-continuation-word { position: absolute; right: 20mm; width: 166mm; text-align: right !important; margin: 0; padding: 0; font-weight: normal !important; font-size: 11pt; z-index: 2; }
           /* Tembusan */
           .sk-tembusan { margin-top: 2rem; }
           .sk-tembusan, .sk-tembusan p { font-weight: normal !important; text-align: left !important; }
@@ -226,6 +227,14 @@ export function handlePrintSk(orderedSelectedAssets: AuctionAsset[], _skNumber: 
       }
 
       // For each boundary, find the last item that fits and inject continuation word
+      const insertContinuationWord = (label: string, boundary: number) => {
+        const contWord = doc.createElement("p");
+        contWord.className = "sk-continuation-word";
+        contWord.textContent = label;
+        contWord.style.top = `${Math.max(0, boundary - (8 * mmToPx))}px`;
+        mainDoc.appendChild(contWord);
+      };
+
       const injected = new Set<number>();
       for (const boundary of boundaries) {
         for (let i = 0; i < allItems.length; i++) {
@@ -237,16 +246,7 @@ export function handlePrintSk(orderedSelectedAssets: AuctionAsset[], _skNumber: 
 
           if (itemBottom <= boundary && nextTop > boundary && !injected.has(i)) {
             // This item is the last one on this page, next item is on next page
-            const contWord = doc.createElement("p");
-            contWord.style.cssText = "text-align: right; margin: 0.5rem 0 0 0; padding: 0; font-weight: normal; font-size: 11pt;";
-            contWord.textContent = allItems[i].nextLabel;
-
-            // Insert after the item
-            if (allItems[i].el.nextSibling) {
-              allItems[i].el.parentElement?.insertBefore(contWord, allItems[i].el.nextSibling);
-            } else {
-              allItems[i].el.parentElement?.appendChild(contWord);
-            }
+            insertContinuationWord(allItems[i].nextLabel, boundary);
             injected.add(i);
             break; // Only one continuation word per page boundary
           }

--- a/frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx
@@ -40,9 +40,9 @@ export function handlePrintSk(orderedSelectedAssets: AuctionAsset[], _skNumber: 
       <head>
         <title>SK Penghentian Penggunaan BMN</title>
         <style>
-          @page { size: A4; margin: 0 0 28mm 0; }
-          @page sk-main { size: A4; margin: 12mm 0 28mm 0; }
-          @page sk-main:first { size: A4; margin: 0 0 28mm 0; }
+          @page { size: A4; margin: 0; }
+          @page sk-main { size: A4; margin: 0; }
+          @page sk-main:first { size: A4; margin: 0; }
           @page sk-attachment { size: A4; margin: 0; }
           * { box-sizing: border-box; }
           body {
@@ -56,6 +56,24 @@ export function handlePrintSk(orderedSelectedAssets: AuctionAsset[], _skNumber: 
             margin: 0 auto; padding: 5mm 20mm 0;
           }
           .sk-main-document { page: sk-main; position: relative; }
+          .sk-print-root .sk-page.sk-main-document.sk-main-paginated {
+            height: 297mm !important;
+            min-height: 297mm !important;
+            padding: 5mm 20mm 28mm !important;
+            overflow: hidden !important;
+            position: relative !important;
+            box-shadow: none !important;
+          }
+          .sk-print-root .sk-page.sk-main-document.sk-main-paginated.sk-main-continuation-page {
+            padding-top: 18mm !important;
+          }
+          .sk-print-root .sk-main-document.sk-main-page-break {
+            page-break-after: always;
+            break-after: page;
+          }
+          .sk-main-flow { width: 100%; }
+          .sk-main-paginated .sk-paginated-field-section + .sk-paginated-field-section { margin-top: 0 !important; }
+          .sk-main-paginated .sk-paginated-field-section.sk-section-start { margin-top: 0.75rem !important; }
           .sk-attachment-document {
             page: sk-attachment;
             page-break-before: always;
@@ -127,7 +145,7 @@ export function handlePrintSk(orderedSelectedAssets: AuctionAsset[], _skNumber: 
           .sk-ketiga-group { break-inside: avoid !important; page-break-inside: avoid !important; }
           .sk-signature-name { font-weight: normal !important; }
           .ttd-placeholder { height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; font-weight: normal !important; text-align: left !important; margin-top: 2rem; margin-bottom: 2rem; }
-          .sk-continuation-word { position: absolute; right: 20mm; width: 166mm; text-align: right !important; margin: 0; padding: 0; font-weight: normal !important; font-size: 11pt; z-index: 2; }
+          .sk-continuation-word { position: absolute; right: 23mm; bottom: 31mm; width: 163mm; height: 0; line-height: 11pt; overflow: visible; white-space: nowrap; text-align: right !important; margin: 0; padding: 0; font-weight: normal !important; font-size: 11pt; z-index: 20; }
           /* Tembusan */
           .sk-tembusan { margin-top: 2rem; }
           .sk-tembusan, .sk-tembusan p { font-weight: normal !important; text-align: left !important; }
@@ -162,6 +180,50 @@ export function handlePrintSk(orderedSelectedAssets: AuctionAsset[], _skNumber: 
       const body = doc.body;
       if (!body) { printWindow.print(); return; }
 
+      const paginationStyle = doc.createElement("style");
+      paginationStyle.textContent = `
+        @page sk-main { size: A4; margin: 0; }
+        @page sk-main:first { size: A4; margin: 0; }
+        .sk-print-root .sk-page.sk-main-document.sk-main-paginated {
+          height: 297mm !important;
+          min-height: 297mm !important;
+          padding: 5mm 20mm 28mm !important;
+          overflow: hidden !important;
+          position: relative !important;
+          box-shadow: none !important;
+        }
+        .sk-print-root .sk-page.sk-main-document.sk-main-paginated.sk-main-continuation-page {
+          padding-top: 18mm !important;
+        }
+        .sk-print-root .sk-main-document.sk-main-page-break {
+          page-break-after: always;
+          break-after: page;
+        }
+        .sk-main-paginated .sk-paginated-field-section + .sk-paginated-field-section {
+          margin-top: 0 !important;
+        }
+        .sk-main-paginated .sk-paginated-field-section.sk-section-start {
+          margin-top: 0.75rem !important;
+        }
+        .sk-continuation-word {
+          position: absolute !important;
+          right: 23mm !important;
+          bottom: 31mm !important;
+          width: 163mm !important;
+          height: 0 !important;
+          line-height: 11pt !important;
+          overflow: visible !important;
+          white-space: nowrap !important;
+          text-align: right !important;
+          margin: 0 !important;
+          padding: 0 !important;
+          font-weight: normal !important;
+          font-size: 11pt !important;
+          z-index: 20 !important;
+        }
+      `;
+      body.appendChild(paginationStyle);
+
       // Force layout by reading offsetHeight
       void body.offsetHeight;
 
@@ -170,88 +232,215 @@ export function handlePrintSk(orderedSelectedAssets: AuctionAsset[], _skNumber: 
       // Total A4 = 297mm. Usable first page ≈ 297 - 28 - 5 = 264mm
       // Continuation pages: 297 - 28 - 12 = 257mm (12mm top margin from @page sk-main)
       const mmToPx = 96 / 25.4; // 1mm = 96/25.4 px at screen resolution
-      const firstPageH = 264 * mmToPx;
-      const contPageH = 257 * mmToPx;
+      const firstPageContentH = 264 * mmToPx;
+      const continuationContentH = 251 * mmToPx;
+      const markerReserveH = 9 * mmToPx;
 
       // Collect all breakable items from the main document section
       const mainDoc = doc.querySelector(".sk-main-document");
       if (!mainDoc) { printWindow.print(); return; }
 
-      const allItems: { el: HTMLElement; nextLabel: string }[] = [];
+      const root = mainDoc.parentElement;
+      if (!root) { printWindow.print(); return; }
 
-      // Mengingat items
-      const mengItems = mainDoc.querySelectorAll<HTMLElement>(".sk-mengingat-item");
-      mengItems.forEach((el, idx) => {
-        if (idx < mengItems.length - 1) {
-          const nextEl = mengItems[idx + 1];
-          const numEl = nextEl.querySelector("div:first-child");
-          const textEl = nextEl.querySelector(".sk-mengingat-text");
-          const num = numEl?.textContent?.trim() || "";
-          const text = textEl?.textContent?.trim() || "";
-          const preview = text.length > 40 ? text.slice(0, 40) + "....." : text + ".....";
-          allItems.push({ el: el as HTMLElement, nextLabel: `${num} ${preview}` });
-        }
-      });
+      const continuationLabel = (num: string, text: string) => {
+        const firstWord = text.trim().split(/\s+/)[0] || "";
+        return `${num.trim()} ${firstWord ? `${firstWord}.....` : "....."}`;
+      };
 
-      // Last mengingat item → next is MEMUTUSKAN
-      if (mengItems.length > 0) {
-        const lastMeng = mengItems[mengItems.length - 1] as HTMLElement;
-        allItems.push({ el: lastMeng, nextLabel: "MEMUTUSKAN :" });
-      }
+      const cloneElement = <T extends HTMLElement>(el: T) => el.cloneNode(true) as T;
 
-      // Memutuskan rows
-      const memRows = mainDoc.querySelectorAll<HTMLElement>(".sk-mengingat-row");
-      const rowLabels = ["Menetapkan", "KESATU", "KEDUA", "KETIGA"];
-      memRows.forEach((el, idx) => {
-        if (idx < memRows.length - 1) {
-          const nextLabel = rowLabels[idx + 1] || "";
-          if (nextLabel) {
-            allItems.push({ el: el as HTMLElement, nextLabel: `${nextLabel}.....` });
-          }
-        }
-      });
+      const createFieldBlock = (
+        sectionLabel: string,
+        item: HTMLElement,
+        showSectionLabel: boolean,
+        marginTop = false,
+      ) => {
+        const section = doc.createElement("div");
+        section.className = "sk-field-section sk-paginated-field-section";
+        section.style.marginTop = marginTop ? "0.75rem" : "0";
+        if (marginTop) section.classList.add("sk-section-start");
 
-      // Sort by vertical position
-      const mainTop = mainDoc.getBoundingClientRect().top;
-      allItems.sort((a, b) => {
-        return (a.el.getBoundingClientRect().top - mainTop) - (b.el.getBoundingClientRect().top - mainTop);
-      });
+        const label = doc.createElement("div");
+        label.className = "sk-field-label";
+        label.textContent = showSectionLabel ? sectionLabel : "";
 
-      // Calculate page boundaries
-      const boundaries: number[] = [];
-      let cumH = firstPageH;
-      boundaries.push(cumH);
-      for (let i = 0; i < 10; i++) {
-        cumH += contPageH;
-        boundaries.push(cumH);
-      }
+        const colon = doc.createElement("div");
+        colon.className = "sk-field-colon";
+        colon.textContent = showSectionLabel ? ":" : "";
 
-      // For each boundary, find the last item that fits and inject continuation word
-      const insertContinuationWord = (label: string, boundary: number) => {
+        const list = doc.createElement("div");
+        list.className = "sk-mengingat-list";
+        const itemClone = cloneElement(item);
+        itemClone.style.paddingTop = "0";
+        list.appendChild(itemClone);
+
+        section.append(label, colon, list);
+        return section;
+      };
+
+      const createDecisionBlock = (rows: HTMLElement[]) => {
+        const table = doc.createElement("table");
+        table.className = "sk-mengingat-table";
+        table.style.borderCollapse = "collapse";
+
+        const tbody = doc.createElement("tbody");
+        rows.forEach((row) => tbody.appendChild(cloneElement(row)));
+        table.appendChild(tbody);
+        return table;
+      };
+
+      const createMemutuskanMenetapkanBlock = (heading: HTMLElement, row: HTMLElement) => {
+        const block = doc.createElement("div");
+        block.appendChild(cloneElement(heading));
+        block.appendChild(createDecisionBlock([row]));
+        return block;
+      };
+
+      const makePage = (isFirstPage: boolean) => {
+        const page = doc.createElement("article");
+        page.className = "sk-page sk-page-ttd sk-main-document sk-main-paginated mx-auto max-w-[210mm] bg-white px-24 py-9 text-black";
+        if (!isFirstPage) page.classList.add("sk-main-continuation-page");
+        page.style.cssText = [
+          "width: 210mm",
+          "height: 297mm",
+          "min-height: 297mm",
+          "margin: 0 auto",
+          `padding: ${isFirstPage ? "5mm" : "18mm"} 20mm 28mm`,
+          "overflow: hidden",
+          "position: relative",
+          "box-sizing: border-box",
+          "background: white",
+          "color: black",
+        ].join("; ");
+
+        const flow = doc.createElement("div");
+        flow.className = "sk-main-flow";
+        page.appendChild(flow);
+
+        const bodyWrap = doc.createElement("div");
+        bodyWrap.className = "sk-body";
+        flow.appendChild(bodyWrap);
+
+        return { page, flow, bodyWrap };
+      };
+
+      const addContinuationWord = (page: HTMLElement, label: string) => {
         const contWord = doc.createElement("p");
         contWord.className = "sk-continuation-word";
         contWord.textContent = label;
-        contWord.style.top = `${Math.max(0, boundary - (8 * mmToPx))}px`;
-        mainDoc.appendChild(contWord);
+        page.appendChild(contWord);
       };
 
-      const injected = new Set<number>();
-      for (const boundary of boundaries) {
-        for (let i = 0; i < allItems.length; i++) {
-          const rect = allItems[i].el.getBoundingClientRect();
-          const itemBottom = rect.bottom - mainTop;
-          const nextTop = i < allItems.length - 1
-            ? allItems[i + 1].el.getBoundingClientRect().top - mainTop
-            : Infinity;
+      const measureFlowContentHeight = (flow: HTMLElement) => {
+        const flowTop = flow.getBoundingClientRect().top;
+        return Array.from(flow.children).reduce((maxBottom, child) => {
+          const rect = (child as HTMLElement).getBoundingClientRect();
+          return Math.max(maxBottom, rect.bottom - flowTop);
+        }, 0);
+      };
 
-          if (itemBottom <= boundary && nextTop > boundary && !injected.has(i)) {
-            // This item is the last one on this page, next item is on next page
-            insertContinuationWord(allItems[i].nextLabel, boundary);
-            injected.add(i);
-            break; // Only one continuation word per page boundary
-          }
-        }
+      const measureOuterHeight = (el: HTMLElement) => {
+        const rect = el.getBoundingClientRect();
+        const style = printWindow.getComputedStyle(el);
+        const marginTop = Number.parseFloat(style.marginTop || "0") || 0;
+        const marginBottom = Number.parseFloat(style.marginBottom || "0") || 0;
+        return rect.height + marginTop + marginBottom;
+      };
+
+      const contentWrap = mainDoc.querySelector<HTMLElement>(".sk-subtitle");
+      const contentSections = contentWrap?.querySelector<HTMLElement>("div");
+      const fieldSections = contentSections?.querySelectorAll<HTMLElement>(":scope > .sk-field-section");
+      const menimbangItems = fieldSections?.[0]?.querySelectorAll<HTMLElement>(".sk-mengingat-item") || [];
+      const mengingatItems = fieldSections?.[1]?.querySelectorAll<HTMLElement>(".sk-mengingat-item") || [];
+
+      const explicitMemutuskanHeading = mainDoc.querySelector<HTMLElement>(".sk-memutuskan");
+      const explicitMemRows = Array.from(mainDoc.querySelectorAll<HTMLElement>(".sk-mengingat-row"));
+      const ketigaGroup = mainDoc.querySelector<HTMLElement>(".sk-ketiga-group");
+
+      let currentPage = makePage(true);
+      root.insertBefore(currentPage.page, mainDoc);
+
+      const kop = mainDoc.querySelector<HTMLElement>(".sk-kop");
+      const title = mainDoc.querySelector<HTMLElement>(".sk-title");
+      const intro = doc.createElement("div");
+      intro.className = "sk-subtitle sk-body";
+      const introParagraphs = Array.from(contentWrap?.children || []).filter((child) => {
+        return child.tagName === "P" && !(child as HTMLElement).classList.contains("sk-memutuskan");
+      });
+      introParagraphs.forEach((child) => intro.appendChild(cloneElement(child as HTMLElement)));
+
+      const firstBody = currentPage.bodyWrap;
+      currentPage.flow.insertBefore(intro, firstBody);
+      if (title) currentPage.flow.insertBefore(cloneElement(title), intro);
+      if (kop) currentPage.flow.insertBefore(cloneElement(kop), currentPage.flow.firstChild);
+      let currentUsedHeight = measureFlowContentHeight(currentPage.flow);
+
+      const blocks: { el: HTMLElement; label: string }[] = [];
+      Array.from(menimbangItems).forEach((item, index) => {
+        const num = item.querySelector("div:first-child")?.textContent || "";
+        const text = item.querySelector(".sk-mengingat-text")?.textContent || "";
+        blocks.push({
+          el: createFieldBlock("Menimbang", item, index === 0),
+          label: continuationLabel(num, text),
+        });
+      });
+
+      Array.from(mengingatItems).forEach((item, index) => {
+        const num = item.querySelector("div:first-child")?.textContent || "";
+        const text = item.querySelector(".sk-mengingat-text")?.textContent || "";
+        blocks.push({
+          el: createFieldBlock("Mengingat", item, index === 0, index === 0),
+          label: continuationLabel(num, text),
+        });
+      });
+
+      if (explicitMemutuskanHeading && explicitMemRows[0]) {
+        const memutuskanBlock = createMemutuskanMenetapkanBlock(explicitMemutuskanHeading, explicitMemRows[0]);
+        blocks.push({ el: memutuskanBlock, label: "MEMUTUSKAN....." });
+      } else if (explicitMemutuskanHeading) {
+        blocks.push({ el: cloneElement(explicitMemutuskanHeading), label: "MEMUTUSKAN....." });
+      } else if (explicitMemRows[0]) {
+        blocks.push({ el: createDecisionBlock([explicitMemRows[0]]), label: "Menetapkan....." });
       }
+      if (explicitMemRows[1]) {
+        blocks.push({ el: createDecisionBlock([explicitMemRows[1]]), label: "KESATU....." });
+      }
+      if (explicitMemRows[2]) {
+        blocks.push({ el: createDecisionBlock([explicitMemRows[2]]), label: "KEDUA....." });
+      }
+      if (ketigaGroup) {
+        blocks.push({ el: cloneElement(ketigaGroup), label: "KETIGA....." });
+      }
+
+      blocks.forEach((block, index) => {
+        const isLastBlock = index === blocks.length - 1;
+        const contentLimit = currentPage.page.classList.contains("sk-main-continuation-page")
+          ? continuationContentH
+          : firstPageContentH;
+        const maxFlowHeight = contentLimit - (isLastBlock ? 0 : markerReserveH);
+        const markerSafeHeight = contentLimit - markerReserveH;
+
+        currentPage.bodyWrap.appendChild(block.el);
+        const blockHeight = measureOuterHeight(block.el);
+        const flowHeight = currentUsedHeight + blockHeight;
+        const canMoveToNextPage = currentPage.bodyWrap.children.length > 1;
+        if ((flowHeight > maxFlowHeight || (!isLastBlock && flowHeight > markerSafeHeight)) && canMoveToNextPage) {
+          currentPage.bodyWrap.removeChild(block.el);
+          currentPage.page.classList.add("sk-main-page-break");
+          addContinuationWord(currentPage.page, block.label);
+
+          currentPage = makePage(false);
+          root.insertBefore(currentPage.page, mainDoc);
+          currentPage.bodyWrap.appendChild(block.el);
+          currentUsedHeight = measureOuterHeight(block.el);
+        } else {
+          currentUsedHeight = flowHeight;
+        }
+      });
+
+      root.removeChild(mainDoc);
+
     } catch {
       // Silently fail — print without continuation words
     }


### PR DESCRIPTION
Closes #352

## Summary
- paginate SK main document into explicit A4 print pages
- add stable continuation words at page breaks
- keep BSrE bottom safe area and group decision/signature blocks
- update docs/HANDOFF.md and docs/progress.md

## Validation
- npx eslint src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx --max-warnings=0
- npx tsc --noEmit
- npm run build
- git diff --check -- frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx docs/HANDOFF.md docs/progress.md