### PR TITLE
feat(bmn): add 5 supporting documents for auction candidates (#356)

### DIFF
--- a/frontend/src/app/bmn/auction-candidates/_components/BaPemeriksaanDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/BaPemeriksaanDocument.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { toast } from "sonner";
+import { getSpelledDate } from "../_lib/auction-helpers";
+import type { PemeriksaAnggota } from "../_lib/pemeriksa-defaults";
+
+interface BaPemeriksaanDocumentProps {
+  number: string;
+  pemeriksaList: PemeriksaAnggota[];
+  stNumber: string;
+  stTanggal: string;
+}
+
+function buildNomorText(number: string, today: Date) {
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  return `BA.${number.trim() || "158"}/K.18/TU/KAP.06.01/${month}/${today.getFullYear()}`;
+}
+
+export function handlePrintBaPemeriksaan() {
+  const printContent = document.getElementById("ba-pemeriksaan-print-root");
+  if (!printContent) {
+    toast.error("Tidak ada dokumen Berita Acara Pemeriksaan untuk dicetak.");
+    return;
+  }
+  const printWindow = window.open("", "_blank");
+  if (!printWindow) return;
+
+  printWindow.document.write(`
+    <html>
+      <head>
+        <title>Berita Acara Pemeriksaan BMN</title>
+        <style>
+          @page { size: A4; margin: 0 0 28mm 0; }
+          * { box-sizing: border-box; }
+          body {
+            margin: 0; padding: 0; background: white; color: black;
+            font-family: 'Bookman Old Style', Georgia, serif;
+            font-size: 11pt; line-height: 1.5;
+          }
+          p { margin: 0; padding: 0; }
+          article { margin: 0; }
+          .doc-page { width: 210mm; box-sizing: border-box; margin: 0 auto; padding: 5mm 20mm 0; }
+          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; text-align: center; }
+          .doc-header img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
+          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; text-align: justify; text-justify: inter-word; }
+          .doc-body p { text-align: justify; text-justify: inter-word; }
+          .doc-title { margin-top: 0.75rem; text-align: center; font-weight: 700; line-height: 1.3; }
+          .doc-title p { margin: 0; }
+          .doc-text-block { margin-top: 1rem; }
+          .doc-text-block > * + * { margin-top: 0.85rem; }
+          .pemeriksa-list { margin-top: 0.5rem; }
+          .pemeriksa-item { display: grid; grid-template-columns: 8mm minmax(0, 1fr); column-gap: 0; }
+          .pemeriksa-item + .pemeriksa-item { margin-top: 0.5rem; }
+          .pemeriksa-row { display: grid; grid-template-columns: 28mm 5mm minmax(0, 1fr); column-gap: 0; }
+          .pemeriksa-row .colon { text-align: center; }
+          .doc-editable { outline: none; border-bottom: none !important; }
+        </style>
+      </head>
+      <body>${printContent.innerHTML}</body>
+    </html>
+  `);
+  printWindow.document.close();
+  printWindow.focus();
+  setTimeout(() => printWindow.print(), 500);
+}
+
+export function BaPemeriksaanDocument({
+  number,
+  pemeriksaList,
+  stNumber,
+  stTanggal,
+}: BaPemeriksaanDocumentProps) {
+  const today = new Date();
+  const nomorText = buildNomorText(number, today);
+  const { day, dateText, month, yearText } = getSpelledDate(today);
+
+  return (
+    <div id="ba-pemeriksaan-print-root" className="ba-pemeriksaan-print-root">
+      <style jsx global>{`
+        .ba-pemeriksaan-print-root .doc-editable { outline: none; border-bottom: 1px dashed transparent; transition: border-bottom-color 0.15s ease; }
+        .ba-pemeriksaan-print-root .doc-editable:hover { border-bottom-color: #94a3b8; }
+        .ba-pemeriksaan-print-root .doc-editable:focus { border-bottom-color: #64748b; }
+        @media print {
+          @page { size: A4; margin: 0 0 28mm 0; }
+          body * { visibility: hidden; }
+          .ba-pemeriksaan-print-root, .ba-pemeriksaan-print-root * { visibility: visible; }
+          .ba-pemeriksaan-print-root {
+            position: absolute; left: 0; top: 0; width: 100%;
+            background: white; color: black;
+            font-family: 'Bookman Old Style', Georgia, serif;
+            font-size: 11pt; line-height: 1.5; margin: 0; padding: 0;
+          }
+          .doc-page { width: 210mm; margin: 0 auto; padding: 5mm 20mm 0; box-shadow: none !important; }
+          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; }
+          .doc-header img { max-width: 196mm !important; }
+          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; }
+          .doc-editable { border-bottom: none !important; }
+          .pemeriksa-item { break-inside: avoid; page-break-inside: avoid; }
+        }
+      `}</style>
+
+      <article
+        className="doc-page mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.5" }}
+      >
+        <div className="doc-header -mx-18 text-center">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
+        </div>
+
+        <div className="doc-title mt-2 text-center font-bold leading-snug">
+          <p className="m-0">BERITA ACARA PEMERIKSAAN BARANG MILIK NEGARA</p>
+          <p className="m-0">BERUPA ALAT ANGKUTAN BERMOTOR</p>
+          <p className="m-0 font-normal">Nomor : {nomorText}</p>
+        </div>
+
+        <div className="doc-body doc-text-block mx-auto mt-4 w-[166mm] space-y-3 text-justify">
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Pada hari ini {day} tanggal {dateText} bulan {month} tahun {yearText}, kami yang bertanda tangan di bawah ini :
+          </p>
+
+          <div className="pemeriksa-list">
+            {pemeriksaList.length === 0 ? (
+              <p className="text-center text-zinc-400" style={{ color: "#94a3b8" }}>
+                Belum ada pemeriksa. Silakan tambah pemeriksa.
+              </p>
+            ) : (
+              pemeriksaList.map((p, index) => (
+                <div className="pemeriksa-item grid grid-cols-[8mm_minmax(0,1fr)]" key={p.id}>
+                  <span>{index + 1}.</span>
+                  <div>
+                    <div className="pemeriksa-row grid grid-cols-[28mm_5mm_minmax(0,1fr)]">
+                      <span>Nama</span>
+                      <span className="colon text-center">:</span>
+                      <span>{p.nama}</span>
+                    </div>
+                    <div className="pemeriksa-row grid grid-cols-[28mm_5mm_minmax(0,1fr)]">
+                      <span>NIP</span>
+                      <span className="colon text-center">:</span>
+                      <span>{p.nip}</span>
+                    </div>
+                    <div className="pemeriksa-row grid grid-cols-[28mm_5mm_minmax(0,1fr)]">
+                      <span>Jabatan</span>
+                      <span className="colon text-center">:</span>
+                      <span>{p.jabatan}</span>
+                    </div>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Telah melaksanakan tugas pemeriksaan secara administrasi, teknis tentang kondisi dan nilai taksiran Barang Milik Negara berupa Alat Angkutan Bermotor yang berada pada Balai Konservasi Sumber Daya Alam Kalimantan Timur sesuai dengan Surat Tugas Nomor : {stNumber || "____"}, tanggal {stTanggal || "____"} sebagaimana terlampir.
+          </p>
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Demikian Berita Acara Pemeriksaan ini dibuat dengan sebenarnya, ditandatangani oleh masing-masing pemeriksa.
+          </p>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/frontend/src/app/bmn/auction-candidates/_components/SkKebenaranDokumenDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkKebenaranDokumenDocument.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { toast } from "sonner";
+import type { AuctionAsset } from "../_lib/auction-helpers";
+import { formatDateLong } from "../_lib/auction-helpers";
+import type { SkKepalaBalai } from "../_lib/sk-defaults";
+
+interface SkKebenaranDokumenDocumentProps {
+  number: string;
+  assets: AuctionAsset[];
+  kepalaBalai: SkKepalaBalai;
+}
+
+function buildNomorText(number: string, today: Date) {
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  return `KT.${number.trim() || "200"}/K.18/TU/KAP.06.01/${month}/${today.getFullYear()}`;
+}
+
+export function handlePrintSkKebenaran() {
+  const printContent = document.getElementById("sk-kebenaran-print-root");
+  if (!printContent) {
+    toast.error("Tidak ada dokumen Surat Keterangan Kebenaran Fotokopi untuk dicetak.");
+    return;
+  }
+  const printWindow = window.open("", "_blank");
+  if (!printWindow) return;
+
+  printWindow.document.write(`
+    <html>
+      <head>
+        <title>Surat Keterangan Kebenaran Fotokopi Dokumen Kepemilikan</title>
+        <style>
+          @page { size: A4; margin: 0 0 28mm 0; }
+          * { box-sizing: border-box; }
+          body {
+            margin: 0; padding: 0; background: white; color: black;
+            font-family: 'Bookman Old Style', Georgia, serif;
+            font-size: 11pt; line-height: 1.4;
+          }
+          p { margin: 0; padding: 0; }
+          article { margin: 0; }
+          .doc-page { width: 210mm; box-sizing: border-box; margin: 0 auto; padding: 5mm 20mm 0; }
+          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; text-align: center; }
+          .doc-header img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
+          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; text-align: justify; text-justify: inter-word; }
+          .doc-body p { text-align: justify; text-justify: inter-word; }
+          .doc-title { margin-top: 0.75rem; text-align: center; font-weight: 700; line-height: 1.3; }
+          .doc-title p { margin: 0; }
+          .doc-text-block { margin-top: 1rem; }
+          .doc-text-block > * + * { margin-top: 0.85rem; }
+          .doc-identity { display: grid; grid-template-columns: 28mm 5mm minmax(0, 1fr); row-gap: 0.2rem; }
+          .doc-identity .colon { text-align: center; }
+          table.kebenaran-table { border-collapse: collapse; width: 100%; font-size: 9pt; text-align: center; }
+          table.kebenaran-table th, table.kebenaran-table td { border: 1px solid #000; padding: 6px; vertical-align: middle; }
+          table.kebenaran-table thead th { font-weight: bold; }
+          .signature { width: 20rem; margin-left: auto; margin-top: 1.5rem; }
+          .signature p { margin: 0; padding: 0; line-height: 1.3; }
+          .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; margin-top: 2rem; margin-bottom: 2rem; }
+          .doc-editable { outline: none; border-bottom: none !important; }
+        </style>
+      </head>
+      <body>${printContent.innerHTML}</body>
+    </html>
+  `);
+  printWindow.document.close();
+  printWindow.focus();
+  setTimeout(() => printWindow.print(), 500);
+}
+
+export function SkKebenaranDokumenDocument({ number, assets, kepalaBalai }: SkKebenaranDokumenDocumentProps) {
+  const today = new Date();
+  const nomorText = buildNomorText(number, today);
+
+  return (
+    <div id="sk-kebenaran-print-root" className="sk-kebenaran-print-root">
+      <style jsx global>{`
+        .sk-kebenaran-print-root .doc-editable { outline: none; border-bottom: 1px dashed transparent; transition: border-bottom-color 0.15s ease; }
+        .sk-kebenaran-print-root .doc-editable:hover { border-bottom-color: #94a3b8; }
+        .sk-kebenaran-print-root .doc-editable:focus { border-bottom-color: #64748b; }
+        .sk-kebenaran-print-root table.kebenaran-table { border-collapse: collapse; width: 100%; font-size: 9pt; text-align: center; }
+        .sk-kebenaran-print-root table.kebenaran-table th,
+        .sk-kebenaran-print-root table.kebenaran-table td { border: 1px solid #000; padding: 6px; vertical-align: middle; }
+        @media print {
+          @page { size: A4; margin: 0 0 28mm 0; }
+          body * { visibility: hidden; }
+          .sk-kebenaran-print-root, .sk-kebenaran-print-root * { visibility: visible; }
+          .sk-kebenaran-print-root {
+            position: absolute; left: 0; top: 0; width: 100%;
+            background: white; color: black;
+            font-family: 'Bookman Old Style', Georgia, serif;
+            font-size: 11pt; line-height: 1.4; margin: 0; padding: 0;
+          }
+          .doc-page { width: 210mm; margin: 0 auto; padding: 5mm 20mm 0; box-shadow: none !important; }
+          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; }
+          .doc-header img { max-width: 196mm !important; }
+          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; }
+          .doc-editable { border-bottom: none !important; }
+          table.kebenaran-table tr { break-inside: avoid; page-break-inside: avoid; }
+        }
+      `}</style>
+
+      <article
+        className="doc-page mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.4" }}
+      >
+        <div className="doc-header -mx-18 text-center">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
+        </div>
+
+        <div className="doc-title mt-2 text-center font-bold leading-snug">
+          <p className="m-0">SURAT KETERANGAN</p>
+          <p className="m-0">KEBENARAN FOTOKOPI DOKUMEN KEPEMILIKAN ATAU DOKUMEN LAIN</p>
+          <p className="m-0">YANG SETARA DENGAN BUKTI KEPEMILIKAN BARANG MILIK NEGARA</p>
+          <p className="m-0">SELAIN TANAH DAN/ATAU BANGUNAN</p>
+          <p className="m-0 font-normal">Nomor : {nomorText}</p>
+        </div>
+
+        <div className="doc-body doc-text-block mx-auto mt-4 w-[166mm] space-y-3 text-justify">
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Yang bertanda tangan di bawah ini :
+          </p>
+          <div className="doc-identity grid grid-cols-[28mm_5mm_minmax(0,1fr)]">
+            <span>Nama</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nama}</span>
+            <span>NIP</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nip}</span>
+            <span>Pangkat/Gol</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">Pembina Muda Tk.I / IV b</span>
+            <span>Jabatan</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">Kepala Balai KSDA Kalimantan Timur</span>
+          </div>
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Dengan ini menerangkan bahwa :
+          </p>
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Fotokopi dokumen kepemilikan Kendaraan Bermotor atau dokumen lain yang setara dengan bukti kepemilikan :
+          </p>
+
+          <table className="kebenaran-table mt-2">
+            <thead>
+              <tr>
+                <th style={{ width: "8%" }}>No.</th>
+                <th style={{ width: "20%" }}>Nomor Dokumen Kepemilikan</th>
+                <th style={{ width: "20%" }}>Merk/Tipe/Jenis</th>
+                <th style={{ width: "16%" }}>Nomor Mesin</th>
+                <th style={{ width: "20%" }}>Nomor Rangka</th>
+                <th style={{ width: "16%" }}>Nomor Polisi</th>
+              </tr>
+            </thead>
+            <tbody>
+              {assets.length === 0 ? (
+                <tr>
+                  <td colSpan={6} style={{ padding: "12px", textAlign: "center", color: "#64748b" }}>
+                    Belum ada aset terpilih.
+                  </td>
+                </tr>
+              ) : (
+                assets.map((asset, index) => (
+                  <tr key={asset.id}>
+                    <td>{index + 1}.</td>
+                    <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.no_identitas || ""}</td>
+                    <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.merk_tipe || ""}</td>
+                    <td contentEditable suppressContentEditableWarning className="doc-editable"></td>
+                    <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.no_rangka || ""}</td>
+                    <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.no_polisi || ""}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Adalah benar sesuai dengan aslinya.
+          </p>
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Demikian keterangan ini kami buat dengan sebenar-benarnya dalam rangka permohonan Persetujuan Pemindahtanganan BMN dengan Penjualan.
+          </p>
+        </div>
+
+        <div className="signature mt-6 ml-auto w-80">
+          <p className="m-0">Samarinda, {formatDateLong(today)}</p>
+          <p className="m-0">Kepala Balai,</p>
+          <div className="ttd-placeholder mt-8 box-border h-28 pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+          <p contentEditable suppressContentEditableWarning className="doc-editable m-0 mt-8">{kepalaBalai.nama}</p>
+          <p contentEditable suppressContentEditableWarning className="doc-editable m-0">NIP. {kepalaBalai.nip}</p>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/frontend/src/app/bmn/auction-candidates/_components/SpTugasDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SpTugasDocument.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { toast } from "sonner";
+import { formatDateLong } from "../_lib/auction-helpers";
+import type { SkKepalaBalai } from "../_lib/sk-defaults";
+
+interface SpTugasDocumentProps {
+  number: string;
+  kepalaBalai: SkKepalaBalai;
+}
+
+function buildNomorText(number: string, today: Date) {
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  return `SM.${number.trim() || "40"}/K.18/TU/KAP.06.01/${month}/${today.getFullYear()}`;
+}
+
+export function handlePrintSpTugas() {
+  const printContent = document.getElementById("sp-tugas-print-root");
+  if (!printContent) {
+    toast.error("Tidak ada dokumen Surat Pernyataan Kelancaran Tugas untuk dicetak.");
+    return;
+  }
+  const printWindow = window.open("", "_blank");
+  if (!printWindow) return;
+
+  printWindow.document.write(`
+    <html>
+      <head>
+        <title>Surat Pernyataan Tidak Mengganggu Kelancaran Tugas</title>
+        <style>
+          @page { size: A4; margin: 0 0 28mm 0; }
+          * { box-sizing: border-box; }
+          body {
+            margin: 0; padding: 0; background: white; color: black;
+            font-family: 'Bookman Old Style', Georgia, serif;
+            font-size: 11pt; line-height: 1.4;
+          }
+          p { margin: 0; padding: 0; }
+          article { margin: 0; }
+          .doc-page { width: 210mm; box-sizing: border-box; margin: 0 auto; padding: 5mm 20mm 0; }
+          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; text-align: center; }
+          .doc-header img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
+          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; text-align: justify; text-justify: inter-word; }
+          .doc-body p { text-align: justify; text-justify: inter-word; }
+          .doc-title { margin-top: 0.75rem; text-align: center; font-weight: 700; line-height: 1.3; }
+          .doc-title p { margin: 0; }
+          .doc-text-block { margin-top: 1rem; }
+          .doc-text-block > * + * { margin-top: 0.85rem; }
+          .doc-identity { display: grid; grid-template-columns: 28mm 5mm minmax(0, 1fr); row-gap: 0.2rem; }
+          .doc-identity .colon { text-align: center; }
+          .signature { width: 20rem; margin-left: auto; margin-top: 1.5rem; }
+          .signature p { margin: 0; padding: 0; line-height: 1.3; }
+          .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; margin-top: 2rem; margin-bottom: 2rem; }
+          .doc-editable { outline: none; border-bottom: none !important; }
+        </style>
+      </head>
+      <body>${printContent.innerHTML}</body>
+    </html>
+  `);
+  printWindow.document.close();
+  printWindow.focus();
+  setTimeout(() => printWindow.print(), 500);
+}
+
+export function SpTugasDocument({ number, kepalaBalai }: SpTugasDocumentProps) {
+  const today = new Date();
+  const nomorText = buildNomorText(number, today);
+
+  return (
+    <div id="sp-tugas-print-root" className="sp-tugas-print-root">
+      <style jsx global>{`
+        .sp-tugas-print-root .doc-editable { outline: none; border-bottom: 1px dashed transparent; transition: border-bottom-color 0.15s ease; }
+        .sp-tugas-print-root .doc-editable:hover { border-bottom-color: #94a3b8; }
+        .sp-tugas-print-root .doc-editable:focus { border-bottom-color: #64748b; }
+        @media print {
+          @page { size: A4; margin: 0 0 28mm 0; }
+          body * { visibility: hidden; }
+          .sp-tugas-print-root, .sp-tugas-print-root * { visibility: visible; }
+          .sp-tugas-print-root {
+            position: absolute; left: 0; top: 0; width: 100%;
+            background: white; color: black;
+            font-family: 'Bookman Old Style', Georgia, serif;
+            font-size: 11pt; line-height: 1.4; margin: 0; padding: 0;
+          }
+          .doc-page { width: 210mm; margin: 0 auto; padding: 5mm 20mm 0; box-shadow: none !important; }
+          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; }
+          .doc-header img { max-width: 196mm !important; }
+          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; }
+          .doc-editable { border-bottom: none !important; }
+        }
+      `}</style>
+
+      <article
+        className="doc-page mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.4" }}
+      >
+        <div className="doc-header -mx-18 text-center">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
+        </div>
+
+        <div className="doc-title mt-2 text-center font-bold leading-snug">
+          <p className="m-0">SURAT PERNYATAAN</p>
+          <p className="m-0 font-normal">Nomor : {nomorText}</p>
+        </div>
+
+        <div className="doc-body doc-text-block mx-auto mt-4 w-[166mm] space-y-3 text-justify">
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Yang bertanda tangan di bawah ini :
+          </p>
+          <div className="doc-identity grid grid-cols-[28mm_5mm_minmax(0,1fr)]">
+            <span>Nama</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nama}</span>
+            <span>NIP</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nip}</span>
+            <span>Pangkat/Gol</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">Pembina Tk.I / IV b</span>
+            <span>Jabatan</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">Kepala Balai KSDA Kalimantan Timur</span>
+          </div>
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Dengan ini menyatakan bahwa dalam rangka kegiatan Penghapusan Barang Milik Negara (BMN) berupa Alat Angkutan Bermotor di lingkungan Balai Konservasi Sumber Daya Alam (BKSDA) Kalimantan Timur, saya selaku Kepala Balai menyatakan bahwa Barang Milik Negara yang akan dipindahtangankan dengan penjualan tidak mengganggu kelancaran tugas dinas.
+          </p>
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Demikian surat pernyataan ini dibuat dengan sebenarnya, untuk dapat dipergunakan sebagaimana mestinya.
+          </p>
+        </div>
+
+        <div className="signature mt-6 ml-auto w-80">
+          <p className="m-0">Samarinda, {formatDateLong(today)}</p>
+          <p className="m-0">Kepala Balai,</p>
+          <div className="ttd-placeholder mt-8 box-border h-28 pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+          <p contentEditable suppressContentEditableWarning className="doc-editable m-0 mt-8">{kepalaBalai.nama}</p>
+          <p contentEditable suppressContentEditableWarning className="doc-editable m-0">NIP. {kepalaBalai.nip}</p>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/frontend/src/app/bmn/auction-candidates/_components/SptjLimitDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SptjLimitDocument.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { toast } from "sonner";
+import { formatDateLong } from "../_lib/auction-helpers";
+import type { SkKepalaBalai } from "../_lib/sk-defaults";
+
+interface SptjLimitDocumentProps {
+  number: string;
+  kepalaBalai: SkKepalaBalai;
+}
+
+function buildNomorText(number: string, today: Date) {
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  return `SM.${number.trim() || "41"}/K.18/TU/KAP.06.01/${month}/${today.getFullYear()}`;
+}
+
+export function handlePrintSptjLimit() {
+  const printContent = document.getElementById("sptj-limit-print-root");
+  if (!printContent) {
+    toast.error("Tidak ada dokumen Surat Pernyataan Tanggung Jawab Nilai Limit untuk dicetak.");
+    return;
+  }
+  const printWindow = window.open("", "_blank");
+  if (!printWindow) return;
+
+  printWindow.document.write(`
+    <html>
+      <head>
+        <title>Surat Pernyataan Tanggung Jawab Nilai Limit</title>
+        <style>
+          @page { size: A4; margin: 0 0 28mm 0; }
+          * { box-sizing: border-box; }
+          body {
+            margin: 0; padding: 0; background: white; color: black;
+            font-family: 'Bookman Old Style', Georgia, serif;
+            font-size: 11pt; line-height: 1.4;
+          }
+          p { margin: 0; padding: 0; }
+          article { margin: 0; }
+          .doc-page {
+            width: 210mm;
+            box-sizing: border-box;
+            margin: 0 auto;
+            padding: 5mm 20mm 0;
+          }
+          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; text-align: center; }
+          .doc-header img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
+          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; text-align: justify; text-justify: inter-word; }
+          .doc-body p { text-align: justify; text-justify: inter-word; }
+          .doc-title { margin-top: 0.75rem; text-align: center; font-weight: 700; line-height: 1.3; }
+          .doc-title p { margin: 0; }
+          .doc-text-block { margin-top: 1rem; }
+          .doc-text-block > * + * { margin-top: 0.85rem; }
+          .doc-identity { display: grid; grid-template-columns: 28mm 5mm minmax(0, 1fr); row-gap: 0.2rem; column-gap: 0; }
+          .doc-identity .colon { text-align: center; }
+          .doc-list { padding-left: 0; margin: 0; }
+          .doc-list-item { display: grid; grid-template-columns: 8mm minmax(0, 1fr); column-gap: 0; }
+          .doc-list-item + .doc-list-item { margin-top: 0.5rem; }
+          .doc-list-item .marker { }
+          .doc-list-item .text { text-align: justify; }
+          .signature { width: 20rem; margin-left: auto; margin-top: 1.5rem; }
+          .signature p { margin: 0; padding: 0; line-height: 1.3; }
+          .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; margin-top: 2rem; margin-bottom: 2rem; }
+          .doc-editable { outline: none; border-bottom: none !important; }
+        </style>
+      </head>
+      <body>${printContent.innerHTML}</body>
+    </html>
+  `);
+  printWindow.document.close();
+  printWindow.focus();
+  setTimeout(() => printWindow.print(), 500);
+}
+
+export function SptjLimitDocument({ number, kepalaBalai }: SptjLimitDocumentProps) {
+  const today = new Date();
+  const nomorText = buildNomorText(number, today);
+
+  return (
+    <div id="sptj-limit-print-root" className="sptj-limit-print-root">
+      <style jsx global>{`
+        .sptj-limit-print-root .doc-editable { outline: none; border-bottom: 1px dashed transparent; transition: border-bottom-color 0.15s ease; }
+        .sptj-limit-print-root .doc-editable:hover { border-bottom-color: #94a3b8; }
+        .sptj-limit-print-root .doc-editable:focus { border-bottom-color: #64748b; }
+        @media print {
+          @page { size: A4; margin: 0 0 28mm 0; }
+          body * { visibility: hidden; }
+          .sptj-limit-print-root, .sptj-limit-print-root * { visibility: visible; }
+          .sptj-limit-print-root {
+            position: absolute; left: 0; top: 0; width: 100%;
+            background: white; color: black;
+            font-family: 'Bookman Old Style', Georgia, serif;
+            font-size: 11pt; line-height: 1.4; margin: 0; padding: 0;
+          }
+          .doc-page { width: 210mm; margin: 0 auto; padding: 5mm 20mm 0; box-shadow: none !important; }
+          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; }
+          .doc-header img { max-width: 196mm !important; }
+          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; }
+          .doc-editable { border-bottom: none !important; }
+        }
+      `}</style>
+
+      <article
+        className="doc-page mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.4" }}
+      >
+        <div className="doc-header -mx-18 text-center">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
+        </div>
+
+        <div className="doc-title mt-2 text-center font-bold leading-snug">
+          <p className="m-0">SURAT PERNYATAAN TANGGUNG JAWAB NILAI LIMIT</p>
+          <p className="m-0 font-normal">Nomor : {nomorText}</p>
+        </div>
+
+        <div className="doc-body doc-text-block mx-auto mt-4 w-[166mm] space-y-3 text-justify">
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Yang bertanda tangan di bawah ini :
+          </p>
+          <div className="doc-identity grid grid-cols-[28mm_5mm_minmax(0,1fr)]">
+            <span>Nama</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nama}</span>
+            <span>NIP</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nip}</span>
+            <span>Pangkat/Gol</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">Pembina Tk.I / IV b</span>
+            <span>Jabatan</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">Kepala Balai KSDA Kalimantan Timur</span>
+          </div>
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Dengan ini menyatakan sebagai berikut :
+          </p>
+          <ol className="doc-list space-y-2">
+            <li className="doc-list-item grid grid-cols-[8mm_minmax(0,1fr)]">
+              <span className="marker">1.</span>
+              <span contentEditable suppressContentEditableWarning className="doc-editable text text-justify">
+                Bertanggungjawab secara penuh atas kebenaran nilai limit yang kami ajukan dalam rangka penjualan, yang bukan merupakan nilai wajar hasil inventarisasi dan penilaian.
+              </span>
+            </li>
+            <li className="doc-list-item grid grid-cols-[8mm_minmax(0,1fr)]">
+              <span className="marker">2.</span>
+              <span contentEditable suppressContentEditableWarning className="doc-editable text text-justify">
+                Perhitungan nilai limit sebagaimana dimaksud pada angka 1 (satu), prinsip efisien, efektif dan menghasilkan manfaat yang optimal bagi negara (antara lain penurunan nilai barang dimaksud apabila tidak dilakukan penghapusan/pemindahtanganan, potensi biaya pemeliharaan yang harus dikeluarkan, ketersediaan ruangan yang sudah tidak memadai dan sebagainya).
+              </span>
+            </li>
+          </ol>
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Demikian pernyataan ini kami buat dengan keadaan sebenarnya untuk dapat dipergunakan sebagaimana mestinya.
+          </p>
+        </div>
+
+        <div className="signature mt-6 ml-auto w-80">
+          <p className="m-0">Samarinda, {formatDateLong(today)}</p>
+          <p className="m-0">Kepala Balai,</p>
+          <div className="ttd-placeholder mt-8 box-border h-28 pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+          <p contentEditable suppressContentEditableWarning className="doc-editable m-0 mt-8">{kepalaBalai.nama}</p>
+          <p contentEditable suppressContentEditableWarning className="doc-editable m-0">NIP. {kepalaBalai.nip}</p>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/frontend/src/app/bmn/auction-candidates/_components/SptjmDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SptjmDocument.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { toast } from "sonner";
+import { formatDateLong } from "../_lib/auction-helpers";
+import type { SkKepalaBalai } from "../_lib/sk-defaults";
+
+interface SptjmDocumentProps {
+  number: string;
+  kepalaBalai: SkKepalaBalai;
+}
+
+function buildNomorText(number: string, today: Date) {
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  return `SPTJM.${number.trim() || "202"}/K.18/TU/KAP.06.01/${month}/${today.getFullYear()}`;
+}
+
+export function handlePrintSptjm() {
+  const printContent = document.getElementById("sptjm-print-root");
+  if (!printContent) {
+    toast.error("Tidak ada dokumen SPTJM untuk dicetak.");
+    return;
+  }
+  const printWindow = window.open("", "_blank");
+  if (!printWindow) return;
+
+  printWindow.document.write(`
+    <html>
+      <head>
+        <title>Surat Pernyataan Tanggung Jawab Mutlak</title>
+        <style>
+          @page { size: A4; margin: 0 0 28mm 0; }
+          * { box-sizing: border-box; }
+          body {
+            margin: 0; padding: 0; background: white; color: black;
+            font-family: 'Bookman Old Style', Georgia, serif;
+            font-size: 11pt; line-height: 1.4;
+          }
+          p { margin: 0; padding: 0; }
+          article { margin: 0; }
+          .doc-page { width: 210mm; box-sizing: border-box; margin: 0 auto; padding: 5mm 20mm 0; }
+          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; text-align: center; }
+          .doc-header img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
+          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; text-align: justify; text-justify: inter-word; }
+          .doc-body p { text-align: justify; text-justify: inter-word; }
+          .doc-title { margin-top: 0.75rem; text-align: center; font-weight: 700; line-height: 1.3; }
+          .doc-title p { margin: 0; }
+          .doc-text-block { margin-top: 1rem; }
+          .doc-text-block > * + * { margin-top: 0.85rem; }
+          .doc-identity { display: grid; grid-template-columns: 28mm 5mm minmax(0, 1fr); row-gap: 0.2rem; }
+          .doc-identity .colon { text-align: center; }
+          .doc-list { padding-left: 0; margin: 0; }
+          .doc-list-item { display: grid; grid-template-columns: 8mm minmax(0, 1fr); }
+          .doc-list-item + .doc-list-item { margin-top: 0.5rem; }
+          .doc-list-item .text { text-align: justify; }
+          .signature { width: 20rem; margin-left: auto; margin-top: 1.5rem; }
+          .signature p { margin: 0; padding: 0; line-height: 1.3; }
+          .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; margin-top: 2rem; margin-bottom: 2rem; }
+          .doc-editable { outline: none; border-bottom: none !important; }
+        </style>
+      </head>
+      <body>${printContent.innerHTML}</body>
+    </html>
+  `);
+  printWindow.document.close();
+  printWindow.focus();
+  setTimeout(() => printWindow.print(), 500);
+}
+
+export function SptjmDocument({ number, kepalaBalai }: SptjmDocumentProps) {
+  const today = new Date();
+  const nomorText = buildNomorText(number, today);
+
+  return (
+    <div id="sptjm-print-root" className="sptjm-print-root">
+      <style jsx global>{`
+        .sptjm-print-root .doc-editable { outline: none; border-bottom: 1px dashed transparent; transition: border-bottom-color 0.15s ease; }
+        .sptjm-print-root .doc-editable:hover { border-bottom-color: #94a3b8; }
+        .sptjm-print-root .doc-editable:focus { border-bottom-color: #64748b; }
+        @media print {
+          @page { size: A4; margin: 0 0 28mm 0; }
+          body * { visibility: hidden; }
+          .sptjm-print-root, .sptjm-print-root * { visibility: visible; }
+          .sptjm-print-root {
+            position: absolute; left: 0; top: 0; width: 100%;
+            background: white; color: black;
+            font-family: 'Bookman Old Style', Georgia, serif;
+            font-size: 11pt; line-height: 1.4; margin: 0; padding: 0;
+          }
+          .doc-page { width: 210mm; margin: 0 auto; padding: 5mm 20mm 0; box-shadow: none !important; }
+          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; }
+          .doc-header img { max-width: 196mm !important; }
+          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; }
+          .doc-editable { border-bottom: none !important; }
+        }
+      `}</style>
+
+      <article
+        className="doc-page mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.4" }}
+      >
+        <div className="doc-header -mx-18 text-center">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
+        </div>
+
+        <div className="doc-title mt-2 text-center font-bold leading-snug">
+          <p className="m-0">SURAT PERNYATAAN TANGGUNG JAWAB MUTLAK</p>
+          <p className="m-0 font-normal">Nomor : {nomorText}</p>
+        </div>
+
+        <div className="doc-body doc-text-block mx-auto mt-4 w-[166mm] space-y-3 text-justify">
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Yang bertanda tangan dibawah ini :
+          </p>
+          <div className="doc-identity grid grid-cols-[28mm_5mm_minmax(0,1fr)]">
+            <span>Nama</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nama}</span>
+            <span>NIP</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nip}</span>
+            <span>Pangkat/Gol</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">Pembina Tk.I / IV b</span>
+            <span>Jabatan</span>
+            <span className="colon text-center">:</span>
+            <span contentEditable suppressContentEditableWarning className="doc-editable">Kepala Balai KSDA Kalimantan Timur</span>
+          </div>
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Dengan ini menyatakan sebagai berikut :
+          </p>
+          <ol className="doc-list space-y-2">
+            <li className="doc-list-item grid grid-cols-[8mm_minmax(0,1fr)]">
+              <span>1.</span>
+              <span contentEditable suppressContentEditableWarning className="doc-editable text text-justify">
+                Bertanggung jawab secara penuh atas kebenaran permohonan yang diajukan baik materiil maupun formil;
+              </span>
+            </li>
+            <li className="doc-list-item grid grid-cols-[8mm_minmax(0,1fr)]">
+              <span>2.</span>
+              <span contentEditable suppressContentEditableWarning className="doc-editable text text-justify">
+                Bahwa Barang Milik Negara yang diusulkan pemindahtanganan dengan penjualan dalam kondisi rusak berat, tidak dapat digunakan dan dimanfaatkan lagi sehingga Barang Milik Negara dimaksud harus dilakukan penghapusan berdasarkan ketentuan perundangan yang berlaku.
+              </span>
+            </li>
+          </ol>
+          <p contentEditable suppressContentEditableWarning className="doc-editable">
+            Demikian pernyataan ini kami buat dengan keadaan sebenarnya untuk dapat dipergunakan sebagaimana mestinya.
+          </p>
+        </div>
+
+        <div className="signature mt-6 ml-auto w-80">
+          <p className="m-0">Samarinda, {formatDateLong(today)}</p>
+          <p className="m-0">Kepala Balai,</p>
+          <div className="ttd-placeholder mt-8 box-border h-28 pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+          <p contentEditable suppressContentEditableWarning className="doc-editable m-0 mt-8">{kepalaBalai.nama}</p>
+          <p contentEditable suppressContentEditableWarning className="doc-editable m-0">NIP. {kepalaBalai.nip}</p>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/frontend/src/app/bmn/auction-candidates/_lib/auction-helpers.ts
+++ b/frontend/src/app/bmn/auction-candidates/_lib/auction-helpers.ts
@@ -14,6 +14,8 @@ export interface AuctionAsset {
   lokasi_spesifik?: string | null;
   tahun_perolehan?: number | null;
   no_polisi?: string | null;
+  no_identitas?: string | null;
+  no_rangka?: string | null;
 }
 
 export interface AssetResponse {

--- a/frontend/src/app/bmn/auction-candidates/_lib/pemeriksa-defaults.ts
+++ b/frontend/src/app/bmn/auction-candidates/_lib/pemeriksa-defaults.ts
@@ -1,0 +1,44 @@
+// Default panitia pemeriksa for the BA Pemeriksaan BMN document.
+
+export interface PemeriksaAnggota {
+  id: string;
+  nama: string;
+  nip: string;
+  jabatan: string;
+}
+
+const makeId = () => "id" + Math.random().toString(36).slice(2);
+
+export const DEFAULT_PEMERIKSA: PemeriksaAnggota[] = [
+  {
+    id: makeId(),
+    nama: "DHENY MARDIONO, S.Hut., M.Sc.",
+    nip: "19750314 199903 1 004",
+    jabatan: "Kepala Sub Bagian Tata Usaha",
+  },
+  {
+    id: makeId(),
+    nama: "HERYANTO SUMANBOWO, S.Hut",
+    nip: "19830528 200102 1 001",
+    jabatan: "PEH Muda",
+  },
+  {
+    id: makeId(),
+    nama: "HARDI PURNAMA",
+    nip: "19720201 199703 1 006",
+    jabatan: "Penata Administrasi Perlengkapan",
+  },
+  {
+    id: makeId(),
+    nama: "TEGAR ANUGRAH, A.Md.Kom.",
+    nip: "19990707 202506 1 006",
+    jabatan: "Pranata Komputer Terampil",
+  },
+];
+
+export const newPemeriksaAnggota = (): PemeriksaAnggota => ({
+  id: makeId(),
+  nama: "",
+  nip: "",
+  jabatan: "",
+});

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -27,6 +27,7 @@ import {
   formatRupiah,
   shortenLokasi,
   getSkNumberSuffix,
+  formatDateLong,
 } from "./_lib/auction-helpers";
 import { ReorderPanel } from "./_components/ReorderPanel";
 import { SummaryTile } from "./_components/SummaryTile";
@@ -34,6 +35,11 @@ import { CorrectionDocument, handlePrintBa } from "./_components/BaKoreksiDocume
 import { SkPenghentianDocument, handlePrintSk } from "./_components/SkPenghentianDocument";
 import { SkPanitiaDocument, handlePrintSkPanitia } from "./_components/SkPanitiaDocument";
 import { SkBuilder } from "./_components/SkBuilder";
+import { SptjLimitDocument, handlePrintSptjLimit } from "./_components/SptjLimitDocument";
+import { SptjmDocument, handlePrintSptjm } from "./_components/SptjmDocument";
+import { SpTugasDocument, handlePrintSpTugas } from "./_components/SpTugasDocument";
+import { SkKebenaranDokumenDocument, handlePrintSkKebenaran } from "./_components/SkKebenaranDokumenDocument";
+import { BaPemeriksaanDocument, handlePrintBaPemeriksaan } from "./_components/BaPemeriksaanDocument";
 import {
   DEFAULT_MENIMBANG,
   DEFAULT_MENGINGAT,
@@ -50,6 +56,11 @@ import {
   DEFAULT_PANITIA_SUSUNAN,
   type PanitiaAnggota,
 } from "./_lib/sk-panitia-defaults";
+import {
+  DEFAULT_PEMERIKSA,
+  newPemeriksaAnggota,
+  type PemeriksaAnggota,
+} from "./_lib/pemeriksa-defaults";
 
 export default function BmnAuctionCandidatesPage() {
   const [searchTerm, setSearchTerm] = useState("");
@@ -59,10 +70,23 @@ export default function BmnAuctionCandidatesPage() {
   const [showDocument, setShowDocument] = useState(false);
   const [showSkDocument, setShowSkDocument] = useState(false);
   const [showSkPanitia, setShowSkPanitia] = useState(false);
+  const [showSptjLimit, setShowSptjLimit] = useState(false);
+  const [showSptjm, setShowSptjm] = useState(false);
+  const [showSpTugas, setShowSpTugas] = useState(false);
+  const [showSkKebenaran, setShowSkKebenaran] = useState(false);
+  const [showBaPemeriksaan, setShowBaPemeriksaan] = useState(false);
   const [baNumber, setBaNumber] = useState("");
   const [baKap, setBaKap] = useState("KAP.06.01");
   const [skNumber, setSkNumber] = useState("");
   const [skPanitiaNumber, setSkPanitiaNumber] = useState("");
+  const [sptjLimitNumber, setSptjLimitNumber] = useState("41");
+  const [sptjmNumber, setSptjmNumber] = useState("202");
+  const [spTugasNumber, setSpTugasNumber] = useState("40");
+  const [skKebenaranNumber, setSkKebenaranNumber] = useState("200");
+  const [baPemeriksaanNumber, setBaPemeriksaanNumber] = useState("158");
+  const [stNumber, setStNumber] = useState("");
+  const [stTanggal, setStTanggal] = useState(formatDateLong(new Date()));
+  const [pemeriksaList, setPemeriksaList] = useState<PemeriksaAnggota[]>(DEFAULT_PEMERIKSA);
   const [menimbang, setMenimbang] = useState(DEFAULT_MENIMBANG);
   const [mengingat, setMengingat] = useState(DEFAULT_MENGINGAT);
   const [memutuskan, setMemutuskan] = useState(DEFAULT_MEMUTUSKAN);
@@ -195,14 +219,24 @@ export default function BmnAuctionCandidatesPage() {
     dragOverIndexRef.current = null;
   }, []);
 
+  const resetAllShows = useCallback(() => {
+    setShowDocument(false);
+    setShowSkDocument(false);
+    setShowSkPanitia(false);
+    setShowSptjLimit(false);
+    setShowSptjm(false);
+    setShowSpTugas(false);
+    setShowSkKebenaran(false);
+    setShowBaPemeriksaan(false);
+  }, []);
+
   const handleProcess = () => {
     if (orderedIds.length === 0) {
       toast.error("Pilih minimal satu aset untuk diproses.");
       return;
     }
+    resetAllShows();
     setShowDocument(true);
-    setShowSkDocument(false);
-    setShowSkPanitia(false);
     setTimeout(() => {
       document.getElementById("ba-koreksi-preview")?.scrollIntoView({ behavior: "smooth", block: "start" });
     }, 50);
@@ -213,9 +247,8 @@ export default function BmnAuctionCandidatesPage() {
       toast.error("Pilih minimal satu aset untuk diproses.");
       return;
     }
+    resetAllShows();
     setShowSkDocument(true);
-    setShowDocument(false);
-    setShowSkPanitia(false);
     setTimeout(() => {
       document.getElementById("sk-penghentian-preview")?.scrollIntoView({ behavior: "smooth", block: "start" });
     }, 50);
@@ -226,17 +259,97 @@ export default function BmnAuctionCandidatesPage() {
       toast.error("Pilih minimal satu aset untuk diproses.");
       return;
     }
+    resetAllShows();
     setShowSkPanitia(true);
-    setShowDocument(false);
-    setShowSkDocument(false);
     setTimeout(() => {
       document.getElementById("sk-panitia-preview")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 50);
+  };
+
+  const handleProcessSptjLimit = () => {
+    resetAllShows();
+    setShowSptjLimit(true);
+    setTimeout(() => {
+      document.getElementById("sptj-limit-preview")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 50);
+  };
+
+  const handleProcessSptjm = () => {
+    resetAllShows();
+    setShowSptjm(true);
+    setTimeout(() => {
+      document.getElementById("sptjm-preview")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 50);
+  };
+
+  const handleProcessSpTugas = () => {
+    resetAllShows();
+    setShowSpTugas(true);
+    setTimeout(() => {
+      document.getElementById("sp-tugas-preview")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 50);
+  };
+
+  const handleProcessSkKebenaran = () => {
+    if (orderedIds.length === 0) {
+      toast.error("Pilih minimal satu aset untuk membuat tabel dokumen kepemilikan.");
+      return;
+    }
+    resetAllShows();
+    setShowSkKebenaran(true);
+    setTimeout(() => {
+      document.getElementById("sk-kebenaran-preview")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 50);
+  };
+
+  const handleProcessBaPemeriksaan = () => {
+    resetAllShows();
+    setShowBaPemeriksaan(true);
+    setTimeout(() => {
+      document.getElementById("ba-pemeriksaan-preview")?.scrollIntoView({ behavior: "smooth", block: "start" });
     }, 50);
   };
 
   const handlePrint = () => handlePrintBa(orderedSelectedAssets);
   const handlePrintSkDoc = () => handlePrintSk(orderedSelectedAssets, skNumber);
   const handlePrintSkPanitiaDoc = () => handlePrintSkPanitia();
+  const handlePrintSptjLimitDoc = () => handlePrintSptjLimit();
+  const handlePrintSptjmDoc = () => handlePrintSptjm();
+  const handlePrintSpTugasDoc = () => handlePrintSpTugas();
+  const handlePrintSkKebenaranDoc = () => handlePrintSkKebenaran();
+  const handlePrintBaPemeriksaanDoc = () => handlePrintBaPemeriksaan();
+
+  const addPemeriksaAnggota = () => {
+    setPemeriksaList((prev) => [...prev, newPemeriksaAnggota()]);
+  };
+
+  const removePemeriksaAnggota = (id: string) => {
+    setPemeriksaList((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  const updatePemeriksaAnggota = (id: string, field: keyof PemeriksaAnggota, value: string) => {
+    setPemeriksaList((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, [field]: value } : item)),
+    );
+  };
+
+  const selectPemeriksaEmployee = (id: string, employeeId: string) => {
+    if (!employeeId) return;
+    const emp = sortedEmployeesForPanitia.find((e) => String(e.id) === employeeId);
+    if (!emp) return;
+    setPemeriksaList((prev) =>
+      prev.map((item) =>
+        item.id === id
+          ? {
+              ...item,
+              nama: emp.nama_lengkap || emp.name || "",
+              nip: formatNip(emp.nip || ""),
+              jabatan: emp.position || emp.jabatan || "",
+            }
+          : item,
+      ),
+    );
+  };
 
   const addPanitiaAnggota = () => {
     setSusunanPanitia((prev) => [
@@ -329,6 +442,47 @@ export default function BmnAuctionCandidatesPage() {
           >
             <FileText className="h-3.5 w-3.5" />
             Proses SK Panitia
+          </Button>
+          <Button
+            size="sm"
+            className="rounded-xl gap-2 bg-blue-600 text-xs hover:bg-blue-500"
+            onClick={handleProcessSptjLimit}
+          >
+            <FileText className="h-3.5 w-3.5" />
+            Proses SPTJ Limit
+          </Button>
+          <Button
+            size="sm"
+            className="rounded-xl gap-2 bg-purple-600 text-xs hover:bg-purple-500"
+            onClick={handleProcessSptjm}
+          >
+            <FileText className="h-3.5 w-3.5" />
+            Proses SPTJM
+          </Button>
+          <Button
+            size="sm"
+            className="rounded-xl gap-2 bg-pink-600 text-xs hover:bg-pink-500"
+            onClick={handleProcessSpTugas}
+          >
+            <FileText className="h-3.5 w-3.5" />
+            Proses SP Tugas
+          </Button>
+          <Button
+            size="sm"
+            className="rounded-xl gap-2 bg-cyan-600 text-xs hover:bg-cyan-500"
+            onClick={handleProcessSkKebenaran}
+            disabled={orderedIds.length === 0}
+          >
+            <FileText className="h-3.5 w-3.5" />
+            Proses SK Kebenaran
+          </Button>
+          <Button
+            size="sm"
+            className="rounded-xl gap-2 bg-orange-600 text-xs hover:bg-orange-500"
+            onClick={handleProcessBaPemeriksaan}
+          >
+            <FileText className="h-3.5 w-3.5" />
+            Proses BA Pemeriksaan
           </Button>
         </div>
       </div>
@@ -439,6 +593,120 @@ export default function BmnAuctionCandidatesPage() {
         </div>
       </div>
 
+      <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
+        <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+          <label htmlFor="sptj-limit-number" className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">
+            Nomor SPTJ Nilai Limit
+          </label>
+          <div className="mt-2 flex h-11 items-center rounded-xl border border-zinc-200 bg-white px-3 text-sm text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-white">
+            <span className="font-semibold">SM.</span>
+            <input
+              id="sptj-limit-number"
+              type="text"
+              value={sptjLimitNumber}
+              onChange={(event) => setSptjLimitNumber(event.target.value)}
+              placeholder="41"
+              className="mx-1 w-16 bg-transparent text-center font-semibold outline-none"
+            />
+            <span className="truncate">/K.18/TU/KAP.06.01/{String(new Date().getMonth() + 1).padStart(2, "0")}/{new Date().getFullYear()}</span>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+          <label htmlFor="sptjm-number" className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">
+            Nomor SPTJM
+          </label>
+          <div className="mt-2 flex h-11 items-center rounded-xl border border-zinc-200 bg-white px-3 text-sm text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-white">
+            <span className="font-semibold">SPTJM.</span>
+            <input
+              id="sptjm-number"
+              type="text"
+              value={sptjmNumber}
+              onChange={(event) => setSptjmNumber(event.target.value)}
+              placeholder="202"
+              className="mx-1 w-16 bg-transparent text-center font-semibold outline-none"
+            />
+            <span className="truncate">/K.18/TU/KAP.06.01/{String(new Date().getMonth() + 1).padStart(2, "0")}/{new Date().getFullYear()}</span>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+          <label htmlFor="sp-tugas-number" className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">
+            Nomor SP Tidak Mengganggu Tugas
+          </label>
+          <div className="mt-2 flex h-11 items-center rounded-xl border border-zinc-200 bg-white px-3 text-sm text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-white">
+            <span className="font-semibold">SM.</span>
+            <input
+              id="sp-tugas-number"
+              type="text"
+              value={spTugasNumber}
+              onChange={(event) => setSpTugasNumber(event.target.value)}
+              placeholder="40"
+              className="mx-1 w-16 bg-transparent text-center font-semibold outline-none"
+            />
+            <span className="truncate">/K.18/TU/KAP.06.01/{String(new Date().getMonth() + 1).padStart(2, "0")}/{new Date().getFullYear()}</span>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+          <label htmlFor="sk-kebenaran-number" className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">
+            Nomor SK Kebenaran Dokumen
+          </label>
+          <div className="mt-2 flex h-11 items-center rounded-xl border border-zinc-200 bg-white px-3 text-sm text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-white">
+            <span className="font-semibold">KT.</span>
+            <input
+              id="sk-kebenaran-number"
+              type="text"
+              value={skKebenaranNumber}
+              onChange={(event) => setSkKebenaranNumber(event.target.value)}
+              placeholder="200"
+              className="mx-1 w-16 bg-transparent text-center font-semibold outline-none"
+            />
+            <span className="truncate">/K.18/TU/KAP.06.01/{String(new Date().getMonth() + 1).padStart(2, "0")}/{new Date().getFullYear()}</span>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 xl:col-span-2">
+          <label htmlFor="ba-pemeriksaan-number" className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">
+            Nomor BA Pemeriksaan + Surat Tugas
+          </label>
+          <div className="mt-2 grid gap-2 lg:grid-cols-3">
+            <div className="flex h-11 items-center rounded-xl border border-zinc-200 bg-white px-3 text-sm text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-white">
+              <span className="font-semibold">BA.</span>
+              <input
+                id="ba-pemeriksaan-number"
+                type="text"
+                value={baPemeriksaanNumber}
+                onChange={(event) => setBaPemeriksaanNumber(event.target.value)}
+                placeholder="158"
+                className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
+              />
+              <span className="truncate">/K.18/TU/KAP.06.01/{String(new Date().getMonth() + 1).padStart(2, "0")}/{new Date().getFullYear()}</span>
+            </div>
+            <div className="flex h-11 items-center rounded-xl border border-zinc-200 bg-white px-3 text-sm text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-white">
+              <span className="mr-2 shrink-0 text-[10px] font-bold uppercase tracking-wider text-zinc-400">No. ST</span>
+              <input
+                type="text"
+                value={stNumber}
+                onChange={(event) => setStNumber(event.target.value)}
+                placeholder="ST.xxx/K.18/TU/..."
+                className="w-full bg-transparent font-semibold outline-none"
+              />
+            </div>
+            <div className="flex h-11 items-center rounded-xl border border-zinc-200 bg-white px-3 text-sm text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-white">
+              <span className="mr-2 shrink-0 text-[10px] font-bold uppercase tracking-wider text-zinc-400">Tgl ST</span>
+              <input
+                type="text"
+                value={stTanggal}
+                onChange={(event) => setStTanggal(event.target.value)}
+                placeholder={formatDateLong(new Date())}
+                className="w-full bg-transparent font-semibold outline-none"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
       {orderedIds.length > 0 && (
         <div className="flex flex-col gap-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 dark:border-red-500/20 dark:bg-red-500/10 sm:flex-row sm:items-center sm:justify-between">
           <div>
@@ -458,6 +726,26 @@ export default function BmnAuctionCandidatesPage() {
               <FileText className="mr-1 h-3.5 w-3.5" />
               Generate SK Panitia
             </Button>
+            <Button size="sm" className="rounded-lg bg-blue-600 text-xs hover:bg-blue-500" onClick={handleProcessSptjLimit}>
+              <FileText className="mr-1 h-3.5 w-3.5" />
+              Generate SPTJ Limit
+            </Button>
+            <Button size="sm" className="rounded-lg bg-purple-600 text-xs hover:bg-purple-500" onClick={handleProcessSptjm}>
+              <FileText className="mr-1 h-3.5 w-3.5" />
+              Generate SPTJM
+            </Button>
+            <Button size="sm" className="rounded-lg bg-pink-600 text-xs hover:bg-pink-500" onClick={handleProcessSpTugas}>
+              <FileText className="mr-1 h-3.5 w-3.5" />
+              Generate SP Tugas
+            </Button>
+            <Button size="sm" className="rounded-lg bg-cyan-600 text-xs hover:bg-cyan-500" onClick={handleProcessSkKebenaran}>
+              <FileText className="mr-1 h-3.5 w-3.5" />
+              Generate SK Kebenaran
+            </Button>
+            <Button size="sm" className="rounded-lg bg-orange-600 text-xs hover:bg-orange-500" onClick={handleProcessBaPemeriksaan}>
+              <FileText className="mr-1 h-3.5 w-3.5" />
+              Generate BA Pemeriksaan
+            </Button>
             {showDocument && (
               <Button size="sm" variant="outline" className="rounded-lg text-xs" onClick={handlePrint}>
                 <Printer className="mr-1 h-3.5 w-3.5" />
@@ -474,6 +762,36 @@ export default function BmnAuctionCandidatesPage() {
               <Button size="sm" variant="outline" className="rounded-lg text-xs" onClick={handlePrintSkPanitiaDoc}>
                 <Printer className="mr-1 h-3.5 w-3.5" />
                 Cetak SK Panitia
+              </Button>
+            )}
+            {showSptjLimit && (
+              <Button size="sm" variant="outline" className="rounded-lg text-xs" onClick={handlePrintSptjLimitDoc}>
+                <Printer className="mr-1 h-3.5 w-3.5" />
+                Cetak SPTJ Limit
+              </Button>
+            )}
+            {showSptjm && (
+              <Button size="sm" variant="outline" className="rounded-lg text-xs" onClick={handlePrintSptjmDoc}>
+                <Printer className="mr-1 h-3.5 w-3.5" />
+                Cetak SPTJM
+              </Button>
+            )}
+            {showSpTugas && (
+              <Button size="sm" variant="outline" className="rounded-lg text-xs" onClick={handlePrintSpTugasDoc}>
+                <Printer className="mr-1 h-3.5 w-3.5" />
+                Cetak SP Tugas
+              </Button>
+            )}
+            {showSkKebenaran && (
+              <Button size="sm" variant="outline" className="rounded-lg text-xs" onClick={handlePrintSkKebenaranDoc}>
+                <Printer className="mr-1 h-3.5 w-3.5" />
+                Cetak SK Kebenaran
+              </Button>
+            )}
+            {showBaPemeriksaan && (
+              <Button size="sm" variant="outline" className="rounded-lg text-xs" onClick={handlePrintBaPemeriksaanDoc}>
+                <Printer className="mr-1 h-3.5 w-3.5" />
+                Cetak BA Pemeriksaan
               </Button>
             )}
           </div>
@@ -749,6 +1067,165 @@ export default function BmnAuctionCandidatesPage() {
                 kepalaBalai={kepalaBalai}
                 tembusan={panitiaTembusan}
                 susunanPanitia={susunanPanitia}
+              />
+            </div>
+          </div>
+        </section>
+      )}
+
+      {showSptjLimit && (
+        <section id="sptj-limit-preview" className="space-y-4">
+          <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
+            <div>
+              <h2 className="text-lg font-bold text-zinc-900 dark:text-white">Preview Surat Pernyataan Tanggung Jawab Nilai Limit</h2>
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">Pernyataan tanggung jawab Kepala Balai atas kebenaran nilai limit penjualan BMN.</p>
+            </div>
+            <Button className="rounded-xl gap-2 bg-blue-600 text-xs hover:bg-blue-500" onClick={handlePrintSptjLimitDoc}>
+              <Printer className="h-3.5 w-3.5" />
+              Cetak / Save PDF
+            </Button>
+          </div>
+          <SptjLimitDocument number={sptjLimitNumber} kepalaBalai={kepalaBalai} />
+        </section>
+      )}
+
+      {showSptjm && (
+        <section id="sptjm-preview" className="space-y-4">
+          <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
+            <div>
+              <h2 className="text-lg font-bold text-zinc-900 dark:text-white">Preview Surat Pernyataan Tanggung Jawab Mutlak (SPTJM)</h2>
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">Pernyataan tanggung jawab mutlak atas usulan pemindahtanganan BMN.</p>
+            </div>
+            <Button className="rounded-xl gap-2 bg-purple-600 text-xs hover:bg-purple-500" onClick={handlePrintSptjmDoc}>
+              <Printer className="h-3.5 w-3.5" />
+              Cetak / Save PDF
+            </Button>
+          </div>
+          <SptjmDocument number={sptjmNumber} kepalaBalai={kepalaBalai} />
+        </section>
+      )}
+
+      {showSpTugas && (
+        <section id="sp-tugas-preview" className="space-y-4">
+          <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
+            <div>
+              <h2 className="text-lg font-bold text-zinc-900 dark:text-white">Preview Surat Pernyataan Tidak Mengganggu Kelancaran Tugas</h2>
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">Pernyataan bahwa pemindahtanganan BMN tidak mengganggu kelancaran tugas dinas.</p>
+            </div>
+            <Button className="rounded-xl gap-2 bg-pink-600 text-xs hover:bg-pink-500" onClick={handlePrintSpTugasDoc}>
+              <Printer className="h-3.5 w-3.5" />
+              Cetak / Save PDF
+            </Button>
+          </div>
+          <SpTugasDocument number={spTugasNumber} kepalaBalai={kepalaBalai} />
+        </section>
+      )}
+
+      {showSkKebenaran && orderedSelectedAssets.length > 0 && (
+        <section id="sk-kebenaran-preview" className="space-y-4">
+          <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
+            <div>
+              <h2 className="text-lg font-bold text-zinc-900 dark:text-white">Preview SK Kebenaran Fotokopi Dokumen Kepemilikan</h2>
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">Surat keterangan kebenaran dokumen kepemilikan kendaraan bermotor. Tabel dapat diedit langsung.</p>
+            </div>
+            <Button className="rounded-xl gap-2 bg-cyan-600 text-xs hover:bg-cyan-500" onClick={handlePrintSkKebenaranDoc}>
+              <Printer className="h-3.5 w-3.5" />
+              Cetak / Save PDF
+            </Button>
+          </div>
+          <SkKebenaranDokumenDocument
+            number={skKebenaranNumber}
+            assets={orderedSelectedAssets}
+            kepalaBalai={kepalaBalai}
+          />
+        </section>
+      )}
+
+      {showBaPemeriksaan && (
+        <section id="ba-pemeriksaan-preview" className="space-y-4">
+          <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
+            <div>
+              <h2 className="text-lg font-bold text-zinc-900 dark:text-white">Preview Berita Acara Pemeriksaan BMN</h2>
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">Berita Acara Pemeriksaan BMN berupa Alat Angkutan Bermotor oleh tim pemeriksa.</p>
+            </div>
+            <Button className="rounded-xl gap-2 bg-orange-600 text-xs hover:bg-orange-500" onClick={handlePrintBaPemeriksaanDoc}>
+              <Printer className="h-3.5 w-3.5" />
+              Cetak / Save PDF
+            </Button>
+          </div>
+          <div className="grid gap-4 lg:grid-cols-[400px_1fr]">
+            <div className="print:hidden">
+              <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-bold text-zinc-900 dark:text-white">Pemeriksa</h3>
+                  <Button size="xs" variant="outline" className="rounded-lg gap-1" onClick={addPemeriksaAnggota}>
+                    <Plus className="h-3 w-3" />
+                    Tambah
+                  </Button>
+                </div>
+                <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  Daftar pemeriksa BMN yang akan ditampilkan pada berita acara.
+                </p>
+                <div className="mt-3 space-y-3">
+                  {pemeriksaList.map((item) => (
+                    <div key={item.id} className="rounded-xl border border-zinc-200 bg-zinc-50/60 p-2.5 dark:border-zinc-800 dark:bg-zinc-900/50">
+                      <div className="flex items-center gap-2">
+                        <select
+                          value=""
+                          onChange={(e) => selectPemeriksaEmployee(item.id, e.target.value)}
+                          className="h-8 flex-1 rounded-lg border border-zinc-200 bg-white px-2 text-xs text-zinc-900 outline-none focus:ring-1 focus:ring-orange-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-white"
+                        >
+                          <option value="">-- Pilih Pegawai --</option>
+                          {sortedEmployeesForPanitia.map((emp) => (
+                            <option key={emp.id} value={String(emp.id)}>
+                              {emp.nama_lengkap || emp.name || "-"}
+                            </option>
+                          ))}
+                        </select>
+                        <Button
+                          size="xs"
+                          variant="destructive"
+                          className="rounded-md gap-1"
+                          onClick={() => removePemeriksaAnggota(item.id)}
+                        >
+                          <Trash2 className="h-3 w-3" />
+                          Hapus
+                        </Button>
+                      </div>
+                      <input
+                        value={item.nama}
+                        onChange={(e) => updatePemeriksaAnggota(item.id, "nama", e.target.value)}
+                        placeholder="Nama"
+                        className="mt-2 h-8 w-full rounded-lg border border-zinc-200 bg-white px-2 text-xs text-zinc-900 outline-none focus:ring-1 focus:ring-orange-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-white"
+                      />
+                      <input
+                        value={item.nip}
+                        onChange={(e) => updatePemeriksaAnggota(item.id, "nip", e.target.value)}
+                        placeholder="NIP"
+                        className="mt-2 h-8 w-full rounded-lg border border-zinc-200 bg-white px-2 text-xs text-zinc-900 outline-none focus:ring-1 focus:ring-orange-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-white"
+                      />
+                      <input
+                        value={item.jabatan}
+                        onChange={(e) => updatePemeriksaAnggota(item.id, "jabatan", e.target.value)}
+                        placeholder="Jabatan"
+                        className="mt-2 h-8 w-full rounded-lg border border-zinc-200 bg-white px-2 text-xs text-zinc-900 outline-none focus:ring-1 focus:ring-orange-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-white"
+                      />
+                    </div>
+                  ))}
+                  {pemeriksaList.length === 0 && (
+                    <p className="rounded-lg border border-dashed border-zinc-300 p-3 text-center text-xs text-zinc-400">
+                      Belum ada pemeriksa. Klik Tambah untuk menambahkan.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+            <div>
+              <BaPemeriksaanDocument
+                number={baPemeriksaanNumber}
+                pemeriksaList={pemeriksaList}
+                stNumber={stNumber}
+                stTanggal={stTanggal}
               />
             </div>
           </div>


### PR DESCRIPTION
Closes #356

5 dokumen pendukung lelang BMN baru di /bmn/auction-candidates:

1. **Surat Pernyataan Tanggung Jawab Nilai Limit** (SM.41/...)
2. **SPTJM - Surat Pernyataan Tanggung Jawab Mutlak** (SPTJM.202/...)
3. **Surat Pernyataan Tidak Mengganggu Kelancaran Tugas** (SM.40/...)
4. **SK Kebenaran Fotokopi Dokumen Kepemilikan** (KT.200/...) - tabel 6 kolom editable inline (No, No Dokumen, Merk/Tipe, No Mesin, No Rangka, No Polisi)
5. **BA Pemeriksaan BMN** (BA.158/...) - daftar pemeriksa editable dengan select pegawai

## Pattern
- Reuse pattern existing (SkPenghentianDocument): KOP /header-new.png, Bookman Old Style 11pt, A4 dengan margin bottom 28mm untuk BSrE
- Dokumen 1, 2, 3 statis 1 halaman + TTD Kepala Balai
- Dokumen 4 punya tabel dengan contentEditable (Nomor Mesin default kosong, belum ada di DB - editable inline)
- Dokumen 5 tidak ada TTD Kepala Balai (sesuai template), pemeriksa list pakai pattern mirror SK Panitia

## File baru
- `_components/SptjLimitDocument.tsx`
- `_components/SptjmDocument.tsx`
- `_components/SpTugasDocument.tsx`
- `_components/SkKebenaranDokumenDocument.tsx`
- `_components/BaPemeriksaanDocument.tsx`
- `_lib/pemeriksa-defaults.ts`  (interface PemeriksaAnggota + 4 default)

## File diubah
- `page.tsx` - 5 state show, 5 state nomor, panel input nomor surat baru, 5 tombol action bar (warna: blue/purple/pink/cyan/orange), 5 tombol banner, 5 section preview
- `_lib/auction-helpers.ts` - tambah `no_identitas` + `no_rangka` ke `AuctionAsset` (sudah ada di backend)

## Validasi
- `npx eslint auction-candidates/** --max-warnings=0` clean
- `npx tsc --noEmit` clean
- `npm run build` clean (59 static pages)