### PR TITLE
feat(bmn): add SK Tim Penilai (Panitia Penaksir Harga BMN) document with print pagination (#370)

### DIFF
--- a/frontend/src/app/bmn/auction-candidates/_components/DocumentActions.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/DocumentActions.tsx
@@ -8,6 +8,7 @@ interface DocumentActionsProps {
   onProcess: () => void;
   onProcessSk: () => void;
   onProcessSkPanitia: () => void;
+  onProcessSkTimPenilai: () => void;
   onProcessSptjLimit: () => void;
   onProcessSptjm: () => void;
   onProcessSpTugas: () => void;
@@ -20,6 +21,7 @@ export function DocumentActions({
   onProcess,
   onProcessSk,
   onProcessSkPanitia,
+  onProcessSkTimPenilai,
   onProcessSptjLimit,
   onProcessSptjm,
   onProcessSpTugas,
@@ -35,7 +37,7 @@ export function DocumentActions({
           Generate Dokumen Lelang
         </h2>
       </div>
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
         <Button
           size="sm"
           className="h-auto rounded-xl gap-2 bg-red-600 py-2.5 text-xs hover:bg-red-500"
@@ -65,12 +67,30 @@ export function DocumentActions({
         </Button>
         <Button
           size="sm"
+          className="h-auto rounded-xl gap-2 bg-emerald-600 py-2.5 text-xs hover:bg-emerald-500"
+          onClick={onProcessSkTimPenilai}
+          disabled={noSelection}
+        >
+          <FileText className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">SK Tim Penilai</span>
+        </Button>
+        <Button
+          size="sm"
           className="h-auto rounded-xl gap-2 bg-orange-600 py-2.5 text-xs hover:bg-orange-500"
           onClick={onProcessBaPemeriksaan}
           disabled={noSelection}
         >
           <FileText className="h-3.5 w-3.5 shrink-0" />
           <span className="truncate">BA Pemeriksaan</span>
+        </Button>
+        <Button
+          size="sm"
+          className="h-auto rounded-xl gap-2 bg-cyan-600 py-2.5 text-xs hover:bg-cyan-500"
+          onClick={onProcessSkKebenaran}
+          disabled={noSelection}
+        >
+          <FileText className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">SK Kebenaran</span>
         </Button>
         <Button
           size="sm"
@@ -95,15 +115,6 @@ export function DocumentActions({
         >
           <FileText className="h-3.5 w-3.5 shrink-0" />
           <span className="truncate">SP Tugas</span>
-        </Button>
-        <Button
-          size="sm"
-          className="h-auto rounded-xl gap-2 bg-cyan-600 py-2.5 text-xs hover:bg-cyan-500"
-          onClick={onProcessSkKebenaran}
-          disabled={noSelection}
-        >
-          <FileText className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">SK Kebenaran</span>
         </Button>
       </div>
       {noSelection && (

--- a/frontend/src/app/bmn/auction-candidates/_components/DocumentNumberInputs.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/DocumentNumberInputs.tsx
@@ -13,6 +13,8 @@ interface DocumentNumberInputsProps {
   setSkNumber: (value: string) => void;
   skPanitiaNumber: string;
   setSkPanitiaNumber: (value: string) => void;
+  skTimPenilaiNumber: string;
+  setSkTimPenilaiNumber: (value: string) => void;
   sptjLimitNumber: string;
   setSptjLimitNumber: (value: string) => void;
   sptjmNumber: string;
@@ -44,6 +46,8 @@ export function DocumentNumberInputs({
   setSkNumber,
   skPanitiaNumber,
   setSkPanitiaNumber,
+  skTimPenilaiNumber,
+  setSkTimPenilaiNumber,
   sptjLimitNumber,
   setSptjLimitNumber,
   sptjmNumber,
@@ -76,7 +80,7 @@ export function DocumentNumberInputs({
             Pengaturan Nomor Surat
           </span>
           <span className="rounded-md bg-zinc-100 px-1.5 py-0.5 text-[9px] font-semibold text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
-            9 dokumen
+            10 dokumen
           </span>
         </div>
         <ChevronDown
@@ -148,6 +152,25 @@ export function DocumentNumberInputs({
                   className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
                 />
                 <span className="truncate">/{skSuffix}</span>
+              </div>
+            </div>
+
+            {/* SK Tim Penilai */}
+            <div>
+              <label htmlFor="sk-tim-penilai-number" className={labelClass}>
+                SK Tim Penilai
+              </label>
+              <div className={`${inputBoxClass} mt-1`}>
+                <span className="font-semibold">SK.</span>
+                <input
+                  id="sk-tim-penilai-number"
+                  type="text"
+                  value={skTimPenilaiNumber}
+                  onChange={(e) => setSkTimPenilaiNumber(e.target.value)}
+                  placeholder="107"
+                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
+                />
+                <span className="truncate">/K.18/TU/KAP.06.01/B/{monthSuffix}</span>
               </div>
             </div>
 

--- a/frontend/src/app/bmn/auction-candidates/_components/SelectedAssetsBanner.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SelectedAssetsBanner.tsx
@@ -8,6 +8,7 @@ interface SelectedAssetsBannerProps {
   showDocument: boolean;
   showSkDocument: boolean;
   showSkPanitia: boolean;
+  showSkTimPenilai: boolean;
   showSptjLimit: boolean;
   showSptjm: boolean;
   showSpTugas: boolean;
@@ -16,6 +17,7 @@ interface SelectedAssetsBannerProps {
   onPrint: () => void;
   onPrintSk: () => void;
   onPrintSkPanitia: () => void;
+  onPrintSkTimPenilai: () => void;
   onPrintSptjLimit: () => void;
   onPrintSptjm: () => void;
   onPrintSpTugas: () => void;
@@ -33,6 +35,7 @@ export function SelectedAssetsBanner({
   showDocument,
   showSkDocument,
   showSkPanitia,
+  showSkTimPenilai,
   showSptjLimit,
   showSptjm,
   showSpTugas,
@@ -41,6 +44,7 @@ export function SelectedAssetsBanner({
   onPrint,
   onPrintSk,
   onPrintSkPanitia,
+  onPrintSkTimPenilai,
   onPrintSptjLimit,
   onPrintSptjm,
   onPrintSpTugas,
@@ -53,6 +57,7 @@ export function SelectedAssetsBanner({
   if (showDocument) printActions.push({ label: "Cetak BA Koreksi", onClick: onPrint });
   if (showSkDocument) printActions.push({ label: "Cetak SK Penghentian", onClick: onPrintSk });
   if (showSkPanitia) printActions.push({ label: "Cetak SK Panitia", onClick: onPrintSkPanitia });
+  if (showSkTimPenilai) printActions.push({ label: "Cetak SK Tim Penilai", onClick: onPrintSkTimPenilai });
   if (showSptjLimit) printActions.push({ label: "Cetak SPTJ Limit", onClick: onPrintSptjLimit });
   if (showSptjm) printActions.push({ label: "Cetak SPTJM", onClick: onPrintSptjm });
   if (showSpTugas) printActions.push({ label: "Cetak SP Tugas", onClick: onPrintSpTugas });

--- a/frontend/src/app/bmn/auction-candidates/_components/SkTimPenilaiBuilder.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkTimPenilaiBuilder.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Plus, Trash2 } from "lucide-react";
+import { api } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  formatNip,
+  newSkBuilderItem,
+  type SkBuilderItem,
+  type SkKepalaBalai,
+} from "../_lib/sk-defaults";
+import type { SkTimPenilaiMemutuskan } from "../_lib/sk-tim-penilai-defaults";
+
+interface EmployeeOption {
+  id: string | number;
+  nama_lengkap?: string;
+  name?: string;
+  nip?: string | null;
+}
+
+interface SkTimPenilaiBuilderProps {
+  menimbang: SkBuilderItem[];
+  setMenimbang: (items: SkBuilderItem[]) => void;
+  mengingat: SkBuilderItem[];
+  setMengingat: (items: SkBuilderItem[]) => void;
+  memutuskan: SkTimPenilaiMemutuskan;
+  setMemutuskan: (m: SkTimPenilaiMemutuskan) => void;
+  kepalaBalai: SkKepalaBalai;
+  setKepalaBalai: (kb: SkKepalaBalai) => void;
+  tembusan: SkBuilderItem[];
+  setTembusan: (items: SkBuilderItem[]) => void;
+}
+
+export function SkTimPenilaiBuilder({
+  menimbang,
+  setMenimbang,
+  mengingat,
+  setMengingat,
+  memutuskan,
+  setMemutuskan,
+  kepalaBalai,
+  setKepalaBalai,
+  tembusan,
+  setTembusan,
+}: SkTimPenilaiBuilderProps) {
+  const { data: employees = [], isLoading: isLoadingEmployees } = useQuery<EmployeeOption[]>({
+    queryKey: ["employees-select-sk-tim-penilai-builder"],
+    queryFn: async () => {
+      const res = await api.get("/kepegawaian/employees/select");
+      return res.data?.data || res.data || [];
+    },
+  });
+
+  const sortedEmployees = useMemo(() => {
+    const list = Array.isArray(employees) ? [...employees] : [];
+    return list.sort((a, b) => {
+      const an = (a.nama_lengkap || a.name || "").toLowerCase();
+      const bn = (b.nama_lengkap || b.name || "").toLowerCase();
+      return an.localeCompare(bn);
+    });
+  }, [employees]);
+
+  const updateMenimbang = (id: string, text: string) => {
+    setMenimbang(menimbang.map((m) => (m.id === id ? { ...m, text } : m)));
+  };
+  const addMenimbang = () => setMenimbang([...menimbang, newSkBuilderItem("")]);
+  const removeMenimbang = (id: string) => {
+    if (menimbang.length <= 1) return;
+    setMenimbang(menimbang.filter((m) => m.id !== id));
+  };
+
+  const updateMengingat = (id: string, text: string) => {
+    setMengingat(mengingat.map((m) => (m.id === id ? { ...m, text } : m)));
+  };
+  const addMengingat = () => setMengingat([...mengingat, newSkBuilderItem("")]);
+  const removeMengingat = (id: string) => {
+    if (mengingat.length <= 1) return;
+    setMengingat(mengingat.filter((m) => m.id !== id));
+  };
+
+  const updateMemutuskan = (key: keyof SkTimPenilaiMemutuskan, value: string) => {
+    setMemutuskan({ ...memutuskan, [key]: value });
+  };
+
+  const handleSelectKepalaBalai = (employeeId: string) => {
+    if (!employeeId) return;
+    const emp = sortedEmployees.find((e) => String(e.id) === employeeId);
+    if (!emp) return;
+    const fullName = (emp.nama_lengkap || emp.name || "").toUpperCase();
+    setKepalaBalai({ nama: fullName, nip: formatNip(emp.nip || "") });
+  };
+
+  const updateTembusan = (id: string, text: string) => {
+    setTembusan(tembusan.map((t) => (t.id === id ? { ...t, text } : t)));
+  };
+  const addTembusan = () => setTembusan([...tembusan, newSkBuilderItem("")]);
+  const removeTembusan = (id: string) => {
+    setTembusan(tembusan.filter((t) => t.id !== id));
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-bold text-zinc-900 dark:text-white">Menimbang</h3>
+          <Button size="xs" variant="outline" className="rounded-lg gap-1" onClick={addMenimbang}>
+            <Plus className="h-3 w-3" />
+            Tambah
+          </Button>
+        </div>
+        <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+          Item akan diberi label a, b, c, ... pada dokumen.
+        </p>
+        <div className="mt-3 space-y-3">
+          {menimbang.map((item, index) => (
+            <div key={item.id} className="rounded-xl border border-zinc-200 bg-zinc-50/60 p-2.5 dark:border-zinc-800 dark:bg-zinc-900/50">
+              <div className="mb-1.5 flex items-center justify-between">
+                <span className="text-[11px] font-bold uppercase tracking-wide text-zinc-500">
+                  Menimbang {String.fromCharCode(97 + index)}
+                </span>
+                <Button
+                  size="xs"
+                  variant="destructive"
+                  className="rounded-md gap-1"
+                  onClick={() => removeMenimbang(item.id)}
+                  disabled={menimbang.length <= 1}
+                >
+                  <Trash2 className="h-3 w-3" />
+                  Hapus
+                </Button>
+              </div>
+              <Textarea
+                value={item.text}
+                onChange={(e) => updateMenimbang(item.id, e.target.value)}
+                placeholder="Tulis isi menimbang..."
+                className="min-h-[72px] text-xs"
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-bold text-zinc-900 dark:text-white">Mengingat</h3>
+          <Button size="xs" variant="outline" className="rounded-lg gap-1" onClick={addMengingat}>
+            <Plus className="h-3 w-3" />
+            Tambah
+          </Button>
+        </div>
+        <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+          Item akan diberi nomor 1, 2, 3, ... pada dokumen.
+        </p>
+        <div className="mt-3 space-y-3">
+          {mengingat.map((item, index) => (
+            <div key={item.id} className="rounded-xl border border-zinc-200 bg-zinc-50/60 p-2.5 dark:border-zinc-800 dark:bg-zinc-900/50">
+              <div className="mb-1.5 flex items-center justify-between">
+                <span className="text-[11px] font-bold uppercase tracking-wide text-zinc-500">
+                  Mengingat {index + 1}
+                </span>
+                <Button
+                  size="xs"
+                  variant="destructive"
+                  className="rounded-md gap-1"
+                  onClick={() => removeMengingat(item.id)}
+                  disabled={mengingat.length <= 1}
+                >
+                  <Trash2 className="h-3 w-3" />
+                  Hapus
+                </Button>
+              </div>
+              <Textarea
+                value={item.text}
+                onChange={(e) => updateMengingat(item.id, e.target.value)}
+                placeholder="Tulis isi mengingat..."
+                className="min-h-[72px] text-xs"
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+        <h3 className="text-sm font-bold text-zinc-900 dark:text-white">Memutuskan</h3>
+        <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+          Bagian Menetapkan, KESATU, KEDUA, KETIGA, dan KEEMPAT dari keputusan.
+        </p>
+        <div className="mt-3 space-y-3">
+          <div>
+            <label className="text-[11px] font-bold uppercase tracking-wide text-zinc-500">Menetapkan</label>
+            <Textarea
+              value={memutuskan.menetapkan}
+              onChange={(e) => updateMemutuskan("menetapkan", e.target.value)}
+              className="mt-1 min-h-[80px] text-xs"
+            />
+          </div>
+          <div>
+            <label className="text-[11px] font-bold uppercase tracking-wide text-zinc-500">KESATU</label>
+            <Textarea
+              value={memutuskan.kesatu}
+              onChange={(e) => updateMemutuskan("kesatu", e.target.value)}
+              className="mt-1 min-h-[80px] text-xs"
+            />
+          </div>
+          <div>
+            <label className="text-[11px] font-bold uppercase tracking-wide text-zinc-500">KEDUA</label>
+            <Textarea
+              value={memutuskan.kedua}
+              onChange={(e) => updateMemutuskan("kedua", e.target.value)}
+              className="mt-1 min-h-[140px] text-xs"
+            />
+          </div>
+          <div>
+            <label className="text-[11px] font-bold uppercase tracking-wide text-zinc-500">KETIGA</label>
+            <Textarea
+              value={memutuskan.ketiga}
+              onChange={(e) => updateMemutuskan("ketiga", e.target.value)}
+              className="mt-1 min-h-[64px] text-xs"
+            />
+          </div>
+          <div>
+            <label className="text-[11px] font-bold uppercase tracking-wide text-zinc-500">KEEMPAT</label>
+            <Textarea
+              value={memutuskan.keempat}
+              onChange={(e) => updateMemutuskan("keempat", e.target.value)}
+              className="mt-1 min-h-[64px] text-xs"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+        <h3 className="text-sm font-bold text-zinc-900 dark:text-white">Kepala Balai</h3>
+        <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+          Pilih pegawai untuk mengisi nama dan NIP penandatangan.
+        </p>
+        <div className="mt-3 space-y-2">
+          <select
+            className="h-9 w-full rounded-lg border border-zinc-200 bg-white px-2 text-xs text-zinc-900 outline-none focus:ring-2 focus:ring-emerald-500/20 dark:border-zinc-700 dark:bg-zinc-950 dark:text-white"
+            onChange={(e) => handleSelectKepalaBalai(e.target.value)}
+            defaultValue=""
+            disabled={isLoadingEmployees}
+          >
+            <option value="" disabled>
+              {isLoadingEmployees ? "Memuat pegawai..." : "Pilih pegawai..."}
+            </option>
+            {sortedEmployees.map((emp) => {
+              const label = emp.nama_lengkap || emp.name || "(tanpa nama)";
+              return (
+                <option key={emp.id} value={String(emp.id)}>
+                  {label}
+                  {emp.nip ? ` — ${emp.nip}` : ""}
+                </option>
+              );
+            })}
+          </select>
+          <div className="rounded-lg bg-zinc-50 p-3 text-xs dark:bg-zinc-950/50">
+            <p className="text-[10px] font-bold uppercase tracking-wide text-zinc-400">Nama</p>
+            <p className="mt-0.5 font-semibold text-zinc-900 dark:text-zinc-100">
+              {kepalaBalai.nama || "—"}
+            </p>
+            <p className="mt-2 text-[10px] font-bold uppercase tracking-wide text-zinc-400">NIP</p>
+            <p className="mt-0.5 font-mono text-zinc-700 dark:text-zinc-300">
+              {kepalaBalai.nip ? `NIP. ${kepalaBalai.nip}` : "—"}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-bold text-zinc-900 dark:text-white">Tembusan</h3>
+          <Button size="xs" variant="outline" className="rounded-lg gap-1" onClick={addTembusan}>
+            <Plus className="h-3 w-3" />
+            Tambah
+          </Button>
+        </div>
+        <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+          Item akan diberi nomor 1, 2, 3, ... pada dokumen.
+        </p>
+        <div className="mt-3 space-y-3">
+          {tembusan.map((item, index) => (
+            <div key={item.id} className="rounded-xl border border-zinc-200 bg-zinc-50/60 p-2.5 dark:border-zinc-800 dark:bg-zinc-900/50">
+              <div className="mb-1.5 flex items-center justify-between">
+                <span className="text-[11px] font-bold uppercase tracking-wide text-zinc-500">
+                  Tembusan {index + 1}
+                </span>
+                <Button
+                  size="xs"
+                  variant="destructive"
+                  className="rounded-md gap-1"
+                  onClick={() => removeTembusan(item.id)}
+                >
+                  <Trash2 className="h-3 w-3" />
+                  Hapus
+                </Button>
+              </div>
+              <Textarea
+                value={item.text}
+                onChange={(e) => updateTembusan(item.id, e.target.value)}
+                placeholder="Tulis isi tembusan..."
+                className="min-h-[48px] text-xs"
+              />
+            </div>
+          ))}
+          {tembusan.length === 0 && (
+            <p className="rounded-lg border border-dashed border-zinc-300 p-3 text-center text-xs text-zinc-400">
+              Belum ada tembusan. Klik Tambah untuk menambahkan.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/bmn/auction-candidates/_components/SkTimPenilaiDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkTimPenilaiDocument.tsx
@@ -1,0 +1,846 @@
+"use client";
+
+import { toast } from "sonner";
+import { formatDateLong } from "../_lib/auction-helpers";
+import type { SkBuilderItem, SkKepalaBalai } from "../_lib/sk-defaults";
+import type {
+  SkTimPenilaiMemutuskan,
+  TimPenilaiAnggota,
+} from "../_lib/sk-tim-penilai-defaults";
+
+interface SkTimPenilaiDocumentProps {
+  skNumber: string;
+  menimbang: SkBuilderItem[];
+  mengingat: SkBuilderItem[];
+  memutuskan: SkTimPenilaiMemutuskan;
+  kepalaBalai: SkKepalaBalai;
+  tembusan: SkBuilderItem[];
+  susunanTimPenilai: TimPenilaiAnggota[];
+}
+
+// SK Tim Penilai uses a custom KAP suffix (KAP.06.01/B) — different from getSkNumberSuffix() which is KAP.05.
+function getTimPenilaiNumberSuffix(date = new Date()) {
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  return `K.18/TU/KAP.06.01/B/${month}/${date.getFullYear()}`;
+}
+
+function renderKeduaText(text: string) {
+  return text
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line, index) => {
+      const trimmedLine = line.trim();
+      const subItemMatch = trimmedLine.match(/^([a-z]\.)\s+(.*)$/i);
+      const numberedItemMatch = trimmedLine.match(/^(\d+\.)\s+(.*)$/);
+
+      if (subItemMatch) {
+        return (
+          <div className="sktp-kedua-item sktp-kedua-subitem" key={`${trimmedLine}-${index}`}>
+            <span className="sktp-kedua-marker">{subItemMatch[1]}</span>
+            <span className="sktp-kedua-item-text">{subItemMatch[2]}</span>
+          </div>
+        );
+      }
+
+      if (numberedItemMatch) {
+        return (
+          <div className="sktp-kedua-item" key={`${trimmedLine}-${index}`}>
+            <span className="sktp-kedua-marker">{numberedItemMatch[1]}</span>
+            <span className="sktp-kedua-item-text">{numberedItemMatch[2]}</span>
+          </div>
+        );
+      }
+
+      return (
+        <div className="sktp-kedua-line" key={`${trimmedLine}-${index}`}>
+          {trimmedLine}
+        </div>
+      );
+    });
+}
+
+export function handlePrintSkTimPenilai() {
+  const printContent = document.getElementById("sk-tim-penilai-print-root");
+  if (!printContent) {
+    toast.error("Tidak ada dokumen SK Tim Penilai untuk dicetak.");
+    return;
+  }
+  const printWindow = window.open("", "_blank");
+  if (!printWindow) return;
+
+  printWindow.document.write(`
+    <html>
+      <head>
+        <title>SK Tim Penilai BMN</title>
+        <style>
+          @page { size: A4; margin: 0; }
+          @page sktp-main { size: A4; margin: 0; }
+          @page sktp-main:first { size: A4; margin: 0; }
+          * { box-sizing: border-box; }
+          body {
+            margin: 0; padding: 0; background: white; color: black;
+            font-family: 'Bookman Old Style', Georgia, serif;
+            font-size: 11pt; line-height: 1.25;
+          }
+          p { margin: 0; padding: 0; }
+          .sktp-page {
+            width: 210mm;
+            margin: 0 auto; padding: 5mm 20mm 0;
+          }
+          .sktp-main-document { page: sktp-main; position: relative; }
+          .sktp-print-root .sktp-page.sktp-main-document.sktp-main-paginated {
+            height: 297mm !important;
+            min-height: 297mm !important;
+            padding: 5mm 20mm 28mm !important;
+            overflow: hidden !important;
+            position: relative !important;
+            box-shadow: none !important;
+          }
+          .sktp-print-root .sktp-page.sktp-main-document.sktp-main-paginated.sktp-main-continuation-page {
+            padding-top: 18mm !important;
+          }
+          .sktp-print-root .sktp-main-document.sktp-main-page-break {
+            page-break-after: always;
+            break-after: page;
+          }
+          .sktp-main-flow { width: 100%; }
+          .sktp-main-paginated .sktp-paginated-field-section + .sktp-paginated-field-section { margin-top: 0 !important; }
+          .sktp-main-paginated .sktp-paginated-field-section.sktp-section-start { margin-top: 0.5rem !important; }
+          .sktp-page-ttd { padding-bottom: 0; }
+          article { margin: 0; }
+          .sktp-page-break { page-break-after: always; break-after: always; }
+          .sktp-kop {
+            margin-top: -5mm; margin-left: -16mm; margin-right: -16mm;
+            margin-bottom: 6px; text-align: center;
+          }
+          .sktp-kop img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
+          .sktp-title {
+            width: 166mm; margin-left: auto; margin-right: auto;
+            margin-top: 10px; text-align: center; font-weight: bold; line-height: 1.3;
+          }
+          .sktp-title-nomor { font-weight: normal; }
+          .sktp-title-tentang { margin-top: 10px; }
+          .sktp-subtitle {
+            width: 166mm; margin-left: auto; margin-right: auto;
+            margin-top: 16px;
+          }
+          .sktp-subtitle > p { text-align: center; font-weight: bold; }
+          .sktp-subtitle > p + p { margin-top: 6px; }
+          .sktp-body { width: 166mm; margin-left: auto; margin-right: auto; }
+          table { border-collapse: collapse; width: 100%; }
+          td { vertical-align: top; padding: 0; }
+          .sktp-field-section {
+            display: grid;
+            grid-template-columns: 28mm 8mm minmax(0, 1fr);
+            break-inside: auto !important;
+            page-break-inside: auto !important;
+          }
+          .sktp-field-section + .sktp-field-section { margin-top: 0.5rem; }
+          .sktp-field-label, .sktp-field-colon { padding: 0; }
+          .sktp-field-colon { text-align: center; }
+          .sktp-mengingat-list {
+            break-inside: auto !important;
+            page-break-inside: auto !important;
+          }
+          .sktp-mengingat-item {
+            display: grid;
+            grid-template-columns: 9mm minmax(0, 1fr);
+            break-inside: avoid !important;
+            page-break-inside: avoid !important;
+            padding-top: 0;
+          }
+          .sktp-mengingat-item:first-child { padding-top: 0; }
+          .sktp-mengingat-text { text-align: justify; }
+          .sktp-memutuskan { text-align: center; font-weight: bold; margin-bottom: 8px; }
+          .sktp-ttd { width: 20rem; margin-left: auto; margin-top: 1.25rem; }
+          .sktp-ttd, .sktp-ttd p { font-weight: normal !important; text-align: left !important; }
+          .sktp-ttd p { margin: 0; padding: 0; line-height: 1.25; }
+          .sktp-ttd-meta { display: grid !important; grid-template-columns: max-content auto 1fr; column-gap: 0.4rem; line-height: 1.3; }
+          .sktp-ttd-meta span { font-weight: normal !important; text-align: left !important; }
+          .sktp-keempat-group { break-inside: avoid !important; page-break-inside: avoid !important; }
+          .sktp-signature-name { font-weight: normal !important; }
+          .sktp-ttd-placeholder { height: 86px; padding-top: 28px; padding-left: 1.35cm; color: #94a3b8; font-weight: normal !important; text-align: left !important; margin-top: 0.75rem; margin-bottom: 0.75rem; }
+          .sktp-continuation-word { position: absolute; right: 23mm; bottom: 31mm; width: 163mm; height: 0; line-height: 11pt; overflow: visible; white-space: nowrap; text-align: right !important; margin: 0; padding: 0; font-weight: normal !important; font-size: 11pt; z-index: 20; }
+          .sktp-tembusan { margin-top: 1rem; }
+          .sktp-tembusan, .sktp-tembusan p { font-weight: normal !important; text-align: left !important; }
+          .sktp-tembusan p { margin: 0; padding: 0; line-height: 1.3; }
+          .sktp-kedua-text { display: grid; row-gap: 0; white-space: normal; }
+          .sktp-kedua-line { text-align: justify; }
+          .sktp-kedua-item { display: grid; grid-template-columns: 7mm minmax(0, 1fr); column-gap: 0; text-align: left; }
+          .sktp-kedua-subitem { margin-left: 8mm; }
+          .sktp-kedua-marker { text-align: left; }
+          .sktp-kedua-item-text { text-align: justify; }
+          .sktp-lampiran {
+            width: 210mm;
+            margin: 0 auto;
+            padding: 12mm 20mm 28mm;
+            page-break-before: always;
+            break-before: page;
+          }
+          .sktp-attachment-meta { width: 109mm; margin-left: auto; text-align: left; }
+          .sktp-attachment-meta .meta-row { display: grid; grid-template-columns: 24mm 5mm minmax(0, 1fr); align-items: start; }
+          .sktp-attachment-meta .meta-label { white-space: nowrap; }
+          .sktp-attachment-meta .meta-colon { text-align: center; }
+          .sktp-lampiran-title { text-align: center; font-weight: bold; line-height: 1.3; margin-top: 1.5rem; margin-bottom: 0.75rem; }
+          .sktp-tabel { width: 100%; border-collapse: collapse; font-size: 10pt; }
+          .sktp-tabel th, .sktp-tabel td { border: 1px solid #000; padding: 0.5rem; }
+          .sktp-tabel td { vertical-align: middle; }
+        </style>
+      </head>
+      <body>${printContent.innerHTML}</body>
+    </html>
+  `);
+  printWindow.document.close();
+  printWindow.focus();
+
+  // JS pagination: split main page into explicit A4 pages,
+  // inject continuation words at page breaks, with bottom safe area for BSrE
+  // and top safe area on continuation pages.
+  setTimeout(() => {
+    try {
+      const doc = printWindow.document;
+      const body = doc.body;
+      if (!body) {
+        printWindow.print();
+        return;
+      }
+
+      const paginationStyle = doc.createElement("style");
+      paginationStyle.textContent = `
+        @page sktp-main { size: A4; margin: 0; }
+        @page sktp-main:first { size: A4; margin: 0; }
+        .sktp-print-root .sktp-page.sktp-main-document.sktp-main-paginated {
+          height: 297mm !important;
+          min-height: 297mm !important;
+          padding: 5mm 20mm 28mm !important;
+          overflow: hidden !important;
+          position: relative !important;
+          box-shadow: none !important;
+        }
+        .sktp-print-root .sktp-page.sktp-main-document.sktp-main-paginated.sktp-main-continuation-page {
+          padding-top: 18mm !important;
+        }
+        .sktp-print-root .sktp-main-document.sktp-main-page-break {
+          page-break-after: always;
+          break-after: page;
+        }
+        .sktp-main-paginated .sktp-paginated-field-section + .sktp-paginated-field-section {
+          margin-top: 0 !important;
+        }
+        .sktp-main-paginated .sktp-paginated-field-section.sktp-section-start {
+          margin-top: 0.5rem !important;
+        }
+        .sktp-continuation-word {
+          position: absolute !important;
+          right: 23mm !important;
+          bottom: 31mm !important;
+          width: 163mm !important;
+          height: 0 !important;
+          line-height: 11pt !important;
+          overflow: visible !important;
+          white-space: nowrap !important;
+          text-align: right !important;
+          margin: 0 !important;
+          padding: 0 !important;
+          font-weight: normal !important;
+          font-size: 11pt !important;
+          z-index: 20 !important;
+        }
+      `;
+      body.appendChild(paginationStyle);
+
+      void body.offsetHeight;
+
+      const mmToPx = 96 / 25.4;
+      const firstPageContentH = 264 * mmToPx;
+      const continuationContentH = 251 * mmToPx;
+      const markerReserveH = 9 * mmToPx;
+
+      const mainDoc = doc.querySelector(".sktp-main-document");
+      if (!mainDoc) {
+        printWindow.print();
+        return;
+      }
+
+      const root = mainDoc.parentElement;
+      if (!root) {
+        printWindow.print();
+        return;
+      }
+
+      const continuationLabel = (num: string, text: string) => {
+        const firstWord = text.trim().split(/\s+/)[0] || "";
+        return `${num.trim()} ${firstWord ? `${firstWord}.....` : "....."}`;
+      };
+
+      const cloneElement = <T extends HTMLElement>(el: T) => el.cloneNode(true) as T;
+
+      const createFieldBlock = (
+        sectionLabel: string,
+        item: HTMLElement,
+        showSectionLabel: boolean,
+        marginTop = false,
+      ) => {
+        const section = doc.createElement("div");
+        section.className = "sktp-field-section sktp-paginated-field-section";
+        section.style.marginTop = marginTop ? "0.75rem" : "0";
+        if (marginTop) section.classList.add("sktp-section-start");
+
+        const label = doc.createElement("div");
+        label.className = "sktp-field-label";
+        label.textContent = showSectionLabel ? sectionLabel : "";
+
+        const colon = doc.createElement("div");
+        colon.className = "sktp-field-colon";
+        colon.textContent = showSectionLabel ? ":" : "";
+
+        const list = doc.createElement("div");
+        list.className = "sktp-mengingat-list";
+        const itemClone = cloneElement(item);
+        itemClone.style.paddingTop = "0";
+        list.appendChild(itemClone);
+
+        section.append(label, colon, list);
+        return section;
+      };
+
+      const createDecisionBlock = (rows: HTMLElement[]) => {
+        const table = doc.createElement("table");
+        table.className = "sktp-mengingat-table";
+        table.style.borderCollapse = "collapse";
+
+        const tbody = doc.createElement("tbody");
+        rows.forEach((row) => tbody.appendChild(cloneElement(row)));
+        table.appendChild(tbody);
+        return table;
+      };
+
+      const createMemutuskanMenetapkanBlock = (heading: HTMLElement, row: HTMLElement) => {
+        const block = doc.createElement("div");
+        block.appendChild(cloneElement(heading));
+        block.appendChild(createDecisionBlock([row]));
+        return block;
+      };
+
+      const makePage = (isFirstPage: boolean) => {
+        const page = doc.createElement("article");
+        page.className = "sktp-page sktp-page-ttd sktp-main-document sktp-main-paginated mx-auto max-w-[210mm] bg-white px-24 py-9 text-black";
+        if (!isFirstPage) page.classList.add("sktp-main-continuation-page");
+        page.style.cssText = [
+          "width: 210mm",
+          "height: 297mm",
+          "min-height: 297mm",
+          "margin: 0 auto",
+          `padding: ${isFirstPage ? "5mm" : "18mm"} 20mm 28mm`,
+          "overflow: hidden",
+          "position: relative",
+          "box-sizing: border-box",
+          "background: white",
+          "color: black",
+        ].join("; ");
+
+        const flow = doc.createElement("div");
+        flow.className = "sktp-main-flow";
+        page.appendChild(flow);
+
+        const bodyWrap = doc.createElement("div");
+        bodyWrap.className = "sktp-body";
+        flow.appendChild(bodyWrap);
+
+        return { page, flow, bodyWrap };
+      };
+
+      const addContinuationWord = (page: HTMLElement, label: string) => {
+        const contWord = doc.createElement("p");
+        contWord.className = "sktp-continuation-word";
+        contWord.textContent = label;
+        page.appendChild(contWord);
+      };
+
+      const measureFlowContentHeight = (flow: HTMLElement) => {
+        const flowTop = flow.getBoundingClientRect().top;
+        return Array.from(flow.children).reduce((maxBottom, child) => {
+          const rect = (child as HTMLElement).getBoundingClientRect();
+          return Math.max(maxBottom, rect.bottom - flowTop);
+        }, 0);
+      };
+
+      const measureOuterHeight = (el: HTMLElement) => {
+        const rect = el.getBoundingClientRect();
+        const style = printWindow.getComputedStyle(el);
+        const marginTop = Number.parseFloat(style.marginTop || "0") || 0;
+        const marginBottom = Number.parseFloat(style.marginBottom || "0") || 0;
+        return rect.height + marginTop + marginBottom;
+      };
+
+      const contentWrap = mainDoc.querySelector<HTMLElement>(".sktp-subtitle");
+      const contentSections = contentWrap?.querySelector<HTMLElement>("div");
+      const fieldSections = contentSections?.querySelectorAll<HTMLElement>(":scope > .sktp-field-section");
+      const menimbangItems = fieldSections?.[0]?.querySelectorAll<HTMLElement>(".sktp-mengingat-item") || [];
+      const mengingatItems = fieldSections?.[1]?.querySelectorAll<HTMLElement>(".sktp-mengingat-item") || [];
+
+      const explicitMemutuskanHeading = mainDoc.querySelector<HTMLElement>(".sktp-memutuskan");
+      const explicitMemRows = Array.from(mainDoc.querySelectorAll<HTMLElement>(".sktp-mengingat-row"));
+      const keempatGroup = mainDoc.querySelector<HTMLElement>(".sktp-keempat-group");
+
+      let currentPage = makePage(true);
+      root.insertBefore(currentPage.page, mainDoc);
+
+      const kop = mainDoc.querySelector<HTMLElement>(".sktp-kop");
+      const title = mainDoc.querySelector<HTMLElement>(".sktp-title");
+      const intro = doc.createElement("div");
+      intro.className = "sktp-subtitle sktp-body";
+      const introParagraphs = Array.from(contentWrap?.children || []).filter((child) => {
+        return child.tagName === "P" && !(child as HTMLElement).classList.contains("sktp-memutuskan");
+      });
+      introParagraphs.forEach((child) => intro.appendChild(cloneElement(child as HTMLElement)));
+
+      const firstBody = currentPage.bodyWrap;
+      currentPage.flow.insertBefore(intro, firstBody);
+      if (title) currentPage.flow.insertBefore(cloneElement(title), intro);
+      if (kop) currentPage.flow.insertBefore(cloneElement(kop), currentPage.flow.firstChild);
+      let currentUsedHeight = measureFlowContentHeight(currentPage.flow);
+
+      const blocks: { el: HTMLElement; label: string }[] = [];
+
+      // Menimbang items
+      Array.from(menimbangItems).forEach((item, index) => {
+        const num = item.querySelector("div:first-child")?.textContent || "";
+        const text = item.querySelector(".sktp-mengingat-text")?.textContent || "";
+        blocks.push({
+          el: createFieldBlock("Menimbang", item, index === 0),
+          label: continuationLabel(num || (index === 0 ? "" : ""), text),
+        });
+      });
+
+      // Mengingat items
+      Array.from(mengingatItems).forEach((item, index) => {
+        const num = item.querySelector("div:first-child")?.textContent || "";
+        const text = item.querySelector(".sktp-mengingat-text")?.textContent || "";
+        blocks.push({
+          el: createFieldBlock("Mengingat", item, index === 0, index === 0),
+          label: continuationLabel(num, text),
+        });
+      });
+
+      // Memutuskan + Menetapkan + KESATU + KEDUA + KETIGA + KEEMPAT
+      if (explicitMemutuskanHeading && explicitMemRows[0]) {
+        blocks.push({
+          el: createMemutuskanMenetapkanBlock(explicitMemutuskanHeading, explicitMemRows[0]),
+          label: "MEMUTUSKAN.....",
+        });
+      } else if (explicitMemutuskanHeading) {
+        blocks.push({ el: cloneElement(explicitMemutuskanHeading), label: "MEMUTUSKAN....." });
+      } else if (explicitMemRows[0]) {
+        blocks.push({ el: createDecisionBlock([explicitMemRows[0]]), label: "Menetapkan....." });
+      }
+      if (explicitMemRows[1]) {
+        blocks.push({ el: createDecisionBlock([explicitMemRows[1]]), label: "KESATU....." });
+      }
+      if (explicitMemRows[2]) {
+        blocks.push({ el: createDecisionBlock([explicitMemRows[2]]), label: "KEDUA....." });
+      }
+      if (explicitMemRows[3]) {
+        blocks.push({ el: createDecisionBlock([explicitMemRows[3]]), label: "KETIGA....." });
+      }
+      if (keempatGroup) {
+        blocks.push({ el: cloneElement(keempatGroup), label: "KEEMPAT....." });
+      }
+
+      blocks.forEach((block, index) => {
+        const isLastBlock = index === blocks.length - 1;
+        const contentLimit = currentPage.page.classList.contains("sktp-main-continuation-page")
+          ? continuationContentH
+          : firstPageContentH;
+        const maxFlowHeight = contentLimit - (isLastBlock ? 0 : markerReserveH);
+        const markerSafeHeight = contentLimit - markerReserveH;
+
+        currentPage.bodyWrap.appendChild(block.el);
+        const blockHeight = measureOuterHeight(block.el);
+        const flowHeight = currentUsedHeight + blockHeight;
+        const canMoveToNextPage = currentPage.bodyWrap.children.length > 1;
+        if ((flowHeight > maxFlowHeight || (!isLastBlock && flowHeight > markerSafeHeight)) && canMoveToNextPage) {
+          currentPage.bodyWrap.removeChild(block.el);
+          currentPage.page.classList.add("sktp-main-page-break");
+          addContinuationWord(currentPage.page, block.label);
+
+          currentPage = makePage(false);
+          root.insertBefore(currentPage.page, mainDoc);
+          currentPage.bodyWrap.appendChild(block.el);
+          currentUsedHeight = measureOuterHeight(block.el);
+        } else {
+          currentUsedHeight = flowHeight;
+        }
+      });
+
+      root.removeChild(mainDoc);
+    } catch {
+      // Silently fail — print without continuation words
+    }
+    setTimeout(() => printWindow.print(), 300);
+  }, 600);
+}
+
+export function SkTimPenilaiDocument({
+  skNumber,
+  menimbang,
+  mengingat,
+  memutuskan,
+  kepalaBalai,
+  tembusan,
+  susunanTimPenilai,
+}: SkTimPenilaiDocumentProps) {
+  const today = new Date();
+  const skNumberText = `SK.${skNumber.trim() || "____"}/${getTimPenilaiNumberSuffix(today)}`;
+  const mengingatTexts = mengingat.map((m) => m.text);
+
+  const pageStyle: React.CSSProperties = {
+    fontFamily: "'Bookman Old Style', Georgia, serif",
+    fontSize: "11pt",
+    lineHeight: "1.25",
+  };
+
+  return (
+    <div id="sk-tim-penilai-print-root" className="sktp-print-root">
+      <style jsx global>{`
+        .sktp-print-root .sktp-page {
+          width: 210mm;
+          margin-left: auto;
+          margin-right: auto;
+          box-sizing: border-box;
+        }
+        .sktp-print-root .sktp-main-document {
+          padding: 5mm 20mm 0 !important;
+        }
+        .sktp-print-root .sktp-kop {
+          margin-top: -5mm;
+          margin-left: -16mm;
+          margin-right: -16mm;
+          margin-bottom: 4px;
+          text-align: center;
+        }
+        .sktp-print-root .sktp-kop img {
+          width: 196mm !important;
+          max-width: 196mm !important;
+          height: auto !important;
+          display: block;
+          margin: 0 auto;
+        }
+        .sktp-print-root .sktp-title,
+        .sktp-print-root .sktp-subtitle,
+        .sktp-print-root .sktp-body {
+          width: 166mm;
+          margin-left: auto;
+          margin-right: auto;
+        }
+        .sktp-print-root .sktp-title {
+          margin-top: 10px;
+          text-align: center;
+          font-weight: bold;
+          line-height: 1.3;
+        }
+        .sktp-print-root .sktp-title-nomor { font-weight: normal; }
+        .sktp-print-root .sktp-title-tentang { margin-top: 10px; }
+        .sktp-print-root .sktp-subtitle { margin-top: 16px; }
+        .sktp-print-root .sktp-subtitle > p { text-align: center; font-weight: bold; }
+        .sktp-print-root .sktp-subtitle > p + p { margin-top: 6px; }
+        .sktp-print-root p { margin: 0; padding: 0; }
+        .sktp-print-root table { border-collapse: collapse; width: 100%; }
+        .sktp-print-root td { vertical-align: top; padding: 0; }
+        .sktp-print-root .sktp-field-section {
+          display: grid;
+          grid-template-columns: 28mm 8mm minmax(0, 1fr);
+          break-inside: auto;
+          page-break-inside: auto;
+        }
+        .sktp-print-root .sktp-field-section + .sktp-field-section { margin-top: 0.5rem; }
+        .sktp-print-root .sktp-field-colon { text-align: center; }
+        .sktp-print-root .sktp-mengingat-list { break-inside: auto; page-break-inside: auto; }
+        .sktp-print-root .sktp-mengingat-item {
+          display: grid;
+          grid-template-columns: 9mm minmax(0, 1fr);
+          break-inside: avoid;
+          page-break-inside: avoid;
+          padding-top: 0;
+        }
+        .sktp-print-root .sktp-mengingat-item:first-child { padding-top: 0; }
+        .sktp-print-root .sktp-mengingat-text { text-align: justify; }
+        .sktp-print-root .sktp-memutuskan {
+          text-align: center;
+          font-weight: bold;
+          margin-bottom: 8px;
+        }
+        .sktp-print-root .sktp-ttd {
+          width: 20rem;
+          margin-left: auto;
+          margin-top: 1.25rem;
+        }
+        .sktp-print-root .sktp-ttd,
+        .sktp-print-root .sktp-ttd p,
+        .sktp-print-root .sktp-tembusan,
+        .sktp-print-root .sktp-tembusan p {
+          font-weight: normal !important;
+          text-align: left !important;
+        }
+        .sktp-print-root .sktp-ttd p,
+        .sktp-print-root .sktp-tembusan p {
+          margin: 0;
+          padding: 0;
+        }
+        .sktp-print-root .sktp-keempat-group { break-inside: avoid !important; page-break-inside: avoid !important; }
+        .sktp-print-root .sktp-signature-name { font-weight: normal !important; }
+        .sktp-print-root .sktp-ttd-placeholder {
+          box-sizing: border-box;
+          height: 86px;
+          padding-top: 28px;
+          padding-left: 1.35cm;
+          color: #94a3b8;
+          font-weight: normal !important;
+          text-align: left !important;
+          margin-top: 0.75rem;
+          margin-bottom: 0.75rem;
+        }
+        .sktp-print-root .sktp-tembusan { margin-top: 1rem; }
+        .sktp-print-root .sktp-tembusan p { line-height: 1.3; }
+        .sktp-print-root .sktp-kedua-text { display: grid; row-gap: 0; white-space: normal; }
+        .sktp-print-root .sktp-kedua-line { text-align: justify; }
+        .sktp-print-root .sktp-kedua-item {
+          display: grid;
+          grid-template-columns: 7mm minmax(0, 1fr);
+          column-gap: 0;
+          text-align: left;
+        }
+        .sktp-print-root .sktp-kedua-subitem { margin-left: 8mm; }
+        .sktp-print-root .sktp-kedua-marker { text-align: left; }
+        .sktp-print-root .sktp-kedua-item-text { text-align: justify; }
+        .sktp-print-root .sktp-lampiran { page-break-before: always; break-before: page; }
+        .sktp-print-root .sktp-attachment-meta { width: 109mm; margin-left: auto; text-align: left; }
+        .sktp-print-root .sktp-attachment-meta .meta-row {
+          display: grid;
+          grid-template-columns: 24mm 5mm minmax(0, 1fr);
+          align-items: start;
+        }
+        .sktp-print-root .sktp-attachment-meta .meta-label { white-space: nowrap; }
+        .sktp-print-root .sktp-attachment-meta .meta-colon { text-align: center; }
+        .sktp-print-root .sktp-lampiran-title {
+          text-align: center;
+          font-weight: bold;
+          line-height: 1.3;
+          margin-top: 1.5rem;
+          margin-bottom: 0.75rem;
+        }
+        .sktp-print-root .sktp-tabel { width: 100%; border-collapse: collapse; font-size: 10pt; }
+        .sktp-print-root .sktp-tabel th, .sktp-print-root .sktp-tabel td { border: 1px solid #000; padding: 0.5rem; }
+        .sktp-print-root .sktp-tabel td { vertical-align: middle; }
+      `}</style>
+
+      {/* === HALAMAN UTAMA === */}
+      <article
+        className="sktp-page sktp-page-ttd sktp-main-document mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        style={pageStyle}
+      >
+        <div className="sktp-kop" style={{ marginTop: "-5mm", marginLeft: "-16mm", marginRight: "-16mm", marginBottom: "4px", textAlign: "center" }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
+        </div>
+
+        <div className="sktp-title mx-auto mt-3 w-[166mm] text-center font-bold leading-snug">
+          <p className="m-0">KEPUTUSAN KEPALA BALAI</p>
+          <p className="m-0">KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR</p>
+          <p className="sktp-title-nomor m-0 font-normal">Nomor : {skNumberText}</p>
+          <p className="sktp-title-tentang m-0 mt-2">TENTANG</p>
+          <p className="m-0">PEMBENTUKAN PANITIA PENAKSIR HARGA BARANG MILIK NEGARA</p>
+          <p className="m-0">PADA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR</p>
+        </div>
+
+        <div className="sktp-subtitle sktp-body mx-auto mt-3 w-[166mm]">
+          <p className="text-center font-bold">DENGAN RAHMAT TUHAN YANG MAHA ESA</p>
+          <p className="mt-2 text-center font-bold">
+            KEPALA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR,
+          </p>
+
+          {/* Menimbang + Mengingat */}
+          <div className="mt-2">
+            <div className="sktp-field-section">
+              <div className="sktp-field-label">Menimbang</div>
+              <div className="sktp-field-colon">:</div>
+              <div className="sktp-mengingat-list">
+                {menimbang.length === 1 ? (
+                  <div className="sktp-mengingat-item">
+                    <div></div>
+                    <div className="sktp-mengingat-text">{menimbang[0].text}</div>
+                  </div>
+                ) : (
+                  menimbang.map((item, i) => (
+                    <div
+                      className="sktp-mengingat-item"
+                      key={item.id}
+                      style={i === 0 ? undefined : { paddingTop: "0.15rem" }}
+                    >
+                      <div>{String.fromCharCode(97 + i)}.</div>
+                      <div className="sktp-mengingat-text">{item.text}</div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+
+            <div className="sktp-field-section">
+              <div className="sktp-field-label">Mengingat</div>
+              <div className="sktp-field-colon">:</div>
+              <div className="sktp-mengingat-list">
+                {mengingatTexts.map((item, i) => (
+                  <div className="sktp-mengingat-item" key={i}>
+                    <div>{i + 1}.</div>
+                    <div className="sktp-mengingat-text">{item}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* MEMUTUSKAN */}
+          <p className="sktp-memutuskan text-center font-bold" style={{ marginTop: "0.75rem" }}>MEMUTUSKAN</p>
+
+          <table className="sktp-mengingat-table mt-4 w-full" style={{ borderCollapse: "collapse" }}>
+            <tbody>
+              <tr className="sktp-mengingat-row">
+                <td style={{ width: "28mm", verticalAlign: "top" }}>Menetapkan</td>
+                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top" }}>:</td>
+                <td style={{ verticalAlign: "top", textTransform: "uppercase", textAlign: "justify" }}>
+                  {memutuskan.menetapkan}
+                </td>
+              </tr>
+              <tr className="sktp-mengingat-row">
+                <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.4rem" }}>KESATU</td>
+                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.4rem" }}>:</td>
+                <td style={{ verticalAlign: "top", paddingTop: "0.4rem", textAlign: "justify" }}>
+                  {memutuskan.kesatu}
+                </td>
+              </tr>
+              <tr className="sktp-mengingat-row">
+                <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.4rem" }}>KEDUA</td>
+                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.4rem" }}>:</td>
+                <td style={{ verticalAlign: "top", paddingTop: "0.4rem", textAlign: "justify" }}>
+                  <div className="sktp-kedua-text">{renderKeduaText(memutuskan.kedua)}</div>
+                </td>
+              </tr>
+              <tr className="sktp-mengingat-row">
+                <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.4rem" }}>KETIGA</td>
+                <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.4rem" }}>:</td>
+                <td style={{ verticalAlign: "top", paddingTop: "0.4rem", textAlign: "justify" }}>
+                  {memutuskan.ketiga}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          {/* KEEMPAT + TTD + Tembusan grouped */}
+          <div className="sktp-keempat-group">
+            <table className="sktp-mengingat-table mt-0 w-full" style={{ borderCollapse: "collapse" }}>
+              <tbody>
+                <tr className="sktp-mengingat-row">
+                  <td style={{ width: "28mm", verticalAlign: "top", paddingTop: "0.4rem" }}>KEEMPAT</td>
+                  <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top", paddingTop: "0.4rem" }}>:</td>
+                  <td style={{ verticalAlign: "top", paddingTop: "0.4rem", textAlign: "justify" }}>
+                    {memutuskan.keempat}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            {/* TTD */}
+            <div className="sktp-ttd signature mt-4 ml-auto w-80">
+              <div className="sktp-ttd-meta" style={{ display: "grid", gridTemplateColumns: "max-content auto 1fr", columnGap: "0.4rem" }}>
+                <span>Ditetapkan di</span>
+                <span>:</span>
+                <span>Samarinda</span>
+                <span>Pada tanggal</span>
+                <span>:</span>
+                <span>{formatDateLong(today)}</span>
+              </div>
+              <p className="m-0 mt-3">Kepala Balai,</p>
+              <div className="sktp-ttd-placeholder mt-3 h-20 box-border pt-7 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+              <p className="sktp-signature-name m-0 mt-4">{kepalaBalai.nama}</p>
+              <p className="m-0">NIP. {kepalaBalai.nip}</p>
+            </div>
+
+            {/* Tembusan */}
+            {tembusan.length > 0 && (
+              <div className="sktp-tembusan mt-4">
+                <p className="m-0">Tembusan</p>
+                {tembusan.length === 1 ? (
+                  <p className="m-0">{tembusan[0].text}</p>
+                ) : (
+                  tembusan.map((item, i) => (
+                    <p key={item.id} className="m-0">{i + 1}.&nbsp; {item.text}</p>
+                  ))
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </article>
+
+      {/* === HALAMAN LAMPIRAN === */}
+      <article
+        className="sktp-page sktp-lampiran mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        style={pageStyle}
+      >
+        <div className="sktp-body mx-auto w-[166mm]">
+          {/* Meta header */}
+          <div className="sktp-attachment-meta ml-auto w-[109mm]">
+            <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
+              <span>Lampiran</span><span>:</span><span>Surat Keputusan Kepala Balai KSDA Kalimantan Timur</span>
+            </div>
+            <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
+              <span>Nomor</span><span>:</span><span>{skNumberText}</span>
+            </div>
+            <div className="meta-row grid grid-cols-[24mm_5mm_minmax(0,1fr)]">
+              <span>Tanggal</span><span>:</span><span>{formatDateLong(today)}</span>
+            </div>
+          </div>
+
+          {/* Title */}
+          <p className="sktp-lampiran-title mt-6 text-center font-bold leading-snug">
+            SUSUNAN PANITIA PENAKSIR HARGA BARANG MILIK NEGARA<br />
+            PADA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR
+          </p>
+
+          {/* Susunan Tabel — 4 kolom */}
+          <table className="sktp-tabel" style={{ width: "100%", borderCollapse: "collapse", marginTop: "2rem", fontSize: "10pt" }}>
+            <thead>
+              <tr>
+                <th style={{ border: "1px solid black", padding: "0.5rem", width: "10mm", textAlign: "center" }}>No.</th>
+                <th style={{ border: "1px solid black", padding: "0.5rem", textAlign: "center" }}>Nama/NIP</th>
+                <th style={{ border: "1px solid black", padding: "0.5rem", textAlign: "center" }}>Jabatan dalam Kegiatan</th>
+                <th style={{ border: "1px solid black", padding: "0.5rem", textAlign: "center", width: "30mm" }}>Keterangan</th>
+              </tr>
+            </thead>
+            <tbody>
+              {susunanTimPenilai.map((item, index) => (
+                <tr key={item.id}>
+                  <td style={{ border: "1px solid black", padding: "0.5rem", textAlign: "center", verticalAlign: "middle" }}>{index + 1}.</td>
+                  <td style={{ border: "1px solid black", padding: "0.5rem", verticalAlign: "middle" }}>
+                    {item.nama}<br/>
+                    NIP. {item.nip}
+                  </td>
+                  <td style={{ border: "1px solid black", padding: "0.5rem", textAlign: "center", verticalAlign: "middle" }}>{item.jabatanKegiatan}</td>
+                  <td style={{ border: "1px solid black", padding: "0.5rem", textAlign: "center", verticalAlign: "middle" }}>{item.keterangan}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {/* TTD */}
+          <div className="sktp-ttd signature mt-16 ml-auto w-80">
+            <p className="m-0">Kepala Balai,</p>
+            <div className="sktp-ttd-placeholder mt-4 h-24 box-border pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+            <p className="sktp-signature-name m-0 mt-4">{kepalaBalai.nama}</p>
+            <p className="m-0">NIP. {kepalaBalai.nip}</p>
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/frontend/src/app/bmn/auction-candidates/_components/TimPenilaiEditor.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/TimPenilaiEditor.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { TimPenilaiAnggota } from "../_lib/sk-tim-penilai-defaults";
+import type { EmployeeOption } from "../_hooks/useEmployeeOptions";
+
+interface TimPenilaiEditorProps {
+  susunanTimPenilai: TimPenilaiAnggota[];
+  employees: EmployeeOption[];
+  onAdd: () => void;
+  onRemove: (id: string) => void;
+  onUpdate: (id: string, field: keyof TimPenilaiAnggota, value: string) => void;
+  onSelectEmployee: (id: string, employeeId: string, employees: EmployeeOption[]) => void;
+}
+
+export function TimPenilaiEditor({
+  susunanTimPenilai,
+  employees,
+  onAdd,
+  onRemove,
+  onUpdate,
+  onSelectEmployee,
+}: TimPenilaiEditorProps) {
+  return (
+    <div className="mt-4 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-bold text-zinc-900 dark:text-white">Susunan Tim Penilai</h3>
+        <Button size="xs" variant="outline" className="rounded-lg gap-1" onClick={onAdd}>
+          <Plus className="h-3 w-3" />
+          Tambah
+        </Button>
+      </div>
+      <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+        Susunan Panitia Penaksir Harga yang akan ditampilkan pada halaman lampiran.
+      </p>
+      <div className="mt-3 space-y-3">
+        {susunanTimPenilai.map((item) => (
+          <div key={item.id} className="rounded-xl border border-zinc-200 bg-zinc-50/60 p-2.5 dark:border-zinc-800 dark:bg-zinc-900/50">
+            <div className="flex items-center gap-2">
+              <select
+                value=""
+                onChange={(e) => onSelectEmployee(item.id, e.target.value, employees)}
+                className="h-8 flex-1 rounded-lg border border-zinc-200 bg-white px-2 text-xs text-zinc-900 outline-none focus:ring-1 focus:ring-emerald-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-white"
+              >
+                <option value="">-- Pilih Pegawai --</option>
+                {employees.map((emp) => (
+                  <option key={emp.id} value={String(emp.id)}>
+                    {emp.nama_lengkap || emp.name || "-"}
+                  </option>
+                ))}
+              </select>
+              <Button
+                size="xs"
+                variant="destructive"
+                className="rounded-md gap-1"
+                onClick={() => onRemove(item.id)}
+              >
+                <Trash2 className="h-3 w-3" />
+                Hapus
+              </Button>
+            </div>
+            <input
+              value={item.jabatanKegiatan}
+              onChange={(e) => onUpdate(item.id, "jabatanKegiatan", e.target.value)}
+              placeholder="Jabatan dalam Kegiatan (Ketua, Sekretaris, Anggota...)"
+              className="mt-2 h-8 w-full rounded-lg border border-zinc-200 bg-white px-2 text-xs text-zinc-900 outline-none focus:ring-1 focus:ring-emerald-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-white"
+            />
+            <input
+              value={item.keterangan}
+              onChange={(e) => onUpdate(item.id, "keterangan", e.target.value)}
+              placeholder="Keterangan (opsional)"
+              className="mt-2 h-8 w-full rounded-lg border border-zinc-200 bg-white px-2 text-xs text-zinc-900 outline-none focus:ring-1 focus:ring-emerald-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-white"
+            />
+            {item.nama && (
+              <div className="mt-2 rounded-lg bg-emerald-50 px-2.5 py-1.5 text-[11px] text-emerald-800 dark:bg-emerald-500/10 dark:text-emerald-300">
+                <p className="font-semibold">{item.nama}</p>
+                <p>NIP. {item.nip}</p>
+              </div>
+            )}
+          </div>
+        ))}
+        {susunanTimPenilai.length === 0 && (
+          <p className="rounded-lg border border-dashed border-zinc-300 p-3 text-center text-xs text-zinc-400">
+            Belum ada anggota Tim Penilai. Klik Tambah untuk menambahkan.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/SkTimPenilaiSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/SkTimPenilaiSection.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { Printer } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { SkTimPenilaiBuilder } from "../SkTimPenilaiBuilder";
+import { SkTimPenilaiDocument } from "../SkTimPenilaiDocument";
+import { TimPenilaiEditor } from "../TimPenilaiEditor";
+import type { SkBuilderItem, SkKepalaBalai } from "../../_lib/sk-defaults";
+import type {
+  SkTimPenilaiMemutuskan,
+  TimPenilaiAnggota,
+} from "../../_lib/sk-tim-penilai-defaults";
+import type { EmployeeOption } from "../../_hooks/useEmployeeOptions";
+
+interface SkTimPenilaiSectionProps {
+  skTimPenilaiNumber: string;
+  timPenilaiMenimbang: SkBuilderItem[];
+  setTimPenilaiMenimbang: (items: SkBuilderItem[]) => void;
+  timPenilaiMengingat: SkBuilderItem[];
+  setTimPenilaiMengingat: (items: SkBuilderItem[]) => void;
+  timPenilaiMemutuskan: SkTimPenilaiMemutuskan;
+  setTimPenilaiMemutuskan: (m: SkTimPenilaiMemutuskan) => void;
+  kepalaBalai: SkKepalaBalai;
+  setKepalaBalai: (kb: SkKepalaBalai) => void;
+  timPenilaiTembusan: SkBuilderItem[];
+  setTimPenilaiTembusan: (items: SkBuilderItem[]) => void;
+  susunanTimPenilai: TimPenilaiAnggota[];
+  employees: EmployeeOption[];
+  onAddTimPenilai: () => void;
+  onRemoveTimPenilai: (id: string) => void;
+  onUpdateTimPenilai: (id: string, field: keyof TimPenilaiAnggota, value: string) => void;
+  onSelectTimPenilaiEmployee: (id: string, employeeId: string, employees: EmployeeOption[]) => void;
+  onPrint: () => void;
+}
+
+export function SkTimPenilaiSection({
+  skTimPenilaiNumber,
+  timPenilaiMenimbang,
+  setTimPenilaiMenimbang,
+  timPenilaiMengingat,
+  setTimPenilaiMengingat,
+  timPenilaiMemutuskan,
+  setTimPenilaiMemutuskan,
+  kepalaBalai,
+  setKepalaBalai,
+  timPenilaiTembusan,
+  setTimPenilaiTembusan,
+  susunanTimPenilai,
+  employees,
+  onAddTimPenilai,
+  onRemoveTimPenilai,
+  onUpdateTimPenilai,
+  onSelectTimPenilaiEmployee,
+  onPrint,
+}: SkTimPenilaiSectionProps) {
+  return (
+    <section id="sk-tim-penilai-preview" className="space-y-4">
+      <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
+        <div>
+          <h2 className="text-lg font-bold text-zinc-900 dark:text-white">Preview SK Tim Penilai (Panitia Penaksir Harga BMN)</h2>
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">Keputusan Kepala Balai tentang pembentukan Panitia Penaksir Harga BMN.</p>
+        </div>
+        <Button className="rounded-xl gap-2 bg-emerald-600 text-xs hover:bg-emerald-500" onClick={onPrint}>
+          <Printer className="h-3.5 w-3.5" />
+          Cetak / Save PDF
+        </Button>
+      </div>
+      <div className="grid gap-4 lg:grid-cols-[400px_1fr]">
+        <div className="print:hidden">
+          <SkTimPenilaiBuilder
+            menimbang={timPenilaiMenimbang}
+            setMenimbang={setTimPenilaiMenimbang}
+            mengingat={timPenilaiMengingat}
+            setMengingat={setTimPenilaiMengingat}
+            memutuskan={timPenilaiMemutuskan}
+            setMemutuskan={setTimPenilaiMemutuskan}
+            kepalaBalai={kepalaBalai}
+            setKepalaBalai={setKepalaBalai}
+            tembusan={timPenilaiTembusan}
+            setTembusan={setTimPenilaiTembusan}
+          />
+
+          <TimPenilaiEditor
+            susunanTimPenilai={susunanTimPenilai}
+            employees={employees}
+            onAdd={onAddTimPenilai}
+            onRemove={onRemoveTimPenilai}
+            onUpdate={onUpdateTimPenilai}
+            onSelectEmployee={onSelectTimPenilaiEmployee}
+          />
+        </div>
+        <div>
+          <SkTimPenilaiDocument
+            skNumber={skTimPenilaiNumber}
+            menimbang={timPenilaiMenimbang}
+            mengingat={timPenilaiMengingat}
+            memutuskan={timPenilaiMemutuskan}
+            kepalaBalai={kepalaBalai}
+            tembusan={timPenilaiTembusan}
+            susunanTimPenilai={susunanTimPenilai}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/bmn/auction-candidates/_hooks/useDocumentNumbers.ts
+++ b/frontend/src/app/bmn/auction-candidates/_hooks/useDocumentNumbers.ts
@@ -12,6 +12,8 @@ export interface UseDocumentNumbersResult {
   setSkNumber: React.Dispatch<React.SetStateAction<string>>;
   skPanitiaNumber: string;
   setSkPanitiaNumber: React.Dispatch<React.SetStateAction<string>>;
+  skTimPenilaiNumber: string;
+  setSkTimPenilaiNumber: React.Dispatch<React.SetStateAction<string>>;
   sptjLimitNumber: string;
   setSptjLimitNumber: React.Dispatch<React.SetStateAction<string>>;
   sptjmNumber: string;
@@ -33,6 +35,7 @@ export function useDocumentNumbers(): UseDocumentNumbersResult {
   const [baKap, setBaKap] = useState("KAP.06.01");
   const [skNumber, setSkNumber] = useState("");
   const [skPanitiaNumber, setSkPanitiaNumber] = useState("");
+  const [skTimPenilaiNumber, setSkTimPenilaiNumber] = useState("107");
   const [sptjLimitNumber, setSptjLimitNumber] = useState("41");
   const [sptjmNumber, setSptjmNumber] = useState("202");
   const [spTugasNumber, setSpTugasNumber] = useState("40");
@@ -50,6 +53,8 @@ export function useDocumentNumbers(): UseDocumentNumbersResult {
     setSkNumber,
     skPanitiaNumber,
     setSkPanitiaNumber,
+    skTimPenilaiNumber,
+    setSkTimPenilaiNumber,
     sptjLimitNumber,
     setSptjLimitNumber,
     sptjmNumber,

--- a/frontend/src/app/bmn/auction-candidates/_hooks/useDocumentToggles.ts
+++ b/frontend/src/app/bmn/auction-candidates/_hooks/useDocumentToggles.ts
@@ -7,6 +7,7 @@ export interface UseDocumentTogglesResult {
   showDocument: boolean;
   showSkDocument: boolean;
   showSkPanitia: boolean;
+  showSkTimPenilai: boolean;
   showSptjLimit: boolean;
   showSptjm: boolean;
   showSpTugas: boolean;
@@ -17,6 +18,7 @@ export interface UseDocumentTogglesResult {
   handleProcess: () => void;
   handleProcessSk: () => void;
   handleProcessSkPanitia: () => void;
+  handleProcessSkTimPenilai: () => void;
   handleProcessSptjLimit: () => void;
   handleProcessSptjm: () => void;
   handleProcessSpTugas: () => void;
@@ -34,6 +36,7 @@ export function useDocumentToggles(orderedIdsLength: number): UseDocumentToggles
   const [showDocument, setShowDocument] = useState(false);
   const [showSkDocument, setShowSkDocument] = useState(false);
   const [showSkPanitia, setShowSkPanitia] = useState(false);
+  const [showSkTimPenilai, setShowSkTimPenilai] = useState(false);
   const [showSptjLimit, setShowSptjLimit] = useState(false);
   const [showSptjm, setShowSptjm] = useState(false);
   const [showSpTugas, setShowSpTugas] = useState(false);
@@ -44,6 +47,7 @@ export function useDocumentToggles(orderedIdsLength: number): UseDocumentToggles
     setShowDocument(false);
     setShowSkDocument(false);
     setShowSkPanitia(false);
+    setShowSkTimPenilai(false);
     setShowSptjLimit(false);
     setShowSptjm(false);
     setShowSpTugas(false);
@@ -79,6 +83,16 @@ export function useDocumentToggles(orderedIdsLength: number): UseDocumentToggles
     resetAllShows();
     setShowSkPanitia(true);
     scrollIntoPreview("sk-panitia-preview");
+  }, [orderedIdsLength, resetAllShows]);
+
+  const handleProcessSkTimPenilai = useCallback(() => {
+    if (orderedIdsLength === 0) {
+      toast.error("Pilih minimal satu aset untuk diproses.");
+      return;
+    }
+    resetAllShows();
+    setShowSkTimPenilai(true);
+    scrollIntoPreview("sk-tim-penilai-preview");
   }, [orderedIdsLength, resetAllShows]);
 
   const handleProcessSptjLimit = useCallback(() => {
@@ -123,6 +137,7 @@ export function useDocumentToggles(orderedIdsLength: number): UseDocumentToggles
     showDocument,
     showSkDocument,
     showSkPanitia,
+    showSkTimPenilai,
     showSptjLimit,
     showSptjm,
     showSpTugas,
@@ -133,6 +148,7 @@ export function useDocumentToggles(orderedIdsLength: number): UseDocumentToggles
     handleProcess,
     handleProcessSk,
     handleProcessSkPanitia,
+    handleProcessSkTimPenilai,
     handleProcessSptjLimit,
     handleProcessSptjm,
     handleProcessSpTugas,

--- a/frontend/src/app/bmn/auction-candidates/_hooks/useSkTimPenilaiBuilderState.ts
+++ b/frontend/src/app/bmn/auction-candidates/_hooks/useSkTimPenilaiBuilderState.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import type { SkBuilderItem } from "../_lib/sk-defaults";
+import {
+  DEFAULT_TIM_PENILAI_MEMUTUSKAN,
+  DEFAULT_TIM_PENILAI_MENGINGAT,
+  DEFAULT_TIM_PENILAI_MENIMBANG,
+  DEFAULT_TIM_PENILAI_TEMBUSAN,
+  type SkTimPenilaiMemutuskan,
+} from "../_lib/sk-tim-penilai-defaults";
+
+export interface UseSkTimPenilaiBuilderStateResult {
+  timPenilaiMenimbang: SkBuilderItem[];
+  setTimPenilaiMenimbang: React.Dispatch<React.SetStateAction<SkBuilderItem[]>>;
+  timPenilaiMengingat: SkBuilderItem[];
+  setTimPenilaiMengingat: React.Dispatch<React.SetStateAction<SkBuilderItem[]>>;
+  timPenilaiMemutuskan: SkTimPenilaiMemutuskan;
+  setTimPenilaiMemutuskan: React.Dispatch<React.SetStateAction<SkTimPenilaiMemutuskan>>;
+  timPenilaiTembusan: SkBuilderItem[];
+  setTimPenilaiTembusan: React.Dispatch<React.SetStateAction<SkBuilderItem[]>>;
+}
+
+export function useSkTimPenilaiBuilderState(): UseSkTimPenilaiBuilderStateResult {
+  const [timPenilaiMenimbang, setTimPenilaiMenimbang] = useState<SkBuilderItem[]>(
+    DEFAULT_TIM_PENILAI_MENIMBANG,
+  );
+  const [timPenilaiMengingat, setTimPenilaiMengingat] = useState<SkBuilderItem[]>(
+    DEFAULT_TIM_PENILAI_MENGINGAT,
+  );
+  const [timPenilaiMemutuskan, setTimPenilaiMemutuskan] = useState<SkTimPenilaiMemutuskan>(
+    DEFAULT_TIM_PENILAI_MEMUTUSKAN,
+  );
+  const [timPenilaiTembusan, setTimPenilaiTembusan] = useState<SkBuilderItem[]>(
+    DEFAULT_TIM_PENILAI_TEMBUSAN,
+  );
+
+  return {
+    timPenilaiMenimbang,
+    setTimPenilaiMenimbang,
+    timPenilaiMengingat,
+    setTimPenilaiMengingat,
+    timPenilaiMemutuskan,
+    setTimPenilaiMemutuskan,
+    timPenilaiTembusan,
+    setTimPenilaiTembusan,
+  };
+}

--- a/frontend/src/app/bmn/auction-candidates/_hooks/useTimPenilaiList.ts
+++ b/frontend/src/app/bmn/auction-candidates/_hooks/useTimPenilaiList.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { formatNip } from "../_lib/sk-defaults";
+import {
+  DEFAULT_TIM_PENILAI_SUSUNAN,
+  newTimPenilaiAnggota,
+  type TimPenilaiAnggota,
+} from "../_lib/sk-tim-penilai-defaults";
+import type { EmployeeOption } from "./useEmployeeOptions";
+
+export interface UseTimPenilaiListResult {
+  susunanTimPenilai: TimPenilaiAnggota[];
+  addTimPenilaiAnggota: () => void;
+  removeTimPenilaiAnggota: (id: string) => void;
+  updateTimPenilaiAnggota: (
+    id: string,
+    field: keyof TimPenilaiAnggota,
+    value: string,
+  ) => void;
+  selectTimPenilaiEmployee: (
+    id: string,
+    employeeId: string,
+    employees: EmployeeOption[],
+  ) => void;
+}
+
+export function useTimPenilaiList(): UseTimPenilaiListResult {
+  const [susunanTimPenilai, setSusunanTimPenilai] = useState<TimPenilaiAnggota[]>(
+    DEFAULT_TIM_PENILAI_SUSUNAN,
+  );
+
+  const addTimPenilaiAnggota = useCallback(() => {
+    setSusunanTimPenilai((prev) => [...prev, newTimPenilaiAnggota()]);
+  }, []);
+
+  const removeTimPenilaiAnggota = useCallback((id: string) => {
+    setSusunanTimPenilai((prev) => prev.filter((item) => item.id !== id));
+  }, []);
+
+  const updateTimPenilaiAnggota = useCallback(
+    (id: string, field: keyof TimPenilaiAnggota, value: string) => {
+      setSusunanTimPenilai((prev) =>
+        prev.map((item) => (item.id === id ? { ...item, [field]: value } : item)),
+      );
+    },
+    [],
+  );
+
+  const selectTimPenilaiEmployee = useCallback(
+    (id: string, employeeId: string, employees: EmployeeOption[]) => {
+      if (!employeeId) return;
+      const emp = employees.find((e) => String(e.id) === employeeId);
+      if (!emp) return;
+      setSusunanTimPenilai((prev) =>
+        prev.map((item) =>
+          item.id === id
+            ? {
+                ...item,
+                nama: emp.nama_lengkap || emp.name || "",
+                nip: formatNip(emp.nip || ""),
+              }
+            : item,
+        ),
+      );
+    },
+    [],
+  );
+
+  return {
+    susunanTimPenilai,
+    addTimPenilaiAnggota,
+    removeTimPenilaiAnggota,
+    updateTimPenilaiAnggota,
+    selectTimPenilaiEmployee,
+  };
+}

--- a/frontend/src/app/bmn/auction-candidates/_lib/sk-tim-penilai-defaults.ts
+++ b/frontend/src/app/bmn/auction-candidates/_lib/sk-tim-penilai-defaults.ts
@@ -1,0 +1,111 @@
+// Default text content for the SK Tim Penilai (Panitia Penaksir Harga) BMN builder.
+
+import { newSkBuilderItem, type SkBuilderItem } from "./sk-defaults";
+
+export interface TimPenilaiAnggota {
+  id: string;
+  nama: string;            // "Dheny Mardiono, S.Hut., M.Sc."
+  nip: string;             // "19750314 199903 1 004"
+  jabatanKegiatan: string; // "Ketua" / "Sekretaris" / "Anggota"
+  keterangan: string;      // free-form note (default empty)
+}
+
+// SK Tim Penilai uses 4 numbered keputusan (KESATU..KEEMPAT) instead of 3.
+export interface SkTimPenilaiMemutuskan {
+  menetapkan: string;
+  kesatu: string;
+  kedua: string;
+  ketiga: string;
+  keempat: string;
+}
+
+const makeId = () => "id" + Math.random().toString(36).slice(2);
+
+export const DEFAULT_TIM_PENILAI_SUSUNAN: TimPenilaiAnggota[] = [
+  {
+    id: makeId(),
+    nama: "Dheny Mardiono, S.Hut., M.Sc.",
+    nip: "19750314 199903 1 004",
+    jabatanKegiatan: "Ketua",
+    keterangan: "",
+  },
+  {
+    id: makeId(),
+    nama: "Heryanto Sumanbowo, S.Hut.",
+    nip: "19830528 200112 1 001",
+    jabatanKegiatan: "Sekretaris",
+    keterangan: "",
+  },
+  {
+    id: makeId(),
+    nama: "Tegar Anugrah, A.Md.Kom.",
+    nip: "19990707 202506 1 006",
+    jabatanKegiatan: "Anggota",
+    keterangan: "",
+  },
+];
+
+export const DEFAULT_TIM_PENILAI_MENIMBANG: SkBuilderItem[] = [
+  newSkBuilderItem(
+    "bahwa dalam rangka melakukan penertiban terhadap Barang Milik Negara yang, rusak berat, tidak ekonomis dan tidak efisien dalam penggunaannya untuk kepentingan dinas serta dilakukan pelelangan baik lelang umum maupun lelang terbatas, perlu menetapkan Keputusan Kepala Balai Balai Konservasi Sumber Daya Alam Kalimantan Timur tentang Pembentukan Panitia Penaksir Harga Barang Milik Negara."
+  ),
+];
+
+export const DEFAULT_TIM_PENILAI_MENGINGAT: SkBuilderItem[] = [
+  newSkBuilderItem("Undang-Undang RI Nomor 17 Tahun 2003 tentang Keuangan Negara;"),
+  newSkBuilderItem("Undang-Undang RI Nomor 1 Tahun 2004 tentang Perbendaharaan Negara;"),
+  newSkBuilderItem("Peraturan Pemerintah Nomor 71 Tahun 2010 tentang Standar Akuntansi Pemerintahan;"),
+  newSkBuilderItem(
+    "Peraturan Pemerintah Nomor 27 Tahun 2014 tentang Pengelolaan Barang Milik Negara/Daerah sebagaimana telah diubah dengan Peraturan Pemerintah Nomor 28 Tahun 2020;"
+  ),
+  newSkBuilderItem("Peraturan Presiden Nomor 175 Tahun 2024 tentang Kementerian Kehutanan;"),
+  newSkBuilderItem(
+    "Peraturan Menteri Keuangan Nomor 4/PMK.06/2015 tentang Pendelegasian Kewenangan dan Tanggung Jawab Tertentu Dari Pengelola Barang kepada Pengguna Barang;"
+  ),
+  newSkBuilderItem(
+    "Peraturan Menteri Keuangan Nomor 83/PMK.06/2016 tentang Tata Cara Pelaksanaan Pemusnahan dan Penghapusan Barang Milik Negara;"
+  ),
+  newSkBuilderItem(
+    "Peraturan Menteri Keuangan Nomor 246/PMK.06/2014 tentang Tata Cara Pelaksanaan Penggunaan Barang Milik Negara sebagaimana telah diubah dengan Peraturan Menteri Keuangan Nomor 87/PMK.06/2016;"
+  ),
+  newSkBuilderItem(
+    "Peraturan Menteri Keuangan Nomor 111/PMK.06/2016 tentang Tata Cara Pelaksanaan Pemindahtanganan Barang Milik Negara;"
+  ),
+  newSkBuilderItem(
+    "Peraturan Menteri Keuangan Nomor 173/PMK.06/2020 tentang Penilaian oleh Penilai Pemerintah di Lingkungan Direktorat Jenderal Kekayaan Negara;"
+  ),
+  newSkBuilderItem("Peraturan Menteri Keuangan Nomor 122 Tahun 2023 tentang Petunjuk Pelaksanaan Lelang;"),
+  newSkBuilderItem(
+    "Keputusan Menteri Keuangan Republik Indonesia Nomor 375 Tahun 2024 tentang Pedoman Penentuan Nilai Taksiran Barang Milik Negara Selain Tanah Dan/Atau Bangunan Berupa Kendaraan Bermotor Oleh Panitia Penaksir;"
+  ),
+  newSkBuilderItem(
+    "Peraturan Menteri Lingkungan Hidup dan Kehutanan Nomor P.11/MENLHK/SETJEN/KAP.3/4/2018 tentang Tata Cara Pelaksanaan Pemindahtanganan Barang Milik Negara Lingkup Kementerian Lingkungan Hidup dan Kehutanan."
+  ),
+];
+
+export const DEFAULT_TIM_PENILAI_MEMUTUSKAN: SkTimPenilaiMemutuskan = {
+  menetapkan:
+    "SURAT KEPUTUSAN KEPALA BALAI BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR TENTANG PEMBENTUKAN PANITIA PENAKSIR HARGA BARANG MILIK NEGARA PADA BALAI KONSERVASI SUMBER DAYA ALAM KALIMANTAN TIMUR.",
+  kesatu:
+    "Membentuk Panitia Penaksir Harga Barang Milik Negara pada Satuan Kerja Kantor Balai Konservasi Sumber Daya Alam Kalimantan Timur dengan susunan keanggotaan yang tercantum dalam Lampiran Surat Keputusan ini.",
+  kedua:
+    "Panitia tersebut bertugas :\n1. Melakukan penelitian terhadap data administratif barang dan dokumen pemilikan serta mencocokan kesesuaian fisik BMN yang akan dijual dengan data administratif;\n2. Menaksir harga jual Barang Milik Negara menurut ketentuan yang berlaku;\n3. Hasil penaksiran dituangkan dalam laporan dan dilaporkan kepada Kuasa Pengguna Barang yang selanjutnya digunakan sebagai dasar penetapan nilai limit penjualan BMN;\n4. Serta tugas panitia lainnya yang dipandang perlu.",
+  ketiga:
+    "Keputusan Biaya yang timbul atas pelaksanaan Surat Keputusan ini dibebankan pada Anggaran Balai Konservasi Sumber Daya Alam Kalimantan Timur.",
+  keempat:
+    "Surat Keputusan ini mulai berlaku pada tanggal ditetapkan dengan ketentuan apabila dikemudian hari terdapat kekeliruan akan diadakan perbaikan sebagaimana mestinya.",
+};
+
+export const DEFAULT_TIM_PENILAI_TEMBUSAN: SkBuilderItem[] = [
+  newSkBuilderItem("Kepala Biro Umum Kementerian Kehutanan"),
+  newSkBuilderItem("Sekretaris Direktorat Jenderal KSDAE"),
+  newSkBuilderItem("Yang Bersangkutan"),
+];
+
+export const newTimPenilaiAnggota = (): TimPenilaiAnggota => ({
+  id: makeId(),
+  nama: "",
+  nip: "",
+  jabatanKegiatan: "",
+  keterangan: "",
+});

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -7,6 +7,7 @@ import { SummaryTile } from "./_components/SummaryTile";
 import { handlePrintBa } from "./_components/BaKoreksiDocument";
 import { handlePrintSk } from "./_components/SkPenghentianDocument";
 import { handlePrintSkPanitia } from "./_components/SkPanitiaDocument";
+import { handlePrintSkTimPenilai } from "./_components/SkTimPenilaiDocument";
 import { handlePrintSptjLimit } from "./_components/SptjLimitDocument";
 import { handlePrintSptjm } from "./_components/SptjmDocument";
 import { handlePrintSpTugas } from "./_components/SpTugasDocument";
@@ -21,6 +22,7 @@ import { AssetTable } from "./_components/AssetTable";
 import { BaKoreksiSection } from "./_components/sections/BaKoreksiSection";
 import { SkPenghentianSection } from "./_components/sections/SkPenghentianSection";
 import { SkPanitiaSection } from "./_components/sections/SkPanitiaSection";
+import { SkTimPenilaiSection } from "./_components/sections/SkTimPenilaiSection";
 import { SptjLimitSection } from "./_components/sections/SptjLimitSection";
 import { SptjmSection } from "./_components/sections/SptjmSection";
 import { SpTugasSection } from "./_components/sections/SpTugasSection";
@@ -34,8 +36,10 @@ import { useDocumentNumbers } from "./_hooks/useDocumentNumbers";
 import { useEmployeeOptions } from "./_hooks/useEmployeeOptions";
 import { usePemeriksaList } from "./_hooks/usePemeriksaList";
 import { usePanitiaList } from "./_hooks/usePanitiaList";
+import { useTimPenilaiList } from "./_hooks/useTimPenilaiList";
 import { useSkBuilderState } from "./_hooks/useSkBuilderState";
 import { useSkPanitiaBuilderState } from "./_hooks/useSkPanitiaBuilderState";
+import { useSkTimPenilaiBuilderState } from "./_hooks/useSkTimPenilaiBuilderState";
 
 export default function BmnAuctionCandidatesPage() {
   const auctionAssets = useAuctionAssets();
@@ -44,8 +48,10 @@ export default function BmnAuctionCandidatesPage() {
   const { sortedEmployeesForPanitia } = useEmployeeOptions();
   const pemeriksa = usePemeriksaList();
   const panitia = usePanitiaList();
+  const timPenilai = useTimPenilaiList();
   const sk = useSkBuilderState();
   const skPanitia = useSkPanitiaBuilderState();
+  const skTimPenilai = useSkTimPenilaiBuilderState();
 
   const {
     searchTerm,
@@ -123,6 +129,7 @@ export default function BmnAuctionCandidatesPage() {
   const handlePrint = () => handlePrintBa(orderedSelectedAssets);
   const handlePrintSkDoc = () => handlePrintSk(orderedSelectedAssets, docNumbers.skNumber);
   const handlePrintSkPanitiaDoc = () => handlePrintSkPanitia();
+  const handlePrintSkTimPenilaiDoc = () => handlePrintSkTimPenilai();
   const handlePrintSptjLimitDoc = () => handlePrintSptjLimit();
   const handlePrintSptjmDoc = () => handlePrintSptjm();
   const handlePrintSpTugasDoc = () => handlePrintSpTugas();
@@ -147,6 +154,7 @@ export default function BmnAuctionCandidatesPage() {
         onProcess={docToggles.handleProcess}
         onProcessSk={docToggles.handleProcessSk}
         onProcessSkPanitia={docToggles.handleProcessSkPanitia}
+        onProcessSkTimPenilai={docToggles.handleProcessSkTimPenilai}
         onProcessSptjLimit={docToggles.handleProcessSptjLimit}
         onProcessSptjm={docToggles.handleProcessSptjm}
         onProcessSpTugas={docToggles.handleProcessSpTugas}
@@ -168,6 +176,7 @@ export default function BmnAuctionCandidatesPage() {
         showDocument={docToggles.showDocument}
         showSkDocument={docToggles.showSkDocument}
         showSkPanitia={docToggles.showSkPanitia}
+        showSkTimPenilai={docToggles.showSkTimPenilai}
         showSptjLimit={docToggles.showSptjLimit}
         showSptjm={docToggles.showSptjm}
         showSpTugas={docToggles.showSpTugas}
@@ -176,6 +185,7 @@ export default function BmnAuctionCandidatesPage() {
         onPrint={handlePrint}
         onPrintSk={handlePrintSkDoc}
         onPrintSkPanitia={handlePrintSkPanitiaDoc}
+        onPrintSkTimPenilai={handlePrintSkTimPenilaiDoc}
         onPrintSptjLimit={handlePrintSptjLimitDoc}
         onPrintSptjm={handlePrintSptjmDoc}
         onPrintSpTugas={handlePrintSpTugasDoc}
@@ -256,6 +266,29 @@ export default function BmnAuctionCandidatesPage() {
           onUpdatePanitia={panitia.updatePanitiaAnggota}
           onSelectPanitiaEmployee={panitia.selectPanitiaEmployee}
           onPrint={handlePrintSkPanitiaDoc}
+        />
+      )}
+
+      {docToggles.showSkTimPenilai && orderedIds.length > 0 && (
+        <SkTimPenilaiSection
+          skTimPenilaiNumber={docNumbers.skTimPenilaiNumber}
+          timPenilaiMenimbang={skTimPenilai.timPenilaiMenimbang}
+          setTimPenilaiMenimbang={skTimPenilai.setTimPenilaiMenimbang}
+          timPenilaiMengingat={skTimPenilai.timPenilaiMengingat}
+          setTimPenilaiMengingat={skTimPenilai.setTimPenilaiMengingat}
+          timPenilaiMemutuskan={skTimPenilai.timPenilaiMemutuskan}
+          setTimPenilaiMemutuskan={skTimPenilai.setTimPenilaiMemutuskan}
+          kepalaBalai={sk.kepalaBalai}
+          setKepalaBalai={sk.setKepalaBalai}
+          timPenilaiTembusan={skTimPenilai.timPenilaiTembusan}
+          setTimPenilaiTembusan={skTimPenilai.setTimPenilaiTembusan}
+          susunanTimPenilai={timPenilai.susunanTimPenilai}
+          employees={sortedEmployeesForPanitia}
+          onAddTimPenilai={timPenilai.addTimPenilaiAnggota}
+          onRemoveTimPenilai={timPenilai.removeTimPenilaiAnggota}
+          onUpdateTimPenilai={timPenilai.updateTimPenilaiAnggota}
+          onSelectTimPenilaiEmployee={timPenilai.selectTimPenilaiEmployee}
+          onPrint={handlePrintSkTimPenilaiDoc}
         />
       )}
 


### PR DESCRIPTION
Closes #370

Tambah dokumen ke-11 di `/bmn/auction-candidates`: **SK Pembentukan Panitia Penaksir Harga BMN** (alias SK Tim Penilai). Mirror struktur SK Panitia dengan penyesuaian konteks penaksir harga.

## Perbedaan vs SK Panitia

| Aspek | SK Panitia | SK Tim Penilai |
|-------|------------|----------------|
| Nomor | `SK.xxx/K.18/TU/KAP.05/MM/YYYY` | `SK.107/K.18/TU/KAP.06.01/B/MM/YYYY` |
| Title | SK Panitia Penghapusan BMN | Pembentukan Panitia Penaksir Harga BMN |
| Menimbang | 2 items | 1 paragraph |
| Mengingat | 8 peraturan | **13 peraturan** (+PP 71/2010, PMK 246/2014, PMK 173/2020, PMK 122/2023, KMK 375/2024) |
| Memutuskan | 3 keputusan | **4 keputusan (KEEMPAT)** |
| Tabel lampiran | 3 kolom | **4 kolom** (No, Nama/NIP, Jabatan, Keterangan) |
| Default susunan | 4 (incl. Kepala Balai) | 3 (Ketua/Sekretaris/Anggota) |

## File baru (7)
- `_lib/sk-tim-penilai-defaults.ts` — interface `TimPenilaiAnggota` (4 fields), `SkTimPenilaiMemutuskan` (5 fields), defaults.
- `_hooks/useSkTimPenilaiBuilderState.ts`
- `_hooks/useTimPenilaiList.ts`
- `_components/SkTimPenilaiBuilder.tsx` — varian SkBuilder dengan textarea KEEMPAT + ring emerald.
- `_components/SkTimPenilaiDocument.tsx` — CSS prefix `sktp-`, baris KEEMPAT, tabel 4 kolom, JS print pagination.
- `_components/TimPenilaiEditor.tsx` — list editor + field Keterangan.
- `_components/sections/SkTimPenilaiSection.tsx` — preview wrapper.

## File diubah (6)
- `_hooks/useDocumentToggles.ts` — `showSkTimPenilai` + `handleProcessSkTimPenilai`.
- `_hooks/useDocumentNumbers.ts` — `skTimPenilaiNumber` (default "107").
- `_components/DocumentActions.tsx` — tombol baru (emerald), grid 3-col × 3-row.
- `_components/DocumentNumberInputs.tsx` — input panel SK Tim Penilai, label "10 dokumen".
- `_components/SelectedAssetsBanner.tsx` — tombol Cetak SK Tim Penilai conditional.
- `page.tsx` — wire imports, hooks, props, render `<SkTimPenilaiSection>`.

## Print pagination (mirror mekanisme SK Panitia)
- `@page` A4 dengan `margin: 0`, padding-bottom 28mm di halaman utama untuk **safe area BSrE/BSSN footer**.
- Halaman lanjutan (page 2+) padded 18mm di atas untuk margin atas.
- JS pagination setelah `window.open`: split jadi halaman A4 eksplisit, ukur tinggi setiap blok.
- `firstPageContentH=264mm`, `continuationContentH=251mm`, `markerReserveH=9mm`.
- **Sambungan kata** di pojok kanan bawah: `{nomor}. {first_word}.....` (untuk Mengingat) atau `LABEL.....` (untuk MEMUTUSKAN/KESATU/KEDUA/KETIGA/KEEMPAT) saat blok berikutnya tidak fit.
- Blok yang dipaginate: Menimbang items → Mengingat items → MEMUTUSKAN+Menetapkan group → KESATU → KEDUA → KETIGA → KEEMPAT+TTD+Tembusan group.
- Lampiran tetap di halaman terpisah via `page-break-before: always`.

## Validation
- `npx eslint --max-warnings=0` clean
- `npx tsc --noEmit` clean
- `npm run build` clean (59/59 static pages)

## Out of Scope
- Tidak ada perubahan backend (frontend-only).
- Document existing (SkPanitia/SkPenghentian/dll) tidak diubah.
