### PR TITLE
feat(bmn): add no_mesin field for motor vehicles (#358)

### DIFF
--- a/backend/app/Modules/Bmn/Models/Asset.php
+++ b/backend/app/Modules/Bmn/Models/Asset.php
@@ -28,7 +28,7 @@ class Asset extends Model
         'kecamatan', 'kab_kota', 'kode_kab_kota', 'provinsi', 'kode_provinsi', 'kode_pos',
         'sbsk', 'optimalisasi', 'penghuni', 'pengguna', 'kode_kpknl', 'uraian_kpknl',
         'uraian_kanwil_djkn', 'nama_kl', 'nama_e1', 'nama_korwil', 'kode_register', 'lokasi_ruang',
-        'jenis_identitas', 'no_identitas', 'no_stnk', 'no_rangka', 'nama_pengguna', 'status_pmk',
+        'jenis_identitas', 'no_identitas', 'no_stnk', 'no_mesin', 'no_rangka', 'nama_pengguna', 'status_pmk',
         'status_foto_geotag', 'foto_geotag_url', 'foto_geotag_path', 'foto_belakang_path',
         'foto_kiri_path', 'foto_kanan_path', 'foto_lokasi_path',
         'foto_bpkb_1_path', 'foto_bpkb_2_path', 'foto_bpkb_3_path', 'foto_bpkb_4_path',

--- a/backend/app/Modules/Bmn/Requests/UpdateAssetRequest.php
+++ b/backend/app/Modules/Bmn/Requests/UpdateAssetRequest.php
@@ -27,6 +27,7 @@ class UpdateAssetRequest extends FormRequest
             'kondisi' => ['sometimes', 'string', Rule::in(['Baik', 'Rusak Ringan', 'Rusak Berat'])],
             'no_polisi' => ['sometimes', 'nullable', 'string'],
             'no_stnk' => ['sometimes', 'nullable', 'string'],
+            'no_mesin' => ['sometimes', 'nullable', 'string'],
             'no_rangka' => ['sometimes', 'nullable', 'string'],
             'no_bpkp' => ['sometimes', 'nullable', 'string'],
             'no_dokumen' => ['sometimes', 'nullable', 'string'],

--- a/backend/app/Modules/Bmn/Resources/AssetResource.php
+++ b/backend/app/Modules/Bmn/Resources/AssetResource.php
@@ -89,6 +89,7 @@ class AssetResource extends JsonResource
             'jenis_identitas' => $this->jenis_identitas,
             'no_identitas' => $this->no_identitas,
             'no_stnk' => $this->no_stnk,
+            'no_mesin' => $this->no_mesin,
             'no_rangka' => $this->no_rangka,
             'tanggal_pajak_stnk' => $this->tanggal_pajak_stnk?->format('Y-m-d'),
             'tanggal_ganti_plat' => $this->tanggal_ganti_plat?->format('Y-m-d'),

--- a/backend/database/migrations/2026_05_22_163000_add_no_mesin_to_bmn_assets_table.php
+++ b/backend/database/migrations/2026_05_22_163000_add_no_mesin_to_bmn_assets_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('bmn_assets', function (Blueprint $table) {
+            $table->string('no_mesin')->nullable()->after('no_stnk');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('bmn_assets', function (Blueprint $table) {
+            $table->dropColumn('no_mesin');
+        });
+    }
+};

--- a/frontend/src/app/bmn/assets/[id]/page.tsx
+++ b/frontend/src/app/bmn/assets/[id]/page.tsx
@@ -277,6 +277,9 @@ function AssetDetail({ assetId }: { assetId: string }) {
                   <EditableRow label="No BPKB" value={asset.no_bpkp} field="no_bpkp" onSave={handleFieldSave} />
                   <EditableRow label="No STNK" value={asset.no_stnk} field="no_stnk" onSave={handleFieldSave} />
                   {(asset.jenis_bmn === "ALAT ANGKUTAN BERMOTOR" && !!asset.no_polisi && asset.no_polisi.trim() !== "-") && (
+                    <EditableRow label="No Mesin" value={asset.no_mesin} field="no_mesin" onSave={handleFieldSave} />
+                  )}
+                  {(asset.jenis_bmn === "ALAT ANGKUTAN BERMOTOR" && !!asset.no_polisi && asset.no_polisi.trim() !== "-") && (
                     <EditableRow label="No Rangka" value={asset.no_rangka} field="no_rangka" onSave={handleFieldSave} />
                   )}
                   <EditableRow label="Tanggal Pajak STNK" value={asset.tanggal_pajak_stnk} field="tanggal_pajak_stnk" onSave={handleFieldSave} type="date" badge={asset.tanggal_pajak_stnk ? <StnkCountdown tanggal={asset.tanggal_pajak_stnk} label="Pajak" /> : undefined} />
@@ -291,6 +294,9 @@ function AssetDetail({ assetId }: { assetId: string }) {
                   <DetailRow label="No Polisi" value={asset.no_polisi} />
                   <DetailRow label="No BPKB" value={asset.no_bpkp} />
                   <DetailRow label="No STNK" value={asset.no_stnk} />
+                  {(asset.jenis_bmn === "ALAT ANGKUTAN BERMOTOR" && !!asset.no_polisi && asset.no_polisi.trim() !== "-") && (
+                    <DetailRow label="No Mesin" value={asset.no_mesin} />
+                  )}
                   {(asset.jenis_bmn === "ALAT ANGKUTAN BERMOTOR" && !!asset.no_polisi && asset.no_polisi.trim() !== "-") && (
                     <DetailRow label="No Rangka" value={asset.no_rangka} />
                   )}

--- a/frontend/src/app/bmn/auction-candidates/_components/SkKebenaranDokumenDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkKebenaranDokumenDocument.tsx
@@ -165,7 +165,7 @@ export function SkKebenaranDokumenDocument({ number, assets, kepalaBalai }: SkKe
                     <td>{index + 1}.</td>
                     <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.no_identitas || ""}</td>
                     <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.merk_tipe || ""}</td>
-                    <td contentEditable suppressContentEditableWarning className="doc-editable"></td>
+                    <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.no_mesin || ""}</td>
                     <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.no_rangka || ""}</td>
                     <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.no_polisi || ""}</td>
                   </tr>

--- a/frontend/src/app/bmn/auction-candidates/_lib/auction-helpers.ts
+++ b/frontend/src/app/bmn/auction-candidates/_lib/auction-helpers.ts
@@ -15,6 +15,7 @@ export interface AuctionAsset {
   tahun_perolehan?: number | null;
   no_polisi?: string | null;
   no_identitas?: string | null;
+  no_mesin?: string | null;
   no_rangka?: string | null;
 }
 


### PR DESCRIPTION
Closes #358

Adds `no_mesin` (Nomor Mesin) field for motor vehicle assets that have a license plate (`no_polisi`), so the SK Kebenaran Fotokopi Dokumen Kepemilikan (KT.200/...) document can auto-fill the Nomor Mesin column from the asset.

## Backend
- New migration `2026_05_22_163000_add_no_mesin_to_bmn_assets_table.php` — adds nullable `no_mesin` column after `no_stnk`.
- `Asset` model — `no_mesin` added to `$fillable`.
- `AssetResource` — `no_mesin` exposed in API response.
- `UpdateAssetRequest` — added validation rule `['sometimes', 'nullable', 'string']`.

## Frontend
- `bmn/assets/[id]/page.tsx` — added `EditableRow` and `DetailRow` for "No Mesin" in Kendaraan & Sertifikat section, only rendered when `jenis_bmn === "ALAT ANGKUTAN BERMOTOR"` and `no_polisi` is valid (mirror pattern for `no_rangka`).
- `auction-candidates/_lib/auction-helpers.ts` — `AuctionAsset` interface gets `no_mesin?: string | null`.
- `auction-candidates/_components/SkKebenaranDokumenDocument.tsx` — Nomor Mesin column auto-fills from `asset.no_mesin || ""` (still editable inline via `contentEditable`).

## Pattern reference
- Issue #330 (no_rangka) — same migration + model + resource + request + UI conditional rendering pattern.

## Validation
- `php -l` clean for all 4 PHP files.
- `npx eslint "src/app/bmn/**" --max-warnings=0` clean.
- `npx tsc --noEmit` clean.
- `npm run build` clean (59/59 static pages).

## Production deploy notes
- Run `php artisan migrate` after pulling on production to apply the new column.
