### PR TITLE
feat(kepegawaian): finalize BMN Penghapusan template state with reset support and ST list badge (#364)

### DIFF
--- a/backend/app/Modules/SuratTugas/Controllers/AssignmentLetterController.php
+++ b/backend/app/Modules/SuratTugas/Controllers/AssignmentLetterController.php
@@ -115,6 +115,7 @@ class AssignmentLetterController extends Controller
                 'tempat_tujuan' => $validated['tempat_tujuan'] ?? null,
                 'sumber_dana' => $validated['sumber_dana'] ?? 'dipa',
                 'sumber_dana_other' => $validated['sumber_dana_other'] ?? null,
+                'template_type' => $validated['template_type'] ?? null,
                 'nama_plh' => $request->input('nama_plh'),
                 'has_seksi_employee' => (bool) $request->input('has_seksi_employee', false),
                 'tanda_setuju' => $request->input('tanda_setuju'),
@@ -195,6 +196,7 @@ class AssignmentLetterController extends Controller
                 'tanggal_mulai' => $validated['tanggal_mulai'],
                 'tanggal_selesai' => $validated['tanggal_selesai'],
                 'tempat_tujuan' => $validated['tempat_tujuan'],
+                'template_type' => $validated['template_type'] ?? null,
             ]);
 
             $pivotData = [];

--- a/backend/app/Modules/SuratTugas/Migrations/2026_05_23_100000_add_template_type_to_st_assignment_letters_table.php
+++ b/backend/app/Modules/SuratTugas/Migrations/2026_05_23_100000_add_template_type_to_st_assignment_letters_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('st_assignment_letters', function (Blueprint $table) {
+            $table->string('template_type', 50)->nullable()->after('kode_surat')->comment('Tag template ST, contoh: bmn-pemeriksaan');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('st_assignment_letters', function (Blueprint $table) {
+            $table->dropColumn('template_type');
+        });
+    }
+};

--- a/backend/app/Modules/SuratTugas/Models/AssignmentLetter.php
+++ b/backend/app/Modules/SuratTugas/Models/AssignmentLetter.php
@@ -19,6 +19,7 @@ class AssignmentLetter extends Model
     protected $fillable = [
         'nomor_surat',
         'kode_surat',
+        'template_type',
         'dasar_hukum',
         'maksud_tujuan',
         'tanggal_mulai',

--- a/backend/app/Modules/SuratTugas/Requests/AssignmentLetterRequest.php
+++ b/backend/app/Modules/SuratTugas/Requests/AssignmentLetterRequest.php
@@ -21,6 +21,7 @@ class AssignmentLetterRequest extends FormRequest
             'tempat_tujuan' => 'nullable|string|max:255',
             'sumber_dana' => 'required|string',
             'sumber_dana_other' => 'nullable|string',
+            'template_type' => 'nullable|string|max:50',
             'employees' => 'required|array|min:1',
             'employees.*.id' => 'required|exists:kpg_employees,id',
             'employees.*.peran' => 'nullable|string|max:100',

--- a/frontend/src/app/kepegawaian/_components/AssignmentHistoryTab.tsx
+++ b/frontend/src/app/kepegawaian/_components/AssignmentHistoryTab.tsx
@@ -16,6 +16,7 @@ interface SuratTugasItem {
     tanggal_mulai: string;
     tanggal_selesai: string;
     status: string;
+    template_type?: string | null;
     employees?: { id: string; nama_lengkap: string; nip: string }[];
 }
 
@@ -153,6 +154,14 @@ export function AssignmentHistoryTab() {
                                             <span className="font-mono text-zinc-900 dark:text-zinc-100 font-bold text-[11px] bg-zinc-100 dark:bg-zinc-800 px-2 py-1 rounded-md">
                                                 {item.nomor_surat || "Belum Input"}
                                             </span>
+                                            {item.template_type === "bmn-pemeriksaan" && (
+                                                <span
+                                                    className="ml-1.5 inline-flex items-center rounded-md border border-orange-200 bg-orange-50 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-orange-700 dark:border-orange-500/30 dark:bg-orange-500/10 dark:text-orange-300"
+                                                    title="Template BMN Penghapusan"
+                                                >
+                                                    Template BMN
+                                                </span>
+                                            )}
                                         </td>
                                         <td className="px-6 py-4 max-w-xs">
                                             <p className="text-zinc-900 dark:text-zinc-200 text-xs font-semibold line-clamp-2 leading-relaxed">{item.maksud_tujuan}</p>

--- a/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx
+++ b/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx
@@ -36,6 +36,7 @@ interface PreviewProps {
   tembusanItems?: string[];
   headerTitle?: string;
   sumberDana?: string;
+  templateType?: string | null;
 }
 
 export default function STBuilderPreview({
@@ -54,8 +55,10 @@ export default function STBuilderPreview({
   tembusanItems = [],
   headerTitle = "KEPALA BALAI,",
   sumberDana = "dipa",
+  templateType = null,
 }: PreviewProps) {
   const isFolu = sumberDana === "folu";
+  const isBmnTemplate = templateType === "bmn-pemeriksaan";
   const visibleTembusanItems = tembusanItems.filter(t => t && t.trim());
   const shouldNumberDefaultTembusan = visibleTembusanItems.length > 1;
 
@@ -236,7 +239,9 @@ export default function STBuilderPreview({
                   {[
                     buildUntukText(),
                     buildBiayaText(),
-                    "Membuat laporan tertulis paling lambat 7 (tujuh) hari kerja setelah selesainya kegiatan tersebut.",
+                    isBmnTemplate
+                      ? "Membuat laporan tertulis paling lambat 7 (tujuh) hari setelah selesainya kegiatan tersebut."
+                      : "Membuat laporan tertulis paling lambat 7 (tujuh) hari kerja setelah selesainya kegiatan tersebut.",
                   ]
                     .filter(item => item && item.trim())
                     .map((item, idx) => (
@@ -257,17 +262,18 @@ export default function STBuilderPreview({
                 </div>
               </div>
 
-              {/* === PENUTUP === */}
-              {isFolu ? (
-                <p className="penutup-surat" style={{ margin: "28px 0 0", textAlign: "justify" }}>
-                  Demikian Surat Perintah Tugas ini dibuat, untuk dapat dipergunakan sebagaimana mestinya dan kepada instansi yang dikunjungi dimohon bantuan seperlunya demi kelancaran pelaksanaan tugas.
-                </p>
-              ) : (
-                <p className="penutup-surat" style={{ margin: "28px 0 0" }}>Demikian untuk dilaksanakan dengan penuh tanggung jawab.</p>
-              )}
+              {/* === PENUTUP + TTD + TEMBUSAN — keep together so TTD never breaks alone === */}
+              <div className="penutup-ttd-group" style={{ pageBreakInside: "avoid", breakInside: "avoid" }}>
+                {isFolu ? (
+                  <p className="penutup-surat" style={{ margin: "28px 0 0", textAlign: "justify" }}>
+                    Demikian Surat Perintah Tugas ini dibuat, untuk dapat dipergunakan sebagaimana mestinya dan kepada instansi yang dikunjungi dimohon bantuan seperlunya demi kelancaran pelaksanaan tugas.
+                  </p>
+                ) : (
+                  <p className="penutup-surat" style={{ margin: "28px 0 0" }}>Demikian untuk dilaksanakan dengan penuh tanggung jawab.</p>
+                )}
 
-              {/* === TANDA TANGAN + TEMBUSAN === */}
-              <div className="ttd-tembusan-wrapper" style={{ pageBreakInside: "avoid" }}>
+                {/* === TANDA TANGAN + TEMBUSAN === */}
+                <div className="ttd-tembusan-wrapper" style={{ pageBreakInside: "avoid" }}>
                 {isFolu ? (
                   <>
                     {/* === FOLU TTD Layout — Dikeluarkan sejajar a.n., rata kanan === */}
@@ -349,6 +355,7 @@ export default function STBuilderPreview({
                     )}
                   </>
                 )}
+              </div>
               </div>
               </div>
             </td>

--- a/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx
+++ b/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/page.tsx
@@ -92,10 +92,6 @@ const SUMBER_DANA_OPTIONS: SumberDanaOption[] = [
     dasarText: '',
     biayaText: 'Segala biaya yang timbul akibat Surat Tugas ini tidak dibebankan pada anggaran manapun (DL 1 / tanpa biaya).'
   },
-  { id: 'bmn', label: 'BMN Penghapusan (tanpa biaya)',
-    dasarText: '',
-    biayaText: ''
-  },
   { id: 'other', label: 'Lainnya',
     dasarText: '',
     biayaText: ''
@@ -149,6 +145,7 @@ export default function STBuilderPage() {
 
   const [sumberDana, setSumberDana] = useState("dipa");
   const [sumberDanaOther, setSumberDanaOther] = useState("");
+  const [templateType, setTemplateType] = useState<string | null>(null);
   const [headerTitle, setHeaderTitle] = useState("KEPALA BALAI,");
   const [namaKegiatan, setNamaKegiatan] = useState("");
   const [activityPrefix, setActivityPrefix] = useState("Perjalanan Dinas");
@@ -192,6 +189,16 @@ export default function STBuilderPage() {
     const selesaiFormatted = formatDateIndonesian(tanggalSelesai);
 
     let text = "";
+    const isBmnTemplate = templateType === "bmn-pemeriksaan";
+
+    // BMN template: always freeform, no date suffix
+    if (isBmnTemplate) {
+      text = namaKegiatan || "...";
+      if (!text.trim().endsWith(".") && !text.trim().endsWith(";")) {
+        text += ".";
+      }
+      return text;
+    }
 
     if (activityPrefix && kotaAsal) {
       // Structured mode: prefix + dari + ke + dalam rangka + kegiatan
@@ -217,8 +224,8 @@ export default function STBuilderPage() {
 
   // Build biaya text
   const buildBiayaText = (): string => {
-    // BMN Penghapusan: no biaya line in Untuk list
-    if (sumberDana === 'bmn') return '';
+    // BMN Penghapusan template: no biaya line in Untuk list (regardless of sumberDana)
+    if (templateType === 'bmn-pemeriksaan') return '';
     const opt = SUMBER_DANA_OPTIONS.find(o => o.id === sumberDana);
     if (opt?.biayaText) {
       const tahun = tanggalSurat ? new Date(tanggalSurat).getFullYear().toString() : new Date().getFullYear().toString();
@@ -311,7 +318,13 @@ export default function STBuilderPage() {
   const applyBmnTemplate = () => {
     setHeaderTitle("KEPALA BALAI,");
     setKlasifikasi("KAP.05");
-    setSumberDana("bmn");
+    setSumberDana("dl1");
+    setTemplateType("bmn-pemeriksaan");
+
+    // Default tanggal kegiatan = hari ini (1 hari, user bisa ubah)
+    const today = new Date().toISOString().substring(0, 10);
+    setTanggalMulai(today);
+    setTanggalSelesai(today);
 
     setMenimbangItems([
       { id: "bmn-m1", text: "bahwa dalam rangka penghapusan Barang Milik Negara berupa Alat Angkutan Bermotor pada Balai Konservasi Sumber Daya Alam Kalimantan Timur;" },
@@ -334,9 +347,13 @@ export default function STBuilderPage() {
     setKotaAsal("");
     setKotaTujuan("");
     setTempatKegiatan("");
-    setNamaKegiatan("Melaksanakan pemeriksaan Barang Milik Negara berupa Alat Angkutan Bermotor pada tanggal {tanggal_pemeriksaan}");
+    setNamaKegiatan("Melaksanakan pemeriksaan Barang Milik Negara berupa Alat Angkutan Bermotor pada tanggal " + formatDateIndonesian(today));
 
     setTembusanItems([]);
+  };
+
+  const resetBmnTemplate = () => {
+    setTemplateType(null);
   };
 
   // Initial Fetch & Parse
@@ -385,6 +402,11 @@ export default function STBuilderPage() {
         const funding = normalizeSumberDana(data.sumber_dana);
         setSumberDana(funding);
         if (data.sumber_dana_other) setSumberDanaOther(data.sumber_dana_other);
+
+        // Load template type if present (for ST that was created with a template)
+        if (data.template_type) {
+          setTemplateType(data.template_type);
+        }
         
         setSelectedEmployees(data.employees || []);
         setKotaTujuan(data.tempat_tujuan || "");
@@ -550,6 +572,7 @@ export default function STBuilderPage() {
         tanggal_surat: tanggalSurat || null,
         sumber_dana: sumberDana,
         sumber_dana_other: sumberDanaOther,
+        template_type: templateType,
         menimbang: menimbangItems,
         dasar: dasarItems,
         tembusan: tembusanItems.length > 0 ? tembusanItems : null,
@@ -587,6 +610,7 @@ export default function STBuilderPage() {
         tanggal_surat: tanggalSurat,
         sumber_dana: sumberDana,
         sumber_dana_other: sumberDanaOther,
+        template_type: templateType,
         menimbang: menimbangItems,
         dasar: dasarItems,
         tembusan: tembusanItems.length > 0 ? tembusanItems : null,
@@ -624,6 +648,7 @@ export default function STBuilderPage() {
         tanggal_surat: tanggalSurat,
         sumber_dana: sumberDana,
         sumber_dana_other: sumberDanaOther,
+        template_type: templateType,
         menimbang: menimbangItems,
         dasar: dasarItems,
         employee_ids: selectedEmployees.map(e => e.id),
@@ -677,7 +702,7 @@ export default function STBuilderPage() {
           .kop-surat img { width: 18.8cm !important; height: auto !important; }
           .surat-content { margin-left: 1.25cm !important; width: calc(100% - 2.2cm) !important; margin-right: 0.95cm !important; }
           .field-section, .kepada-section, .kepada-list, .untuk-section, .untuk-list { break-inside: auto !important; page-break-inside: auto !important; }
-          .employee-entry, .untuk-entry { break-inside: avoid !important; page-break-inside: avoid !important; }
+          .employee-entry, .untuk-entry, .penutup-ttd-group { break-inside: avoid !important; page-break-inside: avoid !important; }
           div[style*="page-break-inside"] { page-break-inside: avoid; }
           /* thead spacer: hidden, not needed with @page margin */
           thead.page-spacer td { height: 0; padding: 0; line-height: 0; font-size: 0; }
@@ -714,6 +739,35 @@ export default function STBuilderPage() {
         </header>
 
         <div className="flex-1 overflow-y-auto p-6 space-y-8 scrollbar-hide">
+          {/* === Template Card (paling atas, di atas Nomor Surat) === */}
+          <div className="rounded-xl border border-orange-200 bg-orange-50 p-3 dark:border-orange-500/30 dark:bg-orange-500/10">
+            {templateType === "bmn-pemeriksaan" ? (
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex h-6 items-center rounded-full bg-orange-600 px-2 text-[10px] font-bold uppercase tracking-wider text-white">Template Aktif</span>
+                  <span className="text-xs font-semibold text-orange-800 dark:text-orange-300">BMN Penghapusan</span>
+                </div>
+                <button
+                  type="button"
+                  onClick={resetBmnTemplate}
+                  className="rounded-lg border border-orange-300 bg-white px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-orange-700 transition hover:bg-orange-100 dark:border-orange-500/30 dark:bg-zinc-900 dark:text-orange-300 dark:hover:bg-orange-500/20"
+                  title="Hapus template BMN dan kembali ke ST manual"
+                >
+                  Hapus Template
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={applyBmnTemplate}
+                className="flex w-full items-center justify-center gap-2 rounded-lg border border-orange-300 bg-white px-3 py-2 text-xs font-bold uppercase tracking-wider text-orange-700 transition hover:bg-orange-100 dark:border-orange-500/30 dark:bg-zinc-900 dark:text-orange-300 dark:hover:bg-orange-500/20"
+                title="One-click apply: Klasifikasi KAP.05 + Menimbang + Dasar (8 peraturan) + Untuk pemeriksaan BMN"
+              >
+                Apply Template BMN Penghapusan
+              </button>
+            )}
+          </div>
+
           <FormSection title="Nomor Surat">
             <div className="flex items-stretch bg-zinc-50 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-xl overflow-hidden focus-within:ring-2 focus-within:ring-blue-500/10">
               <div className="bg-zinc-100 dark:bg-zinc-700 px-3 flex items-center border-r border-zinc-200 dark:border-zinc-600 shrink-0"><span className="text-xs font-bold text-zinc-700 dark:text-zinc-300">ST.</span></div>
@@ -748,14 +802,6 @@ export default function STBuilderPage() {
 
           <FormSection title="Sumber Dana">
             <div className="space-y-2">
-              <button
-                type="button"
-                onClick={applyBmnTemplate}
-                className="flex w-full items-center justify-center gap-2 rounded-xl border border-orange-200 bg-orange-50 px-3 py-2 text-xs font-bold uppercase tracking-wider text-orange-700 transition hover:bg-orange-100 dark:border-orange-500/30 dark:bg-orange-500/10 dark:text-orange-300 dark:hover:bg-orange-500/20"
-                title="One-click apply: Klasifikasi KAP.05 + Menimbang + Dasar (8 peraturan) + Untuk pemeriksaan BMN"
-              >
-                Apply Template BMN Penghapusan
-              </button>
               <select
                 value={sumberDana}
                 onChange={e => {
@@ -959,6 +1005,7 @@ export default function STBuilderPage() {
               tembusanItems={tembusanItems}
               headerTitle={headerTitle}
               sumberDana={sumberDana}
+              templateType={templateType}
             />
           </div>
           {/* Page break indicators */}

--- a/frontend/src/app/kepegawaian/surat-tugas/create/page.tsx
+++ b/frontend/src/app/kepegawaian/surat-tugas/create/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import {
   FileText,
   Printer,
@@ -102,6 +102,8 @@ export default function STCreatePremiumPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const initialEmployeeId = searchParams.get("employee_id");
+  const initialTemplate = searchParams.get("template");
+  const templateAppliedRef = useRef(false);
 
   // --- Form State ---
   const [stNumber, setStNumber] = useState("");
@@ -120,6 +122,7 @@ export default function STCreatePremiumPage() {
 
   const [sumberDana, setSumberDana] = useState("dipa");
   const [sumberDanaOther, setSumberDanaOther] = useState("");
+  const [templateType, setTemplateType] = useState<string | null>(null);
   const [namaKegiatan, setNamaKegiatan] = useState("");
   const [activityPrefix, setActivityPrefix] = useState("Perjalanan Dinas");
   const [tanggalMulai, setTanggalMulai] = useState("");
@@ -167,12 +170,67 @@ export default function STCreatePremiumPage() {
     setSelectedEmployees([normalized]);
   }, [allEmployees, initialEmployeeId, selectedEmployees.length]);
 
+  // Apply BMN Penghapusan template — extracted into a function so it can be triggered by query param OR sidebar button
+  const applyBmnTemplate = useCallback(() => {
+    setKlasifikasi("KAP.05");
+    setSumberDana("dl1");
+    setTemplateType("bmn-pemeriksaan");
+
+    const today = new Date().toISOString().substring(0, 10);
+    setTanggalMulai(today);
+    setTanggalSelesai(today);
+
+    setMenimbangItems([
+      { id: "bmn-m1", text: "bahwa dalam rangka penghapusan Barang Milik Negara berupa Alat Angkutan Bermotor pada Balai Konservasi Sumber Daya Alam Kalimantan Timur;" },
+      { id: "bmn-m2", text: "bahwa sehubungan dengan butir a tersebut di atas dipandang perlu untuk menugaskan staf tersebut di bawah ini untuk melakukan pemeriksaan Barang Milik Negara." },
+    ]);
+
+    setDasarItems([
+      { id: "bmn-d1", text: "Undang-Undang RI Nomor 17 Tahun 2003 tentang Keuangan Negara;" },
+      { id: "bmn-d2", text: "Undang-Undang RI Nomor 1 Tahun 2004 tentang Perbendaharaan Negara;" },
+      { id: "bmn-d3", text: "Peraturan Pemerintah Nomor 27 Tahun 2014 tentang Pengelolaan Barang Milik Negara/Daerah sebagaimana telah diubah dengan Peraturan Pemerintah Nomor 28 Tahun 2020;" },
+      { id: "bmn-d4", text: "Peraturan Presiden Nomor 175 Tahun 2024 tentang Kementerian Kehutanan;" },
+      { id: "bmn-d5", text: "Peraturan Menteri Keuangan Nomor 4/PMK.06/2015 tentang Pendelegasian Kewenangan dan Tanggung Jawab Tertentu Dari Pengelola Barang kepada Pengguna Barang;" },
+      { id: "bmn-d6", text: "Peraturan Menteri Keuangan Nomor 83/PMK.06/2016 tentang Tata Cara Pelaksanaan Pemusnahan dan Penghapusan Barang Milik Negara;" },
+      { id: "bmn-d7", text: "Peraturan Menteri Keuangan Nomor 181/PMK.06/2016 tentang Penatausahaan Barang Milik Negara;" },
+      { id: "bmn-d8", text: "Peraturan Menteri Lingkungan Hidup dan Kehutanan Nomor P.11/MENLHK/SETJEN/KAP.3/4/2018 tentang Tata Cara Pelaksanaan Pemindahtanganan Barang Milik Negara Lingkup Kementerian Lingkungan Hidup dan Kehutanan." },
+    ]);
+
+    setActivityPrefix("");
+    setKotaAsal("");
+    setKotaTujuan("");
+    setTempatKegiatan("");
+    setNamaKegiatan("Melaksanakan pemeriksaan Barang Milik Negara berupa Alat Angkutan Bermotor pada tanggal " + formatDateIndonesian(today));
+  }, []);
+
+  const resetBmnTemplate = useCallback(() => {
+    setTemplateType(null);
+  }, []);
+
+  // Apply BMN Pemeriksaan template from query param (one-shot)
+  useEffect(() => {
+    if (templateAppliedRef.current) return;
+    if (initialTemplate !== "bmn-pemeriksaan") return;
+    templateAppliedRef.current = true;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    applyBmnTemplate();
+  }, [initialTemplate, applyBmnTemplate]);
+
   // Helper for "Untuk" text
   const buildUntukText = (): string => {
     const days = daysBetween(tanggalMulai, tanggalSelesai);
     const daysWord = numberToWords(days);
     const mulaiFormatted = formatDateIndonesian(tanggalMulai);
     const selesaiFormatted = formatDateIndonesian(tanggalSelesai);
+
+    // BMN template: always freeform, no date suffix
+    if (templateType === "bmn-pemeriksaan") {
+      let text = namaKegiatan || "...";
+      if (!text.trim().endsWith(".") && !text.trim().endsWith(";")) {
+        text += ".";
+      }
+      return text;
+    }
 
     let text = `${activityPrefix} dari ${kotaAsal || "..."} ke ${kotaTujuan || "..."}`;
     if (namaKegiatan) {
@@ -191,6 +249,8 @@ export default function STCreatePremiumPage() {
 
   // Build biaya text
   const buildBiayaText = (): string => {
+    // BMN Penghapusan template: skip biaya line entirely (regardless of sumberDana)
+    if (templateType === 'bmn-pemeriksaan') return '';
     const opt = SUMBER_DANA_OPTIONS.find(o => o.id === sumberDana);
     if (opt?.biayaText) {
       const tahun = tanggalSurat ? new Date(tanggalSurat).getFullYear().toString() : new Date().getFullYear().toString();
@@ -270,6 +330,7 @@ export default function STCreatePremiumPage() {
         tanggal_surat: tanggalSurat,
         sumber_dana: sumberDana,
         sumber_dana_other: sumberDanaOther,
+        template_type: templateType,
         menimbang: menimbangItems,
         dasar: dasarItems,
         employee_ids: selectedEmployees.map(e => e.id),
@@ -296,16 +357,35 @@ export default function STCreatePremiumPage() {
     if (!printContent) return;
     const printWindow = window.open("", "_blank");
     if (!printWindow) return;
+    const safeKegiatan = (namaKegiatan || "ST").replace(/[/\\?%*:|"<>]/g, '-');
     printWindow.document.write(`
       <html>
       <head>
-        <title>ST.${stNumber}/K.18/TU/${klasifikasi}/B</title>
+        <title>ST.${stNumber}-${safeKegiatan}</title>
         <style>
-          @page { size: A4; margin: 0; }
-          body { font-family: 'Bookman Old Style', serif; font-size: 11pt; line-height: 1.25; color: #000; margin: 0; padding: 0; }
-          #surat-preview-doc { padding: 0.4cm 1cm 1cm 3cm !important; box-sizing: border-box; }
+          @page { size: A4; margin: 3cm 1cm 1.9cm 1.55cm; }
+          @page :first { margin: 0.7cm 1cm 1.9cm 1.55cm; }
+          body {
+            font-family: 'Bookman Old Style', 'Georgia', serif;
+            font-size: 11pt;
+            line-height: 1.25;
+            color: #000;
+            margin: 0;
+            padding: 0;
+            text-align: justify;
+          }
           table { width: 100%; border-collapse: collapse; }
           td { vertical-align: top; padding: 2px 0; font-size: 11pt; }
+          tr { page-break-inside: avoid; break-inside: avoid; }
+          img { max-width: none !important; }
+          .ttd-placeholder { height: 80px; }
+          .kop-surat { margin-left: 0 !important; margin-right: -0.95cm !important; margin-top: -0.25cm !important; margin-bottom: 2px !important; overflow: visible !important; }
+          .kop-surat img { width: 18.8cm !important; height: auto !important; }
+          .surat-content { margin-left: 1.25cm !important; width: calc(100% - 2.2cm) !important; margin-right: 0.95cm !important; }
+          .field-section, .kepada-section, .kepada-list, .untuk-section, .untuk-list { break-inside: auto !important; page-break-inside: auto !important; }
+          .employee-entry, .untuk-entry, .penutup-ttd-group { break-inside: avoid !important; page-break-inside: avoid !important; }
+          div[style*="page-break-inside"] { page-break-inside: avoid; }
+          thead.page-spacer td { height: 0; padding: 0; line-height: 0; font-size: 0; }
         </style>
       </head>
       <body>${printContent.innerHTML}</body>
@@ -330,6 +410,35 @@ export default function STCreatePremiumPage() {
         </header>
 
         <div className="flex-1 overflow-y-auto p-6 space-y-8 scrollbar-hide">
+          {/* === Template Card (paling atas, di atas Nomor Surat) === */}
+          <div className="rounded-xl border border-orange-200 bg-orange-50 p-3 dark:border-orange-500/30 dark:bg-orange-500/10">
+            {templateType === "bmn-pemeriksaan" ? (
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex h-6 items-center rounded-full bg-orange-600 px-2 text-[10px] font-bold uppercase tracking-wider text-white">Template Aktif</span>
+                  <span className="text-xs font-semibold text-orange-800 dark:text-orange-300">BMN Penghapusan</span>
+                </div>
+                <button
+                  type="button"
+                  onClick={resetBmnTemplate}
+                  className="rounded-lg border border-orange-300 bg-white px-2 py-1 text-[10px] font-bold uppercase tracking-wider text-orange-700 transition hover:bg-orange-100 dark:border-orange-500/30 dark:bg-zinc-900 dark:text-orange-300 dark:hover:bg-orange-500/20"
+                  title="Hapus template BMN dan kembali ke ST manual"
+                >
+                  Hapus Template
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={applyBmnTemplate}
+                className="flex w-full items-center justify-center gap-2 rounded-lg border border-orange-300 bg-white px-3 py-2 text-xs font-bold uppercase tracking-wider text-orange-700 transition hover:bg-orange-100 dark:border-orange-500/30 dark:bg-zinc-900 dark:text-orange-300 dark:hover:bg-orange-500/20"
+                title="One-click apply: Klasifikasi KAP.05 + Menimbang + Dasar (8 peraturan) + Untuk pemeriksaan BMN"
+              >
+                Apply Template BMN Penghapusan
+              </button>
+            )}
+          </div>
+
           <FormSection title="Nomor Surat">
             <div className="flex items-stretch bg-slate-50 dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 rounded-xl overflow-hidden focus-within:ring-2 focus-within:ring-blue-500/10">
               <div className="bg-slate-100 dark:bg-zinc-700 px-3 flex items-center border-r border-slate-200 dark:border-zinc-600 shrink-0"><span className="text-xs font-bold text-zinc-700 dark:text-zinc-300">ST.</span></div>
@@ -518,6 +627,8 @@ export default function STCreatePremiumPage() {
               menimbangItems={menimbangItems} dasarItems={dasarItems} selectedEmployees={selectedEmployees}
               buildUntukText={buildUntukText} buildBiayaText={buildBiayaText}
               kotaSurat={kotaSurat} tanggalSurat={tanggalSurat} kepalaBalai={kepalaBalai}
+              sumberDana={sumberDana}
+              templateType={templateType}
             />
           </div>
           {/* Page break indicators */}

--- a/frontend/src/app/kepegawaian/surat-tugas/inbox/page.tsx
+++ b/frontend/src/app/kepegawaian/surat-tugas/inbox/page.tsx
@@ -30,6 +30,7 @@ interface AssignmentLetter {
   tempat_tujuan: string;
   sumber_dana: string;
   sumber_dana_other: string | null;
+  template_type: string | null;
   file_surat_path: string | null;
   status: 'draft' | 'pending' | 'approved' | 'rejected' | 'completed';
   nomor_surat: string | null;
@@ -343,6 +344,17 @@ export default function SuratTugasInbox() {
                                         {l.maksud_tujuan}
                                     </h3>
 
+                                    {l.template_type === "bmn-pemeriksaan" && (
+                                        <div className="mb-2">
+                                            <span
+                                                className="inline-flex items-center rounded-md border border-orange-200 bg-orange-50 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-orange-700 dark:border-orange-500/30 dark:bg-orange-500/10 dark:text-orange-300"
+                                                title="Template BMN Penghapusan"
+                                            >
+                                                Template BMN
+                                            </span>
+                                        </div>
+                                    )}
+
                                     <div className="flex items-center justify-between text-[9px] font-bold text-slate-500">
                                         <div className="flex items-center gap-2">
                                             <div className="flex items-center gap-1">
@@ -387,6 +399,11 @@ export default function SuratTugasInbox() {
                                         <div className={cn("px-3 py-1 rounded-full border text-[9px] font-black uppercase tracking-wider", getStatusStyle(selectedLetter.status))}>
                                             {getStatusLabel(selectedLetter.status)}
                                         </div>
+                                        {selectedLetter.template_type === "bmn-pemeriksaan" && (
+                                            <div className="px-3 py-1 rounded-full bg-orange-50 dark:bg-orange-900/20 text-orange-700 dark:text-orange-300 border border-orange-200 dark:border-orange-900/30 text-[9px] font-black uppercase tracking-wider">
+                                                Template BMN Penghapusan
+                                            </div>
+                                        )}
                                         {selectedLetter.nomor_surat ? (
                                             <div className="px-3 py-1 rounded-full bg-indigo-50 dark:bg-indigo-900/20 text-indigo-700 dark:text-indigo-400 border border-indigo-100 dark:border-indigo-900/30 text-[9px] font-black tracking-wider flex items-center gap-1.5">
                                                 <Hash className="w-3 h-3" />


### PR DESCRIPTION
Closes #364

Finalisasi template "BMN Penghapusan" untuk ST Builder + ST Create + ST list. Spec dari diskusi user (issue body).

## Backend
- New migration `add_template_type_to_st_assignment_letters_table.php` — kolom `template_type` (nullable string max:50) `after('kode_surat')`.
- `AssignmentLetter` model `$fillable` ditambah `template_type`.
- `AssignmentLetterRequest` validation: `'template_type' => 'nullable|string|max:50'`.
- `AssignmentLetterController` `store()` dan `update()` simpan `template_type`.

## Frontend — Template state
- **Hapus opsi `bmn`** dari `SUMBER_DANA_OPTIONS` di builder.
- **`templateType` state independent** dari sumberDana (nullable string).
- `buildBiayaText()` return `''` saat `templateType === 'bmn-pemeriksaan'` (regardless of sumberDana).
- `buildUntukText()` paksa freeform mode tanpa date suffix saat `templateType === 'bmn-pemeriksaan'`.
- `STBuilderPreview` — item ke-3 Untuk pakai "7 (tujuh) hari" (tanpa "kerja") saat templateType BMN.

## Frontend — Tombol pindah ke paling atas sidebar
- Sebelum: tombol di section Sumber Dana.
- Sesudah: card terpisah PALING ATAS, sebelum "Nomor Surat" (warna orange).
- Saat `templateType=null`: tombol "Apply Template BMN Penghapusan".
- Saat `templateType='bmn-pemeriksaan'`: badge "Template Aktif: BMN Penghapusan" + tombol "Hapus Template".
- Apply ke 2 file: `builder/[id]/page.tsx` DAN `create/page.tsx`.

## Frontend — `applyBmnTemplate` defaults
- Klasifikasi `KAP.05`
- Sumber Dana `dl1` (DL 1 / Tidak ada biaya)
- `tanggalMulai = tanggalSelesai = today` (default 1 hari, user bisa ubah)
- Menimbang 2 items + Dasar 8 peraturan
- `namaKegiatan` = "Melaksanakan pemeriksaan ... pada tanggal {today}"
- Reset structured fields (activityPrefix, kotaAsal, kotaTujuan, tempatKegiatan kosong)
- `templateType = 'bmn-pemeriksaan'`

## Frontend — `resetBmnTemplate`
- Hanya `setTemplateType(null)`. State lain dibiarkan supaya user bisa revert manual jika perlu.

## Frontend — Print fix (rule global)
- `handlePrint` di create page disync dengan builder full CSS rules (KOP, `surat-content`, `untuk-entry` break-inside, `@page` margin 3cm/0.7cm).
- Wrap `Demikian + TTD + Tembusan` jadi `.penutup-ttd-group` dengan `pageBreakInside: avoid`. Rule global ini berlaku untuk SEMUA ST (bukan hanya BMN).
- CSS rule `.penutup-ttd-group` ditambahkan di builder + create print handlers.

## Frontend — Badge "Template BMN" di ST list
- **Inbox** (`/kepegawaian/surat-tugas/inbox`): badge orange di list cards (di bawah `maksud_tujuan`) dan detail panel (pill di samping status).
- **History** (`/kepegawaian/surat-tugas/history`): badge orange di table cell di samping `nomor_surat`.
- `AssignmentLetter` dan `SuratTugasItem` interface ditambah `template_type`.

## Out of Scope (sesuai konfirmasi user)
- TIDAK ada tombol "Generate ST Pemeriksaan" di /bmn/auction-candidates (modul Kepegawaian yang buat ST).
- TIDAK ada redirect dari modul BMN.

## Validation
- `php -l` pada 4 file PHP clean.
- `npx eslint --max-warnings=0` clean.
- `npx tsc --noEmit` clean.
- `npm run build` clean (59/59 static pages).
- Local migration applied (kolom `template_type` sudah ada di local DB).

## Production deploy notes
- Wajib jalankan `php artisan migrate` di backend container production setelah pull `main` agar kolom `template_type` tersedia.
