### PR TITLE
feat(kepegawaian): add Apply BMN Penghapusan template button to ST builder (#360)

### DIFF
--- a/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx
+++ b/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx
@@ -237,7 +237,9 @@ export default function STBuilderPreview({
                     buildUntukText(),
                     buildBiayaText(),
                     "Membuat laporan tertulis paling lambat 7 (tujuh) hari kerja setelah selesainya kegiatan tersebut.",
-                  ].map((item, idx) => (
+                  ]
+                    .filter(item => item && item.trim())
+                    .map((item, idx) => (
                     <div
                       className="untuk-entry"
                       key={idx}

--- a/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx
+++ b/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx
@@ -92,6 +92,10 @@ const SUMBER_DANA_OPTIONS: SumberDanaOption[] = [
     dasarText: '',
     biayaText: 'Segala biaya yang timbul akibat Surat Tugas ini tidak dibebankan pada anggaran manapun (DL 1 / tanpa biaya).'
   },
+  { id: 'bmn', label: 'BMN Penghapusan (tanpa biaya)',
+    dasarText: '',
+    biayaText: ''
+  },
   { id: 'other', label: 'Lainnya',
     dasarText: '',
     biayaText: ''
@@ -213,6 +217,8 @@ export default function STBuilderPage() {
 
   // Build biaya text
   const buildBiayaText = (): string => {
+    // BMN Penghapusan: no biaya line in Untuk list
+    if (sumberDana === 'bmn') return '';
     const opt = SUMBER_DANA_OPTIONS.find(o => o.id === sumberDana);
     if (opt?.biayaText) {
       const tahun = tanggalSurat ? new Date(tanggalSurat).getFullYear().toString() : new Date().getFullYear().toString();
@@ -299,6 +305,38 @@ export default function STBuilderPage() {
         return newItems;
       });
     }
+  };
+
+  // Apply BMN Penghapusan template: one-click preset for ST Pemeriksaan BMN
+  const applyBmnTemplate = () => {
+    setHeaderTitle("KEPALA BALAI,");
+    setKlasifikasi("KAP.05");
+    setSumberDana("bmn");
+
+    setMenimbangItems([
+      { id: "bmn-m1", text: "bahwa dalam rangka penghapusan Barang Milik Negara berupa Alat Angkutan Bermotor pada Balai Konservasi Sumber Daya Alam Kalimantan Timur;" },
+      { id: "bmn-m2", text: "bahwa sehubungan dengan butir a tersebut di atas dipandang perlu untuk menugaskan staf tersebut di bawah ini untuk melakukan pemeriksaan Barang Milik Negara." },
+    ]);
+
+    setDasarItems([
+      { id: "bmn-d1", text: "Undang-Undang RI Nomor 17 Tahun 2003 tentang Keuangan Negara;" },
+      { id: "bmn-d2", text: "Undang-Undang RI Nomor 1 Tahun 2004 tentang Perbendaharaan Negara;" },
+      { id: "bmn-d3", text: "Peraturan Pemerintah Nomor 27 Tahun 2014 tentang Pengelolaan Barang Milik Negara/Daerah sebagaimana telah diubah dengan Peraturan Pemerintah Nomor 28 Tahun 2020;" },
+      { id: "bmn-d4", text: "Peraturan Presiden Nomor 175 Tahun 2024 tentang Kementerian Kehutanan;" },
+      { id: "bmn-d5", text: "Peraturan Menteri Keuangan Nomor 4/PMK.06/2015 tentang Pendelegasian Kewenangan dan Tanggung Jawab Tertentu Dari Pengelola Barang kepada Pengguna Barang;" },
+      { id: "bmn-d6", text: "Peraturan Menteri Keuangan Nomor 83/PMK.06/2016 tentang Tata Cara Pelaksanaan Pemusnahan dan Penghapusan Barang Milik Negara;" },
+      { id: "bmn-d7", text: "Peraturan Menteri Keuangan Nomor 181/PMK.06/2016 tentang Penatausahaan Barang Milik Negara;" },
+      { id: "bmn-d8", text: "Peraturan Menteri Lingkungan Hidup dan Kehutanan Nomor P.11/MENLHK/SETJEN/KAP.3/4/2018 tentang Tata Cara Pelaksanaan Pemindahtanganan Barang Milik Negara Lingkup Kementerian Lingkungan Hidup dan Kehutanan." },
+    ]);
+
+    // Freeform "Untuk" mode: clear structured fields, set namaKegiatan to BMN-specific text
+    setActivityPrefix("");
+    setKotaAsal("");
+    setKotaTujuan("");
+    setTempatKegiatan("");
+    setNamaKegiatan("Melaksanakan pemeriksaan Barang Milik Negara berupa Alat Angkutan Bermotor pada tanggal {tanggal_pemeriksaan}");
+
+    setTembusanItems([]);
   };
 
   // Initial Fetch & Parse
@@ -710,13 +748,21 @@ export default function STBuilderPage() {
 
           <FormSection title="Sumber Dana">
             <div className="space-y-2">
-              <select 
-                value={sumberDana} 
+              <button
+                type="button"
+                onClick={applyBmnTemplate}
+                className="flex w-full items-center justify-center gap-2 rounded-xl border border-orange-200 bg-orange-50 px-3 py-2 text-xs font-bold uppercase tracking-wider text-orange-700 transition hover:bg-orange-100 dark:border-orange-500/30 dark:bg-orange-500/10 dark:text-orange-300 dark:hover:bg-orange-500/20"
+                title="One-click apply: Klasifikasi KAP.05 + Menimbang + Dasar (8 peraturan) + Untuk pemeriksaan BMN"
+              >
+                Apply Template BMN Penghapusan
+              </button>
+              <select
+                value={sumberDana}
                 onChange={e => {
                   const newFunding = e.target.value;
                   setSumberDana(newFunding);
                   updateDasarFromFunding(newFunding, tanggalSurat);
-                }} 
+                }}
                 className="w-full px-3 py-2 bg-zinc-50 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-xl text-sm outline-none cursor-pointer text-zinc-900 dark:text-white"
               >
                 {SUMBER_DANA_OPTIONS.map(opt => <option key={opt.id} value={opt.id}>{opt.label}</option>)}


### PR DESCRIPTION
Closes #360

Adds a one-click **Apply Template BMN Penghapusan** button to the ST Builder so users can generate the Surat Tugas Pemeriksaan BMN format without manually editing every field.

## What
- New entry in `SUMBER_DANA_OPTIONS`: `bmn` (label: `BMN Penghapusan (tanpa biaya)`).
- `buildBiayaText()` returns empty string for `sumberDana === 'bmn'` so no cost line is rendered.
- New `applyBmnTemplate()` handler sets:
  - `klasifikasi = "KAP.05"`
  - `sumberDana = "bmn"`
  - `headerTitle = "KEPALA BALAI,"`
  - **Menimbang** (2 items, BMN penghapusan).
  - **Dasar** (8 peraturan: UU 17/2003, UU 1/2004, PP 27/2014, Perpres 175/2024, PMK 4/PMK.06/2015, PMK 83/PMK.06/2016, PMK 181/PMK.06/2016, P.11/MENLHK 2018).
  - Freeform `Untuk` text with `{tanggal_pemeriksaan}` placeholder for the user to fill.
  - Resets `tembusan`.
- Orange `Apply Template BMN Penghapusan` button placed above the Sumber Dana select in the sidebar.
- `STBuilderPreview` filters empty strings from the Untuk list so the missing biaya line doesn't render.

## Why
- BA Pemeriksaan (#356, #361) requires a referencing ST. Manually building each ST every time is tedious and error-prone.
- Pattern mirrors the existing FOLU template flow (one-click switches Menimbang/Dasar/Tembusan).

## How to use
1. Open any ST in the builder (`/kepegawaian/surat-tugas/builder/[id]`).
2. In the sidebar, click **Apply Template BMN Penghapusan** (orange).
3. Fill in tanggal pemeriksaan in the Untuk text and select 4 pemeriksa pegawai.
4. Save & generate.

## Files changed
- `frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx`
- `frontend/src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx`

## Validation
- `npx eslint <both files> --max-warnings=0` clean.
- `npx tsc --noEmit` clean.
- `npm run build` clean (59/59 static pages).
