### PR TITLE
feat(bmn): add SK Panitia Penghapusan BMN (#354)

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -119,15 +119,22 @@ git push origin main
 - [x] Issue #348: Align colons in SK Ditetapkan/Pada tanggal block. PR #349 merged ke `main` (merge commit `b29e5f5`).
 - [x] Issue #350: Add SK Builder panel beside SK preview (Menimbang/Mengingat/Memutuskan/Tembusan editable + Kepala Balai picker dari kepegawaian). PR #351 merged ke `main` (merge commit `b833a20`).
 - [x] Issue #352: Add continuation words at page breaks in SK document. Branch `issue/352-sk-continuation-words` siap PR/merge.
+- [ ] Issue #354 (IN PROGRESS): Add SK Panitia Penghapusan BMN document. Branch `issue/354-sk-panitia-penghapusan`.
 
 | Field | Value |
 |-------|-------|
-| **Issue Terakhir Selesai** | Issue #352: SK continuation words at page breaks |
-| **Issue Sedang Dikerjakan** | Tidak ada — Issue #352 siap PR/merge |
-| **Branch Aktif** | `issue/352-sk-continuation-words` |
-| **Commit Terakhir di Branch** | Pending commit final sesi ini |
-| **Status** | DONE: SK utama memakai print-only A4 pagination eksplisit; continuation word kanan bawah stabil; margin bawah BSrE aman; MEMUTUSKAN+Menetapkan dan KETIGA+TTD dijaga sebagai unit; lampiran SK tidak diubah. |
-| **Model Terakhir** | Codex |
+| **Issue Terakhir Selesai** | Issue #352: SK continuation words (PR #353 merged) |
+| **Issue Sedang Dikerjakan** | Issue #354: SK Panitia Penghapusan — branch `issue/354-sk-panitia-penghapusan` |
+| **Branch Aktif** | `issue/354-sk-panitia-penghapusan` |
+| **Commit Terakhir di Branch** | `3c03738` |
+| **Status** | WIP: SK Panitia + lampiran tabel (No/Nama-NIP-Jabatan/Jabatan Kegiatan) + employee search + spacing tuning. TODO: (1) spacing MEMUTUSKAN→Tembusan masih besar, (2) sub-item c/d di KEDUA tidak align dengan a/b. |
+| **Model Terakhir** | Kiro |
+| **Timestamp** | 2026-05-21T18:00:00+08:00 |
+
+### TODO Issue #354:
+- [ ] Kurangi spacing antara MEMUTUSKAN → KETIGA → TTD → Tembusan (masih terlalu besar)
+- [ ] Fix alignment sub-item c, d di KEDUA agar sejajar dengan a, b (indentasi)
+- [ ] Verify cetak PDF final
 | **Timestamp** | 2026-05-21T23:59:00+08:00 |
 
 ### Issue #352 Summary:

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,7 +1,45 @@
+# Progress - Phase 51: SK Panitia Penghapusan BMN (IN PROGRESS)
+
+> Document updated: 2026-05-21
+> Status: **IN PROGRESS** 🔄
+
+---
+
+## Issue #354: SK Panitia Penghapusan BMN
+
+### Completed:
+- [x] **Issue Created**: Issue #354.
+- [x] **Branch**: `issue/354-sk-panitia-penghapusan` aktif.
+- [x] **SK Panitia Document**: Komponen `SkPanitiaDocument.tsx` — mirip SK Penghentian tapi isi berbeda (Panitia Penghapusan).
+- [x] **Defaults**: `sk-panitia-defaults.ts` — Menimbang 2 item, Mengingat 8 peraturan, Memutuskan (KEDUA punya sub-items), Tembusan 3 item (termasuk "Yang Bersangkutan").
+- [x] **Lampiran tabel border**: No. | Nama/NIP/Jabatan | Jabatan dalam Kegiatan (tanpa Keterangan).
+- [x] **Employee search**: Dropdown dari `/kepegawaian/employees/select` untuk susunan panitia. Auto-fill nama, NIP (formatted), jabatan instansi (dari field `position`).
+- [x] **Toggle 3 dokumen**: BA / SK Penghentian / SK Panitia — hanya satu tampil.
+- [x] **Tombol teal**: "Proses SK Panitia" di action bar dan banner.
+- [x] **Input nomor SK Panitia**: Format `SK.____/K.18/TU/KAP.05/MM/YYYY`.
+- [x] **Spacing tuning**: line-height 1.25, reduced margins/paddings, firstPageContentH=280mm.
+- [x] **Continuation words**: Pagination eksplisit dengan kata penyambung (reuse pattern dari SK Penghentian).
+
+### Pending / TODO:
+- [ ] **Spacing MEMUTUSKAN → Tembusan** masih terlalu besar saat cetak PDF.
+- [ ] **Sub-item c, d di KEDUA** tidak align dengan a, b (indentasi `white-space: pre-wrap` tidak konsisten).
+- [ ] **PR belum dibuat** — menunggu fix spacing dan alignment.
+
+### Key Files:
+- `frontend/src/app/bmn/auction-candidates/_components/SkPanitiaDocument.tsx` (new)
+- `frontend/src/app/bmn/auction-candidates/_lib/sk-panitia-defaults.ts` (new)
+- `frontend/src/app/bmn/auction-candidates/page.tsx`
+
+### Validation:
+- [x] `npx eslint --max-warnings=0` clean
+- [x] `npx tsc --noEmit` clean
+
+---
+
 # Progress - Phase 50: SK Continuation Words
 
 > Document updated: 2026-05-21
-> Status: **READY TO MERGE** ✅
+> Status: **MERGED** ✅
 
 ---
 

--- a/frontend/src/app/bmn/auction-candidates/_components/SkPanitiaDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkPanitiaDocument.tsx
@@ -1,0 +1,826 @@
+"use client";
+
+import { toast } from "sonner";
+import { formatDateLong, getSkNumberSuffix } from "../_lib/auction-helpers";
+import type {
+  SkBuilderItem,
+  SkKepalaBalai,
+  SkMemutuskan,
+} from "../_lib/sk-defaults";
+import type { PanitiaAnggota } from "../_lib/sk-panitia-defaults";
+
+interface SkPanitiaDocumentProps {
+  skNumber: string;
+  menimbang: SkBuilderItem[];
+  mengingat: SkBuilderItem[];
+  memutuskan: SkMemutuskan;
+  kepalaBalai: SkKepalaBalai;
+  tembusan: SkBuilderItem[];
+  susunanPanitia: PanitiaAnggota[];
+}
+
+export function handlePrintSkPanitia() {
+  const printContent = document.getElementById("sk-panitia-print-root");
+  if (!printContent) {
+    toast.error("Tidak ada dokumen SK Panitia untuk dicetak.");
+    return;
+  }
+  const printWindow = window.open("", "_blank");
+  if (!printWindow) return;
+
+  printWindow.document.write(`
+    <html>
+      <head>
+        <title>SK Panitia Penghapusan BMN</title>
+        <style>
+          @page { size: A4; margin: 0; }
+          @page skp-main { size: A4; margin: 0; }
+          @page skp-main:first { size: A4; margin: 0; }
+          * { box-sizing: border-box; }
+          body {
+            margin: 0; padding: 0; background: white; color: black;
+            font-family: 'Bookman Old Style', Georgia, serif;
+            font-size: 11pt; line-height: 1.25;
+          }
+          p { margin: 0; padding: 0; }
+          .skp-page {
+            width: 210mm;
+            margin: 0 auto; padding: 5mm 20mm 0;
+          }
+          .skp-main-document { page: skp-main; position: relative; }
+          .skp-print-root .skp-page.skp-main-document.skp-main-paginated {
+            height: 297mm !important;
+            min-height: 297mm !important;
+            padding: 5mm 20mm 18mm !important;
+            overflow: hidden !important;
+            position: relative !important;
+            box-shadow: none !important;
+          }
+          .skp-print-root .skp-page.skp-main-document.skp-main-paginated.skp-main-continuation-page {
+            padding-top: 18mm !important;
+          }
+          .skp-print-root .skp-main-document.skp-main-page-break {
+            page-break-after: always;
+            break-after: page;
+          }
+          .skp-main-flow { width: 100%; }
+          .skp-main-paginated .skp-paginated-field-section + .skp-paginated-field-section { margin-top: 0 !important; }
+          .skp-main-paginated .skp-paginated-field-section.skp-section-start { margin-top: 0.5rem !important; }
+          .skp-page-ttd { padding-bottom: 0; }
+          article { margin: 0; }
+          .skp-page-break { page-break-after: always; break-after: always; }
+          /* KOP */
+          .skp-kop {
+            margin-top: -5mm; margin-left: -16mm; margin-right: -16mm;
+            margin-bottom: 6px; text-align: center;
+          }
+          .skp-kop img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
+          /* Judul SK */
+          .skp-title {
+            width: 166mm; margin-left: auto; margin-right: auto;
+            margin-top: 10px; text-align: center; font-weight: bold; line-height: 1.3;
+          }
+          .skp-title-nomor { font-weight: normal; }
+          .skp-title-tentang { margin-top: 10px; }
+          /* Sub-judul */
+          .skp-subtitle {
+            width: 166mm; margin-left: auto; margin-right: auto;
+            margin-top: 16px;
+          }
+          .skp-subtitle > p { text-align: center; font-weight: bold; }
+          .skp-subtitle > p + p { margin-top: 6px; }
+          /* Body */
+          .skp-body { width: 166mm; margin-left: auto; margin-right: auto; }
+          table { border-collapse: collapse; width: 100%; }
+          td { vertical-align: top; padding: 0; }
+          /* Menimbang/Mengingat */
+          .skp-field-section {
+            display: grid;
+            grid-template-columns: 28mm 8mm minmax(0, 1fr);
+            break-inside: auto !important;
+            page-break-inside: auto !important;
+          }
+          .skp-field-section + .skp-field-section { margin-top: 0.5rem; }
+          .skp-field-label, .skp-field-colon { padding: 0; }
+          .skp-field-colon { text-align: center; }
+          .skp-mengingat-list {
+            break-inside: auto !important;
+            page-break-inside: auto !important;
+          }
+          .skp-mengingat-item {
+            display: grid;
+            grid-template-columns: 9mm minmax(0, 1fr);
+            break-inside: avoid !important;
+            page-break-inside: avoid !important;
+            padding-top: 0;
+          }
+          .skp-mengingat-item:first-child { padding-top: 0; }
+          .skp-mengingat-text { text-align: justify; }
+          /* Memutuskan */
+          .skp-memutuskan { text-align: center; font-weight: bold; margin-bottom: 12px; }
+          /* TTD block */
+          .skp-ttd { width: 20rem; margin-left: auto; margin-top: 3rem; }
+          .skp-ttd, .skp-ttd p { font-weight: normal !important; text-align: left !important; }
+          .skp-ttd p { margin: 0; padding: 0; line-height: 1.3; }
+          .skp-ttd-meta { display: grid !important; grid-template-columns: max-content auto 1fr; column-gap: 0.4rem; line-height: 1.3; }
+          .skp-ttd-meta span { font-weight: normal !important; text-align: left !important; }
+          .skp-ketiga-group { break-inside: avoid !important; page-break-inside: avoid !important; }
+          .skp-signature-name { font-weight: normal !important; }
+          .skp-ttd-placeholder { height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; font-weight: normal !important; text-align: left !important; margin-top: 2rem; margin-bottom: 2rem; }
+          .skp-continuation-word { position: absolute; right: 23mm; bottom: 31mm; width: 163mm; height: 0; line-height: 11pt; overflow: visible; white-space: nowrap; text-align: right !important; margin: 0; padding: 0; font-weight: normal !important; font-size: 11pt; z-index: 20; }
+          /* Tembusan */
+          .skp-tembusan { margin-top: 2rem; }
+          .skp-tembusan, .skp-tembusan p { font-weight: normal !important; text-align: left !important; }
+          .skp-tembusan p { margin: 0; padding: 0; line-height: 1.5; }
+          /* pre-wrap for KEDUA */
+          .skp-kedua-text { white-space: pre-wrap; }
+          /* Lampiran */
+          .skp-lampiran {
+            width: 210mm;
+            margin: 0 auto;
+            padding: 12mm 20mm 28mm;
+            page-break-before: always;
+            break-before: page;
+          }
+          .skp-attachment-meta { width: 109mm; margin-left: auto; text-align: left; }
+          .skp-attachment-meta .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
+          .skp-attachment-meta .meta-label { white-space: nowrap; }
+          .skp-attachment-meta .meta-colon { text-align: center; }
+          .skp-lampiran-title { text-align: center; font-weight: bold; line-height: 1.3; margin-top: 1.5rem; margin-bottom: 0.75rem; }
+          .skp-panitia-table { width: 100%; border-collapse: collapse; font-size: 10pt; }
+          .skp-panitia-table th, .skp-panitia-table td { border: 1px solid #000; padding: 0.5rem; }
+          .skp-panitia-table td { vertical-align: middle; }
+        </style>
+      </head>
+      <body>${printContent.innerHTML}</body>
+    </html>
+  `);
+  printWindow.document.close();
+  printWindow.focus();
+  setTimeout(() => {
+    try {
+      const doc = printWindow.document;
+      const body = doc.body;
+      if (!body) { printWindow.print(); return; }
+
+      const paginationStyle = doc.createElement("style");
+      paginationStyle.textContent = `
+        @page skp-main { size: A4; margin: 0; }
+        @page skp-main:first { size: A4; margin: 0; }
+        .skp-print-root .skp-page.skp-main-document.skp-main-paginated {
+          height: 297mm !important;
+          min-height: 297mm !important;
+          padding: 5mm 20mm 18mm !important;
+          overflow: hidden !important;
+          position: relative !important;
+          box-shadow: none !important;
+        }
+        .skp-print-root .skp-page.skp-main-document.skp-main-paginated.skp-main-continuation-page {
+          padding-top: 18mm !important;
+        }
+        .skp-print-root .skp-main-document.skp-main-page-break {
+          page-break-after: always;
+          break-after: page;
+        }
+        .skp-main-paginated .skp-paginated-field-section + .skp-paginated-field-section {
+          margin-top: 0 !important;
+        }
+        .skp-main-paginated .skp-paginated-field-section.skp-section-start {
+          margin-top: 0.5rem !important;
+        }
+        .skp-continuation-word {
+          position: absolute !important;
+          right: 23mm !important;
+          bottom: 31mm !important;
+          width: 163mm !important;
+          height: 0 !important;
+          line-height: 11pt !important;
+          overflow: visible !important;
+          white-space: nowrap !important;
+          text-align: right !important;
+          margin: 0 !important;
+          padding: 0 !important;
+          font-weight: normal !important;
+          font-size: 11pt !important;
+          z-index: 20 !important;
+        }
+      `;
+      body.appendChild(paginationStyle);
+
+      void body.offsetHeight;
+
+      const mmToPx = 96 / 25.4;
+      const firstPageContentH = 280 * mmToPx;
+      const continuationContentH = 267 * mmToPx;
+      const markerReserveH = 5 * mmToPx;
+
+      const mainDoc = doc.querySelector(".skp-main-document");
+      if (!mainDoc) { printWindow.print(); return; }
+
+      const root = mainDoc.parentElement;
+      if (!root) { printWindow.print(); return; }
+
+      const continuationLabel = (num: string, text: string) => {
+        const firstWord = text.trim().split(/\s+/)[0] || "";
+        return `${num.trim()} ${firstWord ? `${firstWord}.....` : "....."}`;
+      };
+
+      const cloneElement = <T extends HTMLElement>(el: T) => el.cloneNode(true) as T;
+
+      const createFieldBlock = (
+        sectionLabel: string,
+        item: HTMLElement,
+        showSectionLabel: boolean,
+        marginTop = false,
+      ) => {
+        const section = doc.createElement("div");
+        section.className = "skp-field-section skp-paginated-field-section";
+        section.style.marginTop = marginTop ? "0.75rem" : "0";
+        if (marginTop) section.classList.add("skp-section-start");
+
+        const label = doc.createElement("div");
+        label.className = "skp-field-label";
+        label.textContent = showSectionLabel ? sectionLabel : "";
+
+        const colon = doc.createElement("div");
+        colon.className = "skp-field-colon";
+        colon.textContent = showSectionLabel ? ":" : "";
+
+        const list = doc.createElement("div");
+        list.className = "skp-mengingat-list";
+        const itemClone = cloneElement(item);
+        itemClone.style.paddingTop = "0";
+        list.appendChild(itemClone);
+
+        section.append(label, colon, list);
+        return section;
+      };
+
+      const createDecisionBlock = (rows: HTMLElement[]) => {
+        const table = doc.createElement("table");
+        table.className = "skp-mengingat-table";
+        table.style.borderCollapse = "collapse";
+
+        const tbody = doc.createElement("tbody");
+        rows.forEach((row) => tbody.appendChild(cloneElement(row)));
+        table.appendChild(tbody);
+        return table;
+      };
+
+      const createMemutuskanMenetapkanBlock = (heading: HTMLElement, row: HTMLElement) => {
+        const block = doc.createElement("div");
+        block.appendChild(cloneElement(heading));
+        block.appendChild(createDecisionBlock([row]));
+        return block;
+      };
+
+      const makePage = (isFirstPage: boolean) => {
+        const page = doc.createElement("article");
+        page.className = "skp-page skp-page-ttd skp-main-document skp-main-paginated mx-auto max-w-[210mm] bg-white px-24 py-9 text-black";
+        if (!isFirstPage) page.classList.add("skp-main-continuation-page");
+        page.style.cssText = [
+          "width: 210mm",
+          "height: 297mm",
+          "min-height: 297mm",
+          "margin: 0 auto",
+          `padding: ${isFirstPage ? "5mm" : "18mm"} 20mm 28mm`,
+          "overflow: hidden",
+          "position: relative",
+          "box-sizing: border-box",
+          "background: white",
+          "color: black",
+        ].join("; ");
+
+        const flow = doc.createElement("div");
+        flow.className = "skp-main-flow";
+        page.appendChild(flow);
+
+        const bodyWrap = doc.createElement("div");
+        bodyWrap.className = "skp-body";
+        flow.appendChild(bodyWrap);
+
+        return { page, flow, bodyWrap };
+      };
+
+      const addContinuationWord = (page: HTMLElement, label: string) => {
+        const contWord = doc.createElement("p");
+        contWord.className = "skp-continuation-word";
+        contWord.textContent = label;
+        page.appendChild(contWord);
+      };
+
+      const measureFlowContentHeight = (flow: HTMLElement) => {
+        const flowTop = flow.getBoundingClientRect().top;
+        return Array.from(flow.children).reduce((maxBottom, child) => {
+          const rect = (child as HTMLElement).getBoundingClientRect();
+          return Math.max(maxBottom, rect.bottom - flowTop);
+        }, 0);
+      };
+
+      const measureOuterHeight = (el: HTMLElement) => {
+        const rect = el.getBoundingClientRect();
+        const style = printWindow.getComputedStyle(el);
+        const marginTop = Number.parseFloat(style.marginTop || "0") || 0;
+        const marginBottom = Number.parseFloat(style.marginBottom || "0") || 0;
+        return rect.height + marginTop + marginBottom;
+      };
+
+      const contentWrap = mainDoc.querySelector<HTMLElement>(".skp-subtitle");
+      const contentSections = contentWrap?.querySelector<HTMLElement>("div");
+      const fieldSections = contentSections?.querySelectorAll<HTMLElement>(":scope > .skp-field-section");
+      const menimbangItems = fieldSections?.[0]?.querySelectorAll<HTMLElement>(".skp-mengingat-item") || [];
+      const mengingatItems = fieldSections?.[1]?.querySelectorAll<HTMLElement>(".skp-mengingat-item") || [];
+
+      const explicitMemutuskanHeading = mainDoc.querySelector<HTMLElement>(".skp-memutuskan");
+      const explicitMemRows = Array.from(mainDoc.querySelectorAll<HTMLElement>(".skp-mengingat-row"));
+      const ketigaGroup = mainDoc.querySelector<HTMLElement>(".skp-ketiga-group");
+
+      let currentPage = makePage(true);
+      root.insertBefore(currentPage.page, mainDoc);
+
+      const kop = mainDoc.querySelector<HTMLElement>(".skp-kop");
+      const title = mainDoc.querySelector<HTMLElement>(".skp-title");
+      const intro = doc.createElement("div");
+      intro.className = "skp-subtitle skp-body";
+      const introParagraphs = Array.from(contentWrap?.children || []).filter((child) => {
+        return child.tagName === "P" && !(child as HTMLElement).classList.contains("skp-memutuskan");
+      });
+      introParagraphs.forEach((child) => intro.appendChild(cloneElement(child as HTMLElement)));
+
+      const firstBody = currentPage.bodyWrap;
+      currentPage.flow.insertBefore(intro, firstBody);
+      if (title) currentPage.flow.insertBefore(cloneElement(title), intro);
+      if (kop) currentPage.flow.insertBefore(cloneElement(kop), currentPage.flow.firstChild);
+      let currentUsedHeight = measureFlowContentHeight(currentPage.flow);
+
+      const blocks: { el: HTMLElement; label: string }[] = [];
+      Array.from(menimbangItems).forEach((item, index) => {
+        const num = item.querySelector("div:first-child")?.textContent || "";
+        const text = item.querySelector(".skp-mengingat-text")?.textContent || "";
+        blocks.push({
+          el: createFieldBlock("Menimbang", item, index === 0),
+          label: continuationLabel(num, text),
+        });
+      });
+
+      Array.from(mengingatItems).forEach((item, index) => {
+        const num = item.querySelector("div:first-child")?.textContent || "";
+        const text = item.querySelector(".skp-mengingat-text")?.textContent || "";
+        blocks.push({
+          el: createFieldBlock("Mengingat", item, index === 0, index === 0),
+          label: continuationLabel(num, text),
+        });
+      });
+
+      if (explicitMemutuskanHeading && explicitMemRows[0]) {
+        const memutuskanBlock = createMemutuskanMenetapkanBlock(explicitMemutuskanHeading, explicitMemRows[0]);
+        blocks.push({ el: memutuskanBlock, label: "MEMUTUSKAN....." });
+      } else if (explicitMemutuskanHeading) {
+        blocks.push({ el: cloneElement(explicitMemutuskanHeading), label: "MEMUTUSKAN....." });
+      } else if (explicitMemRows[0]) {
+        blocks.push({ el: createDecisionBlock([explicitMemRows[0]]), label: "Menetapkan....." });
+      }
+      if (explicitMemRows[1]) {
+        blocks.push({ el: createDecisionBlock([explicitMemRows[1]]), label: "KESATU....." });
+      }
+      if (explicitMemRows[2]) {
+        blocks.push({ el: createDecisionBlock([explicitMemRows[2]]), label: "KEDUA....." });
+      }
+      if (ketigaGroup) {
+        blocks.push({ el: cloneElement(ketigaGroup), label: "KETIGA....." });
+      }
+
+      blocks.forEach((block, index) => {
+        const isLastBlock = index === blocks.length - 1;
+        const contentLimit = currentPage.page.classList.contains("skp-main-continuation-page")
+          ? continuationContentH
+          : firstPageContentH;
+        const maxFlowHeight = contentLimit - (isLastBlock ? 0 : markerReserveH);
+        const markerSafeHeight = contentLimit - markerReserveH;
+
+        currentPage.bodyWrap.appendChild(block.el);
+        const blockHeight = measureOuterHeight(block.el);
+        const flowHeight = currentUsedHeight + blockHeight;
+        const canMoveToNextPage = currentPage.bodyWrap.children.length > 1;
+        if ((flowHeight > maxFlowHeight || (!isLastBlock && flowHeight > markerSafeHeight)) && canMoveToNextPage) {
+          currentPage.bodyWrap.removeChild(block.el);
+          currentPage.page.classList.add("skp-main-page-break");
+          addContinuationWord(currentPage.page, block.label);
+
+          currentPage = makePage(false);
+          root.insertBefore(currentPage.page, mainDoc);
+          currentPage.bodyWrap.appendChild(block.el);
+          currentUsedHeight = measureOuterHeight(block.el);
+        } else {
+          currentUsedHeight = flowHeight;
+        }
+      });
+
+      root.removeChild(mainDoc);
+
+    } catch {
+      // Silently fail — print without continuation words
+    }
+    setTimeout(() => printWindow.print(), 300);
+  }, 600);
+}
+
+
+export function SkPanitiaDocument({
+  skNumber,
+  menimbang,
+  mengingat,
+  memutuskan,
+  kepalaBalai,
+  tembusan,
+  susunanPanitia,
+}: SkPanitiaDocumentProps) {
+  const today = new Date();
+  const skNumberText = `SK.${skNumber.trim() || "____"}/${getSkNumberSuffix(today)}`;
+
+  const mengingatTexts = mengingat.map((m) => m.text);
+
+  const pageStyle: React.CSSProperties = {
+    fontFamily: "'Bookman Old Style', Georgia, serif",
+    fontSize: "11pt",
+    lineHeight: "1.4",
+  };
+
+  return (
+    <div id="sk-panitia-print-root" className="skp-print-root">
+      <style jsx global>{`
+        .skp-print-root .skp-page {
+          width: 210mm;
+          margin-left: auto;
+          margin-right: auto;
+          box-sizing: border-box;
+        }
+        .skp-print-root .skp-main-document {
+          padding: 5mm 20mm 0 !important;
+        }
+        .skp-print-root .skp-kop {
+          margin-top: -5mm;
+          margin-left: -16mm;
+          margin-right: -16mm;
+          margin-bottom: 4px;
+          text-align: center;
+        }
+        .skp-print-root .skp-kop img {
+          width: 196mm !important;
+          max-width: 196mm !important;
+          height: auto !important;
+          display: block;
+          margin: 0 auto;
+        }
+        .skp-print-root .skp-title,
+        .skp-print-root .skp-subtitle,
+        .skp-print-root .skp-body {
+          width: 166mm;
+          margin-left: auto;
+          margin-right: auto;
+        }
+        .skp-print-root .skp-title {
+          margin-top: 10px;
+          text-align: center;
+          font-weight: bold;
+          line-height: 1.3;
+        }
+        .skp-print-root .skp-title-nomor {
+          font-weight: normal;
+        }
+        .skp-print-root .skp-title-tentang {
+          margin-top: 10px;
+        }
+        .skp-print-root .skp-subtitle {
+          margin-top: 16px;
+        }
+        .skp-print-root .skp-subtitle > p {
+          text-align: center;
+          font-weight: bold;
+        }
+        .skp-print-root .skp-subtitle > p + p {
+          margin-top: 6px;
+        }
+        .skp-print-root p {
+          margin: 0;
+          padding: 0;
+        }
+        .skp-print-root table {
+          border-collapse: collapse;
+          width: 100%;
+        }
+        .skp-print-root td {
+          vertical-align: top;
+          padding: 0;
+        }
+        .skp-print-root .skp-field-section {
+          display: grid;
+          grid-template-columns: 28mm 8mm minmax(0, 1fr);
+          break-inside: auto;
+          page-break-inside: auto;
+        }
+        .skp-print-root .skp-field-section + .skp-field-section {
+          margin-top: 0.5rem;
+        }
+        .skp-print-root .skp-field-colon {
+          text-align: center;
+        }
+        .skp-print-root .skp-mengingat-list {
+          break-inside: auto;
+          page-break-inside: auto;
+        }
+        .skp-print-root .skp-mengingat-item {
+          display: grid;
+          grid-template-columns: 9mm minmax(0, 1fr);
+          break-inside: avoid;
+          page-break-inside: avoid;
+          padding-top: 0;
+        }
+        .skp-print-root .skp-mengingat-item:first-child {
+          padding-top: 0;
+        }
+        .skp-print-root .skp-mengingat-text {
+          text-align: justify;
+        }
+        .skp-print-root .skp-memutuskan {
+          text-align: center;
+          font-weight: bold;
+          margin-bottom: 12px;
+        }
+        .skp-print-root .skp-continuation-word {
+          text-align: right !important;
+          margin-top: 0.5rem;
+          font-weight: normal !important;
+        }
+        .skp-print-root .skp-ttd {
+          width: 20rem;
+          margin-left: auto;
+          margin-top: 3rem;
+        }
+        .skp-print-root .skp-ttd,
+        .skp-print-root .skp-ttd p,
+        .skp-print-root .skp-tembusan,
+        .skp-print-root .skp-tembusan p {
+          font-weight: normal !important;
+          text-align: left !important;
+        }
+        .skp-print-root .skp-ttd p,
+        .skp-print-root .skp-tembusan p {
+          margin: 0;
+          padding: 0;
+        }
+        .skp-print-root .skp-signature-name {
+          font-weight: normal !important;
+        }
+        .skp-print-root .skp-ttd-placeholder {
+          box-sizing: border-box;
+          height: 112px;
+          padding-top: 40px;
+          padding-left: 1.35cm;
+          color: #94a3b8;
+          font-weight: normal !important;
+          text-align: left !important;
+          margin-top: 2rem;
+          margin-bottom: 2rem;
+        }
+        .skp-print-root .skp-tembusan {
+          margin-top: 2rem;
+        }
+        .skp-print-root .skp-tembusan p {
+          line-height: 1.5;
+        }
+        .skp-print-root .skp-kedua-text {
+          white-space: pre-wrap;
+        }
+        .skp-print-root .skp-lampiran {
+          page-break-before: always;
+          break-before: page;
+        }
+        .skp-print-root .skp-attachment-meta {
+          width: 109mm;
+          margin-left: auto;
+          text-align: left;
+        }
+        .skp-print-root .skp-attachment-meta .meta-row {
+          display: grid;
+          grid-template-columns: 24mm 5mm minmax(0, 1fr);
+          align-items: start;
+        }
+        .skp-print-root .skp-attachment-meta .meta-label {
+          white-space: nowrap;
+        }
+        .skp-print-root .skp-attachment-meta .meta-colon {
+          text-align: center;
+        }
+        .skp-print-root .skp-lampiran-title {
+          text-align: center;
+          font-weight: bold;
+          line-height: 1.3;
+          margin-top: 1.5rem;
+          margin-bottom: 0.75rem;
+        }
+        .skp-print-root .skp-panitia-table { width: 100%; border-collapse: collapse; font-size: 10pt; }
+        .skp-print-root .skp-panitia-table th, .skp-print-root .skp-panitia-table td { border: 1px solid #000; padding: 0.5rem; }
+        .skp-print-root .skp-panitia-table td { vertical-align: middle; }
+      `}</style>
+
+      {/* ── HALAMAN SK PANITIA: KOP + Judul + Menimbang + Mengingat + MEMUTUSKAN + TTD + Tembusan ── */}
+      <article
+        className="skp-page skp-page-ttd skp-main-document mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        style={pageStyle}
+      >
+        <div className="skp-kop" style={{ marginTop: "-5mm", marginLeft: "-16mm", marginRight: "-16mm", marginBottom: "4px", textAlign: "center" }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
+        </div>
+
+        <div className="skp-title mx-auto mt-3 w-[166mm] text-center font-bold leading-snug">
+          <p className="m-0">KEPUTUSAN KEPALA BALAI</p>
+          <p className="m-0">KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR</p>
+          <p className="skp-title-nomor m-0 font-normal">Nomor : {skNumberText}</p>
+          <p className="skp-title-tentang m-0 mt-2">TENTANG</p>
+          <p className="m-0">PANITIA PENGHAPUSAN BARANG MILIK NEGARA</p>
+          <p className="m-0">BERUPA ALAT ANGKUTAN BERMOTOR</p>
+        </div>
+
+        <div className="skp-subtitle skp-body mx-auto mt-3 w-[166mm]">
+          <p className="text-center font-bold">DENGAN RAHMAT TUHAN YANG MAHA ESA</p>
+          <p className="mt-2 text-center font-bold">
+            KEPALA BALAI<br />
+            KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR,
+          </p>
+
+          {/* Menimbang + Mengingat */}
+          <div className="mt-2">\n            <div className="skp-field-section">
+              <div className="skp-field-label">Menimbang</div>
+              <div className="skp-field-colon">:</div>
+              <div className="skp-mengingat-list">
+                {menimbang.map((item, i) => (
+                  <div
+                    className="skp-mengingat-item"
+                    key={item.id}
+                    style={i === 0 ? undefined : { paddingTop: "0.15rem" }}
+                  >
+                    <div>{String.fromCharCode(97 + i)}.</div>
+                    <div className="skp-mengingat-text">{item.text}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="skp-field-section">
+              <div className="skp-field-label">Mengingat</div>
+              <div className="skp-field-colon">:</div>
+              <div className="skp-mengingat-list">
+                {mengingatTexts.map((item, i) => (
+                  <div className="skp-mengingat-item" key={i}>
+                    <div>{i + 1}.</div>
+                    <div className="skp-mengingat-text">{item}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* MEMUTUSKAN */}
+          <p className="skp-memutuskan text-center font-bold" style={{ marginTop: "0.75rem" }}>MEMUTUSKAN</p>
+
+          <table className="skp-mengingat-table mt-4 w-full" style={{ borderCollapse: "collapse" }}>
+            <tbody>
+              <tr className="skp-mengingat-row">
+                <td style={{ width: "28mm", verticalAlign: "top" }}>Menetapkan</td>
+                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top" }}>:</td>
+                <td style={{ verticalAlign: "top", textTransform: "uppercase", textAlign: "justify" }}>
+                  {memutuskan.menetapkan}
+                </td>
+              </tr>
+              <tr className="skp-mengingat-row">
+                <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.6rem" }}>KESATU</td>
+                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.6rem" }}>:</td>
+                <td style={{ verticalAlign: "top", paddingTop: "0.6rem", textAlign: "justify" }}>
+                  {memutuskan.kesatu}
+                </td>
+              </tr>
+              <tr className="skp-mengingat-row">
+                <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.6rem" }}>KEDUA</td>
+                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.6rem" }}>:</td>
+                <td style={{ verticalAlign: "top", paddingTop: "0.6rem", textAlign: "justify" }}>
+                  <span className="skp-kedua-text" style={{ whiteSpace: "pre-wrap" }}>{memutuskan.kedua}</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          {/* KETIGA + TTD + Tembusan grouped */}
+          <div className="skp-ketiga-group">
+            <table className="skp-mengingat-table mt-0 w-full" style={{ borderCollapse: "collapse" }}>
+              <tbody>
+                <tr className="skp-mengingat-row">
+                  <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.6rem" }}>KETIGA</td>
+                  <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.6rem" }}>:</td>
+                  <td style={{ verticalAlign: "top", paddingTop: "0.6rem", textAlign: "justify" }}>
+                    {memutuskan.ketiga}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            {/* TTD */}
+            <div className="skp-ttd signature mt-6 ml-auto w-80">
+              <div className="skp-ttd-meta" style={{ display: "grid", gridTemplateColumns: "max-content auto 1fr", columnGap: "0.4rem" }}>
+                <span>Ditetapkan di</span>
+                <span>:</span>
+                <span>Samarinda</span>
+                <span>Pada tanggal</span>
+                <span>:</span>
+                <span>{formatDateLong(today)}</span>
+              </div>
+              <p className="m-0 mt-3">Kepala Balai,</p>
+              <div className="skp-ttd-placeholder mt-4 h-24 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+              <p className="skp-signature-name m-0 mt-4">{kepalaBalai.nama}</p>
+              <p className="m-0">NIP. {kepalaBalai.nip}</p>
+            </div>
+
+            {/* Tembusan */}
+            {tembusan.length > 0 && (
+              <div className="skp-tembusan mt-10">
+                <p className="m-0">Tembusan :</p>
+                {tembusan.length === 1 ? (
+                  <p className="m-0">{tembusan[0].text}</p>
+                ) : (
+                  tembusan.map((item, i) => (
+                    <p key={item.id} className="m-0">{i + 1}.&nbsp; {item.text}</p>
+                  ))
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </article>
+
+      {/* ── HALAMAN LAMPIRAN: Susunan Panitia ── */}
+      <article
+        className="skp-page skp-lampiran mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        style={pageStyle}
+      >
+        <div className="skp-body mx-auto w-[166mm]">
+          {/* Meta header */}
+          <div className="skp-attachment-meta ml-auto w-[109mm]">
+            <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
+              <span>Lampiran</span><span>:</span><span>Surat Keputusan Kepala Balai KSDA Kalimantan Timur</span>
+            </div>
+            <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
+              <span>Nomor</span><span>:</span><span>{skNumberText}</span>
+            </div>
+            <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
+              <span>Tanggal</span><span>:</span><span>{formatDateLong(today)}</span>
+            </div>
+          </div>
+
+          {/* Title */}
+          <p className="skp-lampiran-title mt-6 text-center font-bold leading-snug">
+            PANITIA PENGHAPUSAN BARANG MILIK NEGARA<br />
+            BERUPA ALAT ANGKUTAN BERMOTOR<br />
+            PADA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR
+          </p>
+
+          {/* Susunan Panitia table */}
+          <table className="skp-panitia-table" style={{ width: "100%", borderCollapse: "collapse", marginTop: "2rem", fontSize: "10pt" }}>
+            <thead>
+              <tr>
+                <th style={{ border: "1px solid black", padding: "0.5rem", width: "8mm", textAlign: "center" }}>No.</th>
+                <th style={{ border: "1px solid black", padding: "0.5rem", textAlign: "center" }}>Nama/NIP/Jabatan</th>
+                <th style={{ border: "1px solid black", padding: "0.5rem", textAlign: "center" }}>Jabatan dalam Kegiatan</th>
+              </tr>
+            </thead>
+            <tbody>
+              {susunanPanitia.map((item, index) => (
+                <tr key={item.id}>
+                  <td style={{ border: "1px solid black", padding: "0.5rem", textAlign: "center", verticalAlign: "middle" }}>{index + 1}.</td>
+                  <td style={{ border: "1px solid black", padding: "0.5rem", verticalAlign: "middle" }}>
+                    {item.nama}<br/>
+                    NIP. {item.nip}<br/>
+                    {item.jabatanInstansi}
+                  </td>
+                  <td style={{ border: "1px solid black", padding: "0.5rem", textAlign: "center", verticalAlign: "middle" }}>{item.jabatanKegiatan}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {/* TTD */}
+          <div className="skp-ttd signature mt-16 ml-auto w-80">
+            <p className="m-0">Kepala Balai,</p>
+            <div className="skp-ttd-placeholder mt-4 h-24 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+            <p className="skp-signature-name m-0 mt-4">{kepalaBalai.nama}</p>
+            <p className="m-0">NIP. {kepalaBalai.nip}</p>
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+}
+
+
+
+

--- a/frontend/src/app/bmn/auction-candidates/_components/SkPanitiaDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkPanitiaDocument.tsx
@@ -19,6 +19,38 @@ interface SkPanitiaDocumentProps {
   susunanPanitia: PanitiaAnggota[];
 }
 
+function renderKeduaText(text: string) {
+  return text.split("\n").filter((line) => line.trim().length > 0).map((line, index) => {
+    const trimmedLine = line.trim();
+    const subItemMatch = trimmedLine.match(/^([a-z]\.)\s+(.*)$/i);
+    const numberedItemMatch = trimmedLine.match(/^(\d+\.)\s+(.*)$/);
+
+    if (subItemMatch) {
+      return (
+        <div className="skp-kedua-item skp-kedua-subitem" key={`${trimmedLine}-${index}`}>
+          <span className="skp-kedua-marker">{subItemMatch[1]}</span>
+          <span className="skp-kedua-item-text">{subItemMatch[2]}</span>
+        </div>
+      );
+    }
+
+    if (numberedItemMatch) {
+      return (
+        <div className="skp-kedua-item" key={`${trimmedLine}-${index}`}>
+          <span className="skp-kedua-marker">{numberedItemMatch[1]}</span>
+          <span className="skp-kedua-item-text">{numberedItemMatch[2]}</span>
+        </div>
+      );
+    }
+
+    return (
+      <div className="skp-kedua-line" key={`${trimmedLine}-${index}`}>
+        {trimmedLine}
+      </div>
+    );
+  });
+}
+
 export function handlePrintSkPanitia() {
   const printContent = document.getElementById("sk-panitia-print-root");
   if (!printContent) {
@@ -51,7 +83,7 @@ export function handlePrintSkPanitia() {
           .skp-print-root .skp-page.skp-main-document.skp-main-paginated {
             height: 297mm !important;
             min-height: 297mm !important;
-            padding: 5mm 20mm 18mm !important;
+            padding: 5mm 20mm 28mm !important;
             overflow: hidden !important;
             position: relative !important;
             box-shadow: none !important;
@@ -117,23 +149,28 @@ export function handlePrintSkPanitia() {
           .skp-mengingat-item:first-child { padding-top: 0; }
           .skp-mengingat-text { text-align: justify; }
           /* Memutuskan */
-          .skp-memutuskan { text-align: center; font-weight: bold; margin-bottom: 12px; }
+          .skp-memutuskan { text-align: center; font-weight: bold; margin-bottom: 8px; }
           /* TTD block */
-          .skp-ttd { width: 20rem; margin-left: auto; margin-top: 3rem; }
+          .skp-ttd { width: 20rem; margin-left: auto; margin-top: 1.25rem; }
           .skp-ttd, .skp-ttd p { font-weight: normal !important; text-align: left !important; }
-          .skp-ttd p { margin: 0; padding: 0; line-height: 1.3; }
+          .skp-ttd p { margin: 0; padding: 0; line-height: 1.25; }
           .skp-ttd-meta { display: grid !important; grid-template-columns: max-content auto 1fr; column-gap: 0.4rem; line-height: 1.3; }
           .skp-ttd-meta span { font-weight: normal !important; text-align: left !important; }
           .skp-ketiga-group { break-inside: avoid !important; page-break-inside: avoid !important; }
           .skp-signature-name { font-weight: normal !important; }
-          .skp-ttd-placeholder { height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; font-weight: normal !important; text-align: left !important; margin-top: 2rem; margin-bottom: 2rem; }
+          .skp-ttd-placeholder { height: 86px; padding-top: 28px; padding-left: 1.35cm; color: #94a3b8; font-weight: normal !important; text-align: left !important; margin-top: 0.75rem; margin-bottom: 0.75rem; }
           .skp-continuation-word { position: absolute; right: 23mm; bottom: 31mm; width: 163mm; height: 0; line-height: 11pt; overflow: visible; white-space: nowrap; text-align: right !important; margin: 0; padding: 0; font-weight: normal !important; font-size: 11pt; z-index: 20; }
           /* Tembusan */
-          .skp-tembusan { margin-top: 2rem; }
+          .skp-tembusan { margin-top: 1rem; }
           .skp-tembusan, .skp-tembusan p { font-weight: normal !important; text-align: left !important; }
-          .skp-tembusan p { margin: 0; padding: 0; line-height: 1.5; }
+          .skp-tembusan p { margin: 0; padding: 0; line-height: 1.3; }
           /* pre-wrap for KEDUA */
-          .skp-kedua-text { white-space: pre-wrap; }
+          .skp-kedua-text { display: grid; row-gap: 0; white-space: normal; }
+          .skp-kedua-line { text-align: justify; }
+          .skp-kedua-item { display: grid; grid-template-columns: 7mm minmax(0, 1fr); column-gap: 0; text-align: left; }
+          .skp-kedua-subitem { margin-left: 8mm; }
+          .skp-kedua-marker { text-align: left; }
+          .skp-kedua-item-text { text-align: justify; }
           /* Lampiran */
           .skp-lampiran {
             width: 210mm;
@@ -170,7 +207,7 @@ export function handlePrintSkPanitia() {
         .skp-print-root .skp-page.skp-main-document.skp-main-paginated {
           height: 297mm !important;
           min-height: 297mm !important;
-          padding: 5mm 20mm 18mm !important;
+          padding: 5mm 20mm 28mm !important;
           overflow: hidden !important;
           position: relative !important;
           box-shadow: none !important;
@@ -210,9 +247,9 @@ export function handlePrintSkPanitia() {
       void body.offsetHeight;
 
       const mmToPx = 96 / 25.4;
-      const firstPageContentH = 280 * mmToPx;
-      const continuationContentH = 267 * mmToPx;
-      const markerReserveH = 5 * mmToPx;
+      const firstPageContentH = 264 * mmToPx;
+      const continuationContentH = 251 * mmToPx;
+      const markerReserveH = 9 * mmToPx;
 
       const mainDoc = doc.querySelector(".skp-main-document");
       if (!mainDoc) { printWindow.print(); return; }
@@ -443,7 +480,7 @@ export function SkPanitiaDocument({
   const pageStyle: React.CSSProperties = {
     fontFamily: "'Bookman Old Style', Georgia, serif",
     fontSize: "11pt",
-    lineHeight: "1.4",
+    lineHeight: "1.25",
   };
 
   return (
@@ -545,7 +582,7 @@ export function SkPanitiaDocument({
         .skp-print-root .skp-memutuskan {
           text-align: center;
           font-weight: bold;
-          margin-bottom: 12px;
+          margin-bottom: 8px;
         }
         .skp-print-root .skp-continuation-word {
           text-align: right !important;
@@ -555,7 +592,7 @@ export function SkPanitiaDocument({
         .skp-print-root .skp-ttd {
           width: 20rem;
           margin-left: auto;
-          margin-top: 3rem;
+          margin-top: 1.25rem;
         }
         .skp-print-root .skp-ttd,
         .skp-print-root .skp-ttd p,
@@ -574,23 +611,43 @@ export function SkPanitiaDocument({
         }
         .skp-print-root .skp-ttd-placeholder {
           box-sizing: border-box;
-          height: 112px;
-          padding-top: 40px;
+          height: 86px;
+          padding-top: 28px;
           padding-left: 1.35cm;
           color: #94a3b8;
           font-weight: normal !important;
           text-align: left !important;
-          margin-top: 2rem;
-          margin-bottom: 2rem;
+          margin-top: 0.75rem;
+          margin-bottom: 0.75rem;
         }
         .skp-print-root .skp-tembusan {
-          margin-top: 2rem;
+          margin-top: 1rem;
         }
         .skp-print-root .skp-tembusan p {
-          line-height: 1.5;
+          line-height: 1.3;
         }
         .skp-print-root .skp-kedua-text {
-          white-space: pre-wrap;
+          display: grid;
+          row-gap: 0;
+          white-space: normal;
+        }
+        .skp-print-root .skp-kedua-line {
+          text-align: justify;
+        }
+        .skp-print-root .skp-kedua-item {
+          display: grid;
+          grid-template-columns: 7mm minmax(0, 1fr);
+          column-gap: 0;
+          text-align: left;
+        }
+        .skp-print-root .skp-kedua-subitem {
+          margin-left: 8mm;
+        }
+        .skp-print-root .skp-kedua-marker {
+          text-align: left;
+        }
+        .skp-print-root .skp-kedua-item-text {
+          text-align: justify;
         }
         .skp-print-root .skp-lampiran {
           page-break-before: always;
@@ -641,6 +698,7 @@ export function SkPanitiaDocument({
           <p className="skp-title-tentang m-0 mt-2">TENTANG</p>
           <p className="m-0">PANITIA PENGHAPUSAN BARANG MILIK NEGARA</p>
           <p className="m-0">BERUPA ALAT ANGKUTAN BERMOTOR</p>
+          <p className="m-0">PADA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR</p>
         </div>
 
         <div className="skp-subtitle skp-body mx-auto mt-3 w-[166mm]">
@@ -695,17 +753,17 @@ export function SkPanitiaDocument({
                 </td>
               </tr>
               <tr className="skp-mengingat-row">
-                <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.6rem" }}>KESATU</td>
-                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.6rem" }}>:</td>
-                <td style={{ verticalAlign: "top", paddingTop: "0.6rem", textAlign: "justify" }}>
+                <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.4rem" }}>KESATU</td>
+                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.4rem" }}>:</td>
+                <td style={{ verticalAlign: "top", paddingTop: "0.4rem", textAlign: "justify" }}>
                   {memutuskan.kesatu}
                 </td>
               </tr>
               <tr className="skp-mengingat-row">
-                <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.6rem" }}>KEDUA</td>
-                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.6rem" }}>:</td>
-                <td style={{ verticalAlign: "top", paddingTop: "0.6rem", textAlign: "justify" }}>
-                  <span className="skp-kedua-text" style={{ whiteSpace: "pre-wrap" }}>{memutuskan.kedua}</span>
+                <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.4rem" }}>KEDUA</td>
+                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.4rem" }}>:</td>
+                <td style={{ verticalAlign: "top", paddingTop: "0.4rem", textAlign: "justify" }}>
+                  <div className="skp-kedua-text">{renderKeduaText(memutuskan.kedua)}</div>
                 </td>
               </tr>
             </tbody>
@@ -716,9 +774,9 @@ export function SkPanitiaDocument({
             <table className="skp-mengingat-table mt-0 w-full" style={{ borderCollapse: "collapse" }}>
               <tbody>
                 <tr className="skp-mengingat-row">
-                  <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.6rem" }}>KETIGA</td>
-                  <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.6rem" }}>:</td>
-                  <td style={{ verticalAlign: "top", paddingTop: "0.6rem", textAlign: "justify" }}>
+                  <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.4rem" }}>KETIGA</td>
+                  <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.4rem" }}>:</td>
+                  <td style={{ verticalAlign: "top", paddingTop: "0.4rem", textAlign: "justify" }}>
                     {memutuskan.ketiga}
                   </td>
                 </tr>
@@ -726,7 +784,7 @@ export function SkPanitiaDocument({
             </table>
 
             {/* TTD */}
-            <div className="skp-ttd signature mt-6 ml-auto w-80">
+            <div className="skp-ttd signature mt-4 ml-auto w-80">
               <div className="skp-ttd-meta" style={{ display: "grid", gridTemplateColumns: "max-content auto 1fr", columnGap: "0.4rem" }}>
                 <span>Ditetapkan di</span>
                 <span>:</span>
@@ -736,14 +794,14 @@ export function SkPanitiaDocument({
                 <span>{formatDateLong(today)}</span>
               </div>
               <p className="m-0 mt-3">Kepala Balai,</p>
-              <div className="skp-ttd-placeholder mt-4 h-24 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+              <div className="skp-ttd-placeholder mt-3 h-20 box-border pt-7 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
               <p className="skp-signature-name m-0 mt-4">{kepalaBalai.nama}</p>
               <p className="m-0">NIP. {kepalaBalai.nip}</p>
             </div>
 
             {/* Tembusan */}
             {tembusan.length > 0 && (
-              <div className="skp-tembusan mt-10">
+              <div className="skp-tembusan mt-4">
                 <p className="m-0">Tembusan :</p>
                 {tembusan.length === 1 ? (
                   <p className="m-0">{tembusan[0].text}</p>
@@ -800,7 +858,12 @@ export function SkPanitiaDocument({
                   <td style={{ border: "1px solid black", padding: "0.5rem", verticalAlign: "middle" }}>
                     {item.nama}<br/>
                     NIP. {item.nip}<br/>
-                    {item.jabatanInstansi}
+                    {item.jabatanInstansi.split("\n").map((line, lineIndex) => (
+                      <span key={`${item.id}-jabatan-${lineIndex}`}>
+                        {lineIndex > 0 && <br />}
+                        {line}
+                      </span>
+                    ))}
                   </td>
                   <td style={{ border: "1px solid black", padding: "0.5rem", textAlign: "center", verticalAlign: "middle" }}>{item.jabatanKegiatan}</td>
                 </tr>

--- a/frontend/src/app/bmn/auction-candidates/_lib/sk-panitia-defaults.ts
+++ b/frontend/src/app/bmn/auction-candidates/_lib/sk-panitia-defaults.ts
@@ -1,0 +1,75 @@
+// Default text content for the SK Panitia Penghapusan BMN builder.
+
+import {
+  newSkBuilderItem,
+  type SkBuilderItem,
+  type SkMemutuskan,
+} from "./sk-defaults";
+
+export interface PanitiaAnggota {
+  id: string;
+  nama: string;           // "Dheny Mardiono, S.Hut., M.Sc."
+  nip: string;            // "19750314 199903 1 004"
+  jabatanInstansi: string; // "Kepala Sub Bagian Tata Usaha"
+  jabatanKegiatan: string; // "Ketua" — this is the role in the committee
+}
+
+const makeId = () => "id" + Math.random().toString(36).slice(2);
+
+export const DEFAULT_PANITIA_SUSUNAN: PanitiaAnggota[] = [
+  { id: makeId(), nama: "Dheny Mardiono, S.Hut., M.Sc.", nip: "19750314 199903 1 004", jabatanInstansi: "Kepala Sub Bagian Tata Usaha", jabatanKegiatan: "Ketua" },
+  { id: makeId(), nama: "Heryanto Sumanbowo, S.Hut.", nip: "198305 28200112 1 001", jabatanInstansi: "PEH Ahli Muda", jabatanKegiatan: "Sekretaris" },
+  { id: makeId(), nama: "Tegar Anugrah, A.Md.Kom.", nip: "19990707 202506 1 006", jabatanInstansi: "Pranata Komputer Terampil", jabatanKegiatan: "Anggota" },
+];
+
+export const DEFAULT_PANITIA_MENIMBANG: SkBuilderItem[] = [
+  newSkBuilderItem(
+    "bahwa Barang Milik Negara pada Balai Konservasi Sumber Daya Alam Kalimantan Timur berupa Alat Angkutan Bermotor dalam keadaan rusak berat dan tidak ekonomis lagi untuk digunakan lagi, sehingga perlu segera dihapuskan dari daftar inventaris;"
+  ),
+  newSkBuilderItem(
+    "bahwa sehubungan dengan hal tersebut di atas, dipandang perlu membentuk Panitia Penghapusan Barang Milik Negara berupa Alat Angkutan Bermotor pada Balai Konservasi Sumber Daya Alam Kalimantan Timur dengan Keputusan Kepala Balai."
+  ),
+];
+
+export const DEFAULT_PANITIA_MENGINGAT: SkBuilderItem[] = [
+  newSkBuilderItem(
+    "Undang-Undang RI Nomor 17 Tahun 2003 tentang Keuangan Negara;"
+  ),
+  newSkBuilderItem(
+    "Undang-Undang RI Nomor 1 Tahun 2004 tentang Perbendaharaan Negara;"
+  ),
+  newSkBuilderItem(
+    "Peraturan Pemerintah Nomor 27 Tahun 2014 tentang Pengelolaan Barang Milik Negara/Daerah sebagaimana telah diubah dengan Peraturan Pemerintah Nomor 28 Tahun 2020;"
+  ),
+  newSkBuilderItem(
+    "Peraturan Menteri Keuangan Nomor 83/PMK.06/2016 tentang Tata Cara Pelaksanaan Pemusnahan dan Penghapusan Barang Milik Negara;"
+  ),
+  newSkBuilderItem(
+    "Peraturan Menteri Keuangan Nomor 173/PMK.06/2020 tentang Penilaian oleh Penilai Pemerintah di Lingkungan Direktorat Jenderal Kekayaan Negara;"
+  ),
+  newSkBuilderItem(
+    "Peraturan Menteri Keuangan Nomor 111/PMK.06/2016 tentang Tata Cara Pelaksanaan Pemindahtanganan Barang Milik Negara;"
+  ),
+  newSkBuilderItem(
+    "Peraturan Menteri Keuangan Nomor 122 Tahun 2023 tentang Petunjuk Pelaksanaan Lelang;"
+  ),
+  newSkBuilderItem(
+    "Peraturan Menteri Lingkungan Hidup dan Kehutanan Nomor P.11/MENLHK/SETJEN/KAP.3/4/2018 tentang Tata Cara Pelaksanaan Pemindahtanganan Barang Milik Negara Lingkup Kementerian Lingkungan Hidup dan Kehutanan."
+  ),
+];
+
+export const DEFAULT_PANITIA_MEMUTUSKAN: SkMemutuskan = {
+  menetapkan:
+    "KEPUTUSAN KEPALA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR TENTANG PANITIA PENGHAPUSAN BARANG MILIK NEGARA BERUPA ALAT ANGKUTAN BERMOTOR PADA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR.",
+  kesatu:
+    "Membentuk Panitia Penghapusan Barang Milik Negara berupa Alat Angkutan Bermotor pada Balai Konservasi Sumber Daya Alam Kalimantan Timur dengan susunan sebagaimana tercantum dalam lampiran Keputusan ini.",
+  kedua:
+    "Panitia Penghapusan bertugas :\n1. Meneliti/menilai barang inventaris yang akan dihapuskan meliputi :\n    a. Menginventaris / dan meneliti barang yang akan dihapus;\n    b. Meneliti kondisi fisik barang inventaris yang akan dihapus;\n    c. Menetapkan perkiraan nilai barang inventaris yang akan dihapus;\n    d. Membuat berita acara penelitian / penilaian;\n2. Menyusun kelengkapan persyaratan penghapusan;\n3. Berkoordinasi dengan KPKNL setempat dan melaksanakan lelang, dalam hal penghapusan tersebut yang akan ditindaklanjuti dengan penjualan secara lelang;\n4. Menyusun laporan termasuk membuat berita acara hasil pelaksanaan tindak lanjut penghapusan.",
+  ketiga: "Keputusan ini mulai berlaku sejak tanggal ditetapkan.",
+};
+
+export const DEFAULT_PANITIA_TEMBUSAN: SkBuilderItem[] = [
+  newSkBuilderItem("Kepala Biro Umum Kementerian Kehutanan"),
+  newSkBuilderItem("Sekretaris Direktorat Jenderal KSDAE"),
+  newSkBuilderItem("Yang Bersangkutan"),
+];

--- a/frontend/src/app/bmn/auction-candidates/_lib/sk-panitia-defaults.ts
+++ b/frontend/src/app/bmn/auction-candidates/_lib/sk-panitia-defaults.ts
@@ -1,6 +1,7 @@
 // Default text content for the SK Panitia Penghapusan BMN builder.
 
 import {
+  DEFAULT_KEPALA_BALAI,
   newSkBuilderItem,
   type SkBuilderItem,
   type SkMemutuskan,
@@ -17,6 +18,13 @@ export interface PanitiaAnggota {
 const makeId = () => "id" + Math.random().toString(36).slice(2);
 
 export const DEFAULT_PANITIA_SUSUNAN: PanitiaAnggota[] = [
+  {
+    id: makeId(),
+    nama: DEFAULT_KEPALA_BALAI.nama,
+    nip: DEFAULT_KEPALA_BALAI.nip,
+    jabatanInstansi: "Kepala Balai Konservasi Sumber Daya Alam\nKalimantan Timur",
+    jabatanKegiatan: "Penanggung Jawab",
+  },
   { id: makeId(), nama: "Dheny Mardiono, S.Hut., M.Sc.", nip: "19750314 199903 1 004", jabatanInstansi: "Kepala Sub Bagian Tata Usaha", jabatanKegiatan: "Ketua" },
   { id: makeId(), nama: "Heryanto Sumanbowo, S.Hut.", nip: "198305 28200112 1 001", jabatanInstansi: "PEH Ahli Muda", jabatanKegiatan: "Sekretaris" },
   { id: makeId(), nama: "Tegar Anugrah, A.Md.Kom.", nip: "19990707 202506 1 006", jabatanInstansi: "Pranata Komputer Terampil", jabatanKegiatan: "Anggota" },

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -727,7 +727,7 @@ export default function BmnAuctionCandidatesPage() {
                         <div className="mt-2 rounded-lg bg-teal-50 px-2.5 py-1.5 text-[11px] text-teal-800 dark:bg-teal-500/10 dark:text-teal-300">
                           <p className="font-semibold">{item.nama}</p>
                           <p>NIP. {item.nip}</p>
-                          <p>{item.jabatanInstansi}</p>
+                          <p className="whitespace-pre-line">{item.jabatanInstansi}</p>
                         </div>
                       )}
                     </div>

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -15,8 +15,10 @@ import {
   Gavel,
   Loader2,
   Package,
+  Plus,
   Printer,
   Search,
+  Trash2,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -30,6 +32,7 @@ import { ReorderPanel } from "./_components/ReorderPanel";
 import { SummaryTile } from "./_components/SummaryTile";
 import { CorrectionDocument, handlePrintBa } from "./_components/BaKoreksiDocument";
 import { SkPenghentianDocument, handlePrintSk } from "./_components/SkPenghentianDocument";
+import { SkPanitiaDocument, handlePrintSkPanitia } from "./_components/SkPanitiaDocument";
 import { SkBuilder } from "./_components/SkBuilder";
 import {
   DEFAULT_MENIMBANG,
@@ -37,7 +40,16 @@ import {
   DEFAULT_MEMUTUSKAN,
   DEFAULT_KEPALA_BALAI,
   DEFAULT_TEMBUSAN,
+  formatNip,
 } from "./_lib/sk-defaults";
+import {
+  DEFAULT_PANITIA_MENIMBANG,
+  DEFAULT_PANITIA_MENGINGAT,
+  DEFAULT_PANITIA_MEMUTUSKAN,
+  DEFAULT_PANITIA_TEMBUSAN,
+  DEFAULT_PANITIA_SUSUNAN,
+  type PanitiaAnggota,
+} from "./_lib/sk-panitia-defaults";
 
 export default function BmnAuctionCandidatesPage() {
   const [searchTerm, setSearchTerm] = useState("");
@@ -46,14 +58,21 @@ export default function BmnAuctionCandidatesPage() {
   const [orderedIds, setOrderedIds] = useState<string[]>([]);
   const [showDocument, setShowDocument] = useState(false);
   const [showSkDocument, setShowSkDocument] = useState(false);
+  const [showSkPanitia, setShowSkPanitia] = useState(false);
   const [baNumber, setBaNumber] = useState("");
   const [baKap, setBaKap] = useState("KAP.06.01");
   const [skNumber, setSkNumber] = useState("");
+  const [skPanitiaNumber, setSkPanitiaNumber] = useState("");
   const [menimbang, setMenimbang] = useState(DEFAULT_MENIMBANG);
   const [mengingat, setMengingat] = useState(DEFAULT_MENGINGAT);
   const [memutuskan, setMemutuskan] = useState(DEFAULT_MEMUTUSKAN);
   const [kepalaBalai, setKepalaBalai] = useState(DEFAULT_KEPALA_BALAI);
   const [tembusan, setTembusan] = useState(DEFAULT_TEMBUSAN);
+  const [panitiaMenimbang, setPanitiaMenimbang] = useState(DEFAULT_PANITIA_MENIMBANG);
+  const [panitiaMengingat, setPanitiaMengingat] = useState(DEFAULT_PANITIA_MENGINGAT);
+  const [panitiaMemutuskan, setPanitiaMemutuskan] = useState(DEFAULT_PANITIA_MEMUTUSKAN);
+  const [panitiaTembusan, setPanitiaTembusan] = useState(DEFAULT_PANITIA_TEMBUSAN);
+  const [susunanPanitia, setSusunanPanitia] = useState<PanitiaAnggota[]>(DEFAULT_PANITIA_SUSUNAN);
   const debouncedSearch = useDebounce(searchTerm, 400);
 
   // drag-and-drop refs
@@ -75,6 +94,23 @@ export default function BmnAuctionCandidatesPage() {
     },
     placeholderData: (prev) => prev,
   });
+
+  const { data: employeesForPanitia = [] } = useQuery<{ id: string | number; nama_lengkap?: string; name?: string; nip?: string | null; jabatan?: string | null; position?: string | null }[]>({
+    queryKey: ["employees-select-panitia"],
+    queryFn: async () => {
+      const res = await api.get("/kepegawaian/employees/select");
+      return res.data?.data || res.data || [];
+    },
+  });
+
+  const sortedEmployeesForPanitia = useMemo(() => {
+    const list = Array.isArray(employeesForPanitia) ? [...employeesForPanitia] : [];
+    return list.sort((a, b) => {
+      const an = (a.nama_lengkap || a.name || "").toLowerCase();
+      const bn = (b.nama_lengkap || b.name || "").toLowerCase();
+      return an.localeCompare(bn);
+    });
+  }, [employeesForPanitia]);
 
   const assets = useMemo(() => response?.data || [], [response?.data]);
   const selectedIds = useMemo(() => new Set(orderedIds), [orderedIds]);
@@ -166,6 +202,7 @@ export default function BmnAuctionCandidatesPage() {
     }
     setShowDocument(true);
     setShowSkDocument(false);
+    setShowSkPanitia(false);
     setTimeout(() => {
       document.getElementById("ba-koreksi-preview")?.scrollIntoView({ behavior: "smooth", block: "start" });
     }, 50);
@@ -178,13 +215,63 @@ export default function BmnAuctionCandidatesPage() {
     }
     setShowSkDocument(true);
     setShowDocument(false);
+    setShowSkPanitia(false);
     setTimeout(() => {
       document.getElementById("sk-penghentian-preview")?.scrollIntoView({ behavior: "smooth", block: "start" });
     }, 50);
   };
 
+  const handleProcessSkPanitia = () => {
+    if (orderedIds.length === 0) {
+      toast.error("Pilih minimal satu aset untuk diproses.");
+      return;
+    }
+    setShowSkPanitia(true);
+    setShowDocument(false);
+    setShowSkDocument(false);
+    setTimeout(() => {
+      document.getElementById("sk-panitia-preview")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 50);
+  };
+
   const handlePrint = () => handlePrintBa(orderedSelectedAssets);
   const handlePrintSkDoc = () => handlePrintSk(orderedSelectedAssets, skNumber);
+  const handlePrintSkPanitiaDoc = () => handlePrintSkPanitia();
+
+  const addPanitiaAnggota = () => {
+    setSusunanPanitia((prev) => [
+      ...prev,
+      { id: "id" + Math.random().toString(36).slice(2), nama: "", nip: "", jabatanInstansi: "", jabatanKegiatan: "" },
+    ]);
+  };
+
+  const removePanitiaAnggota = (id: string) => {
+    setSusunanPanitia((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  const updatePanitiaAnggota = (id: string, field: keyof PanitiaAnggota, value: string) => {
+    setSusunanPanitia((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, [field]: value } : item))
+    );
+  };
+
+  const selectPanitiaEmployee = (id: string, employeeId: string) => {
+    if (!employeeId) return;
+    const emp = sortedEmployeesForPanitia.find((e) => String(e.id) === employeeId);
+    if (!emp) return;
+    setSusunanPanitia((prev) =>
+      prev.map((item) =>
+        item.id === id
+          ? {
+              ...item,
+              nama: emp.nama_lengkap || emp.name || "",
+              nip: formatNip(emp.nip || ""),
+              jabatanInstansi: emp.position || emp.jabatan || "",
+            }
+          : item
+      )
+    );
+  };
 
   return (
     <div className="p-6 md:p-10 space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
@@ -233,6 +320,15 @@ export default function BmnAuctionCandidatesPage() {
           >
             <FileText className="h-3.5 w-3.5" />
             Proses SK Penghentian
+          </Button>
+          <Button
+            size="sm"
+            className="rounded-xl gap-2 bg-teal-600 text-xs hover:bg-teal-500"
+            onClick={handleProcessSkPanitia}
+            disabled={orderedIds.length === 0}
+          >
+            <FileText className="h-3.5 w-3.5" />
+            Proses SK Panitia
           </Button>
         </div>
       </div>
@@ -320,6 +416,29 @@ export default function BmnAuctionCandidatesPage() {
         </div>
       </div>
 
+      <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+        <label htmlFor="sk-panitia-number" className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">
+          Nomor SK Panitia Penghapusan
+        </label>
+        <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
+          <div className="flex h-11 items-center rounded-xl border border-zinc-200 bg-white px-3 text-sm text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-white">
+            <span className="font-semibold">SK.</span>
+            <input
+              id="sk-panitia-number"
+              type="text"
+              value={skPanitiaNumber}
+              onChange={(event) => setSkPanitiaNumber(event.target.value)}
+              placeholder="____"
+              className="mx-1 w-20 bg-transparent text-center font-semibold outline-none"
+            />
+            <span>/{getSkNumberSuffix()}</span>
+          </div>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+            Tahun otomatis mengikuti tanggal generate dokumen.
+          </p>
+        </div>
+      </div>
+
       {orderedIds.length > 0 && (
         <div className="flex flex-col gap-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 dark:border-red-500/20 dark:bg-red-500/10 sm:flex-row sm:items-center sm:justify-between">
           <div>
@@ -335,6 +454,10 @@ export default function BmnAuctionCandidatesPage() {
               <FileText className="mr-1 h-3.5 w-3.5" />
               Generate SK Penghentian
             </Button>
+            <Button size="sm" className="rounded-lg bg-teal-600 text-xs hover:bg-teal-500" onClick={handleProcessSkPanitia}>
+              <FileText className="mr-1 h-3.5 w-3.5" />
+              Generate SK Panitia
+            </Button>
             {showDocument && (
               <Button size="sm" variant="outline" className="rounded-lg text-xs" onClick={handlePrint}>
                 <Printer className="mr-1 h-3.5 w-3.5" />
@@ -345,6 +468,12 @@ export default function BmnAuctionCandidatesPage() {
               <Button size="sm" variant="outline" className="rounded-lg text-xs" onClick={handlePrintSkDoc}>
                 <Printer className="mr-1 h-3.5 w-3.5" />
                 Cetak SK
+              </Button>
+            )}
+            {showSkPanitia && (
+              <Button size="sm" variant="outline" className="rounded-lg text-xs" onClick={handlePrintSkPanitiaDoc}>
+                <Printer className="mr-1 h-3.5 w-3.5" />
+                Cetak SK Panitia
               </Button>
             )}
           </div>
@@ -517,6 +646,109 @@ export default function BmnAuctionCandidatesPage() {
                 memutuskan={memutuskan}
                 kepalaBalai={kepalaBalai}
                 tembusan={tembusan}
+              />
+            </div>
+          </div>
+        </section>
+      )}
+
+      {showSkPanitia && orderedIds.length > 0 && (
+        <section id="sk-panitia-preview" className="space-y-4">
+          <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
+            <div>
+              <h2 className="text-lg font-bold text-zinc-900 dark:text-white">Preview SK Panitia Penghapusan BMN</h2>
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">Keputusan Kepala Balai tentang pembentukan Panitia Penghapusan BMN.</p>
+            </div>
+            <Button className="rounded-xl gap-2 bg-teal-600 text-xs hover:bg-teal-500" onClick={handlePrintSkPanitiaDoc}>
+              <Printer className="h-3.5 w-3.5" />
+              Cetak / Save PDF
+            </Button>
+          </div>
+          <div className="grid gap-4 lg:grid-cols-[400px_1fr]">
+            <div className="print:hidden">
+              <SkBuilder
+                menimbang={panitiaMenimbang}
+                setMenimbang={setPanitiaMenimbang}
+                mengingat={panitiaMengingat}
+                setMengingat={setPanitiaMengingat}
+                memutuskan={panitiaMemutuskan}
+                setMemutuskan={setPanitiaMemutuskan}
+                kepalaBalai={kepalaBalai}
+                setKepalaBalai={setKepalaBalai}
+                tembusan={panitiaTembusan}
+                setTembusan={setPanitiaTembusan}
+              />
+
+              {/* Susunan Panitia editor */}
+              <div className="mt-4 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-bold text-zinc-900 dark:text-white">Susunan Panitia</h3>
+                  <Button size="xs" variant="outline" className="rounded-lg gap-1" onClick={addPanitiaAnggota}>
+                    <Plus className="h-3 w-3" />
+                    Tambah
+                  </Button>
+                </div>
+                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  Susunan panitia yang akan ditampilkan pada halaman lampiran.
+                </p>
+                <div className="mt-3 space-y-3">
+                  {susunanPanitia.map((item) => (
+                    <div key={item.id} className="rounded-xl border border-zinc-200 bg-zinc-50/60 p-2.5 dark:border-zinc-800 dark:bg-zinc-900/50">
+                      <div className="flex items-center gap-2">
+                        <select
+                          value=""
+                          onChange={(e) => selectPanitiaEmployee(item.id, e.target.value)}
+                          className="h-8 flex-1 rounded-lg border border-zinc-200 bg-white px-2 text-xs text-zinc-900 outline-none focus:ring-1 focus:ring-teal-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-white"
+                        >
+                          <option value="">-- Pilih Pegawai --</option>
+                          {sortedEmployeesForPanitia.map((emp) => (
+                            <option key={emp.id} value={String(emp.id)}>
+                              {emp.nama_lengkap || emp.name || "-"}
+                            </option>
+                          ))}
+                        </select>
+                        <Button
+                          size="xs"
+                          variant="destructive"
+                          className="rounded-md gap-1"
+                          onClick={() => removePanitiaAnggota(item.id)}
+                        >
+                          <Trash2 className="h-3 w-3" />
+                          Hapus
+                        </Button>
+                      </div>
+                      <input
+                        value={item.jabatanKegiatan}
+                        onChange={(e) => updatePanitiaAnggota(item.id, "jabatanKegiatan", e.target.value)}
+                        placeholder="Jabatan dalam Kegiatan (Ketua, Sekretaris, Anggota...)"
+                        className="mt-2 h-8 w-full rounded-lg border border-zinc-200 bg-white px-2 text-xs text-zinc-900 outline-none focus:ring-1 focus:ring-teal-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-white"
+                      />
+                      {item.nama && (
+                        <div className="mt-2 rounded-lg bg-teal-50 px-2.5 py-1.5 text-[11px] text-teal-800 dark:bg-teal-500/10 dark:text-teal-300">
+                          <p className="font-semibold">{item.nama}</p>
+                          <p>NIP. {item.nip}</p>
+                          <p>{item.jabatanInstansi}</p>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                  {susunanPanitia.length === 0 && (
+                    <p className="rounded-lg border border-dashed border-zinc-300 p-3 text-center text-xs text-zinc-400">
+                      Belum ada anggota panitia. Klik Tambah untuk menambahkan.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+            <div>
+              <SkPanitiaDocument
+                skNumber={skPanitiaNumber}
+                menimbang={panitiaMenimbang}
+                mengingat={panitiaMengingat}
+                memutuskan={panitiaMemutuskan}
+                kepalaBalai={kepalaBalai}
+                tembusan={panitiaTembusan}
+                susunanPanitia={susunanPanitia}
               />
             </div>
           </div>

--- a/frontend/src/app/kepegawaian/_components/EmployeeAccessSheet.tsx
+++ b/frontend/src/app/kepegawaian/_components/EmployeeAccessSheet.tsx
@@ -20,9 +20,8 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Shield, KeyRound, Loader2, AlertCircle, Info, Check } from "lucide-react";
+import { Shield, Loader2, AlertCircle, Check } from "lucide-react";
 import { api } from "@/lib/api";
 import { toast } from "sonner";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";

--- a/frontend/src/app/portal/page.tsx
+++ b/frontend/src/app/portal/page.tsx
@@ -8,7 +8,7 @@ import {
   Boxes, LayoutGrid, Package, FileText, LogOut,
   Fingerprint, KeyRound, Loader2, BadgeCheck, Mail, Phone, Briefcase,
   HandHelping, Sun, Sunset, Moon, Pencil, Sparkles, Bell,
-  Eye, Users, ClipboardList, Building2, X, MapPin, Calendar, Car,
+  Eye, Users, ClipboardList, Building2,
 } from "lucide-react";
 import { RouteGuard } from "@/components/RouteGuard";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -42,6 +42,11 @@ interface SuratTugasItem {
   file_surat_path: string | null;
 }
 
+interface DasarItem {
+  id?: string;
+  text: string;
+}
+
 interface SuratTugasDetail {
   id: string;
   nomor_surat: string | null;
@@ -56,8 +61,8 @@ interface SuratTugasDetail {
   sumber_dana: string | null;
   nama_plh: string | null;
   keterangan: string | null;
-  dasar: unknown;
-  menimbang: unknown;
+  dasar: DasarItem[] | string | null;
+  menimbang: DasarItem[] | string | null;
   tembusan: string[] | null;
   employees?: Array<{
     id: string;
@@ -131,11 +136,12 @@ export default function PersonalDashboard() {
   const [editData, setEditData] = useState({ email: "", phone: "" });
   const [editLoading, setEditLoading] = useState(false);
 
+  const borrowedAssets = data?.my_assets;
   const filteredMyAssets = useMemo(() => {
-    if (!data?.my_assets) return myAssets;
-    const borrowedIds = new Set(data.my_assets.map(a => String(a.id)));
+    if (!borrowedAssets) return myAssets;
+    const borrowedIds = new Set(borrowedAssets.map(a => String(a.id)));
     return myAssets.filter(a => !borrowedIds.has(a.id));
-  }, [myAssets, data?.my_assets]);
+  }, [myAssets, borrowedAssets]);
 
   const fetchDashboard = useCallback(async () => {
     try {
@@ -624,8 +630,8 @@ export default function PersonalDashboard() {
               id: stDetail.id,
               nomor_surat: stDetail.nomor_surat,
               kode_surat: stDetail.kode_surat,
-              menimbang: stDetail.menimbang as any,
-              dasar: stDetail.dasar as any,
+              menimbang: stDetail.menimbang,
+              dasar: stDetail.dasar,
               maksud_tujuan: stDetail.maksud_tujuan,
               tempat_tujuan: stDetail.tempat_tujuan,
               tanggal_mulai: stDetail.tanggal_mulai,

--- a/frontend/src/app/portal/surat-tugas/[id]/page.tsx
+++ b/frontend/src/app/portal/surat-tugas/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft, Loader2, FileText, Calendar, MapPin, Users } from "lucide-react";
 import { RouteGuard } from "@/components/RouteGuard";
@@ -36,7 +36,6 @@ interface SuratTugasDetail {
 
 export default function SuratTugasPreviewPage() {
   const params = useParams();
-  const router = useRouter();
   const [data, setData] = useState<SuratTugasDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -46,8 +45,9 @@ export default function SuratTugasPreviewPage() {
       try {
         const resp = await api.get(`/surat-tugas/my/${params.id}`);
         setData(resp.data.data);
-      } catch (err: any) {
-        setError(err?.response?.data?.message || "Gagal memuat data surat tugas");
+      } catch (err: unknown) {
+        const error = err as { response?: { data?: { message?: string } } };
+        setError(error.response?.data?.message || "Gagal memuat data surat tugas");
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
Closes #354

## Summary
- Add SK Panitia Penghapusan BMN document flow with editable committee defaults and print pagination.
- Reserve BSrE/BSSN footer space while keeping continuation words and grouped KETIGA/TTD behavior stable.
- Add Kepala Balai as default Penanggung Jawab and preserve Kalimantan Timur line break in the lampiran table.
- Clean up existing portal lint blockers so full frontend lint passes.

## Validation
- npm run lint -- --max-warnings=0
- npx tsc --noEmit
- npm run build