### PR TITLE
fix(bmn): align BA pemeriksaan lampiran pagination (#378)

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -134,17 +134,18 @@ git push origin main
 - [x] Issue #372: Add Nota Dinas KSDAE and Surat Permohonan KPKNL documents (2-page each: portrait + landscape lampiran). PR #373 merged ke `main` (merge commit `abecc91`); remote branch deleted.
 - [x] Issue #374: Align Surat Permohonan KPKNL page 1 print content + Nota Dinas/KPKNL landscape lampiran pagination. PR #375 merged ke `main` (merge commit `776722a`); remote branch deleted.
 - [x] Issue #376: Add Kertas Kerja Analisis Nilai Taksiran BMN per selected auction asset. PR #377 merged ke `main` (merge commit `878a311`); remote branch deleted.
+- [ ] Issue #378: Make BA Pemeriksaan lampiran landscape and paginate final TTD page. **WIP lokal di branch `issue/378-ba-pemeriksaan-lampiran-landscape`; siap user visual check.**
 
 | Field | Value |
 |-------|-------|
 | **Issue Terakhir Selesai** | Issue #376: Kertas Kerja Analisis Nilai Taksiran BMN per aset terpilih (PR #377 merged) |
-| **Issue Sedang Dikerjakan** | None |
-| **Branch Aktif** | `main` |
-| **Commit Terakhir di Main** | `878a311` |
+| **Issue Sedang Dikerjakan** | Issue #378: BA Pemeriksaan lampiran landscape + pagination |
+| **Branch Aktif** | `issue/378-ba-pemeriksaan-lampiran-landscape` |
+| **Commit Terakhir di Main** | `efe9375` |
 | **Commit Production Server** | `e2dee79` (#370, #372, #374 belum di-deploy) |
-| **Status** | MERGED: Issue #376 sudah punya form/preview Kertas Kerja per aset di `/bmn/auction-candidates`, tombol buka kertas kerja dari tabel aset dan reorder panel, nomor otomatis mengikuti urutan aset terpilih, kop pakai `logo_kemenhut.png`, checkbox jenis kendaraan/dokumen/masa berlaku ikut tampil saat print, data hasil lelang default 3 baris + tambah/hapus baris, panitia penaksir bisa pilih dari data pegawai dan diedit manual. Update terakhir: kategori lokasi bisa diedit dari panel kiri; kondisi kendaraan jadi pilihan tunggal 0,5/0,6/0,7 dan mengubah faktor limit; `Total` dan `Nilai taksiran` penyesuaian dihitung otomatis; summary nilai dirapikan seperti referensi; tanggal default otomatis hari ini; nomor polisi ditampilkan langsung untuk aset angkutan bermotor yang punya `no_polisi`, tanpa label `No Pol`; input/textarea table disembunyikan saat print; teks panjang di tabel bisa turun baris dan membuka tinggi row. PR #377 merged, branch remote deleted, belum deploy. |
+| **Status** | WIP: Issue #378 memperbaiki lampiran BA Pemeriksaan di `/bmn/auction-candidates` agar halaman lampiran memakai A4 landscape, tabel aset dipaginasi manual seperti Nota Dinas/KPKNL, halaman terakhir membawa aset + TTD pelaksana/kepala balai tanpa `${ttd_pengirim}`, dan jika aset banyak halaman terakhir dibatasi maksimal 6 aset dengan minimal 1 aset tetap tergabung bersama TTD 5 orang. Paginasi final page sekarang mempertimbangkan estimasi tinggi teks aset, sehingga 6 aset dengan nama/merk panjang bisa dikurangi agar TTD tidak jatuh sendiri. Baris `Lampiran` berisi teks editable `PEMERIKSAAN BARANG MILIK NEGARA BERUPA ALAT ANGKUTAN BERMOTOR`, row nomor kolom 1-11 hanya tampil pada halaman lanjutan, dan `Nilai Buku` selalu `-` di tengah. Shared lampiran Nota Dinas/KPKNL juga diubah agar halaman pertama tidak menampilkan row nomor kolom dan halaman lanjutan lebih aman dari single-row overflow. Belum commit/push/PR; siap visual check user. |
 | **Model Terakhir** | GPT-5 Codex |
-| **Timestamp** | 2026-05-27T16:13:30+08:00 |
+| **Timestamp** | 2026-05-27T16:35:00+08:00 |
 
 ### Issue #358 Summary:
 - [x] Migration `2026_05_22_163000_add_no_mesin_to_bmn_assets_table.php` — kolom `no_mesin` nullable string `after('no_stnk')`.
@@ -179,7 +180,40 @@ git push origin main
 - [x] Full validation clean: `npm run lint -- --max-warnings=0`, `npx tsc --noEmit`, `npm run build`, `git diff --check`.
 
 ### Next Steps:
-- [ ] Deploy issue #370, #372, #374, dan #376 ke SSH production saat user siap.
+- [ ] User visual check BA Pemeriksaan lampiran landscape issue #378 di `/bmn/auction-candidates`.
+- [ ] Setelah user approve: commit, push, PR issue #378; merge sesuai instruksi user.
+- [ ] Deploy issue #370, #372, #374, #376, dan #378 ke SSH production saat user siap.
+
+---
+
+**UPDATE SESI CODEX (2026-05-27 - Issue #378 WIP: BA Pemeriksaan lampiran landscape):**
+- **Objective**: Ubah lampiran BA Pemeriksaan BMN menjadi A4 landscape dan paginasi manual saat aset banyak.
+- **Status**: WIP lokal; siap user visual check. Belum commit/push/PR.
+- **GitHub**:
+  - Issue: #378 `fix(bmn): make BA Pemeriksaan lampiran landscape`
+  - Branch lokal: `issue/378-ba-pemeriksaan-lampiran-landscape`
+- **Changes sejauh ini**:
+  - `BaPemeriksaanDocument.tsx` sekarang memakai named print pages: halaman utama portrait dan halaman lampiran `ba-pem-landscape`.
+  - Lampiran BA Pemeriksaan dirender sebagai halaman A4 landscape (`297mm`) dengan tabel selebar area landscape.
+  - Tabel aset dipaginasi manual, mirip pola Nota Dinas/KPKNL; halaman terakhir membawa aset + tanda tangan, halaman sebelumnya hanya tabel.
+  - Untuk banyak aset, halaman terakhir dibatasi maksimal 6 aset; minimal 1 aset tetap ikut bersama blok TTD.
+  - Lampiran BA Pemeriksaan yang berisi 7 aset atau lebih dipaksa turun minimal 1 aset bersama TTD, agar TTD tidak muncul sendiri di halaman baru.
+  - Paginasi final page mempertimbangkan estimasi tinggi teks nama/merk/no polisi/kondisi; kalau 6 aset terlalu tinggi, final page otomatis dikurangi agar TTD tetap satu halaman dengan aset.
+  - Kapasitas halaman lanjutan BA Pemeriksaan diturunkan menjadi 12 aset per halaman agar browser print tidak mendorong satu aset sendirian ke halaman berikutnya.
+  - Baris `Lampiran` di meta lampiran berisi teks editable `PEMERIKSAAN BARANG MILIK NEGARA BERUPA ALAT ANGKUTAN BERMOTOR` dan dibuat satu baris penuh.
+  - Tabel lampiran menambahkan row nomor kolom `1` sampai `11` hanya pada halaman lanjutan, bukan halaman lampiran pertama.
+  - Kolom `Nilai Buku` selalu menampilkan `-` rata tengah.
+  - Shared `AssetLampiranLandscapeTable.tsx` untuk Nota Dinas/KPKNL juga diubah agar row nomor kolom `1` sampai `11` tidak tampil pada halaman lampiran pertama.
+  - Kapasitas halaman lanjutan Nota Dinas/KPKNL diturunkan menjadi 10 aset dan paginator menghindari sisa 1 aset sendirian di halaman tengah.
+  - Blok TTD lampiran tidak memakai `${ttd_pengirim}`; tetap menampilkan pelaksana kegiatan/pemeriksa dan Kepala Balai.
+  - TTD final page memakai grid landscape: pelaksana kegiatan di kiri (pemeriksa 2 kolom) dan Kepala Balai di kanan.
+- **Files changed**:
+  - Modified: `frontend/src/app/bmn/auction-candidates/_components/BaPemeriksaanDocument.tsx`
+  - Modified: `frontend/src/app/bmn/auction-candidates/_components/AssetLampiranLandscapeTable.tsx`
+- **Validation terakhir**:
+  - `npx eslint "src/app/bmn/auction-candidates/_components/BaPemeriksaanDocument.tsx" --max-warnings=0` clean.
+  - `npx tsc --noEmit` clean.
+  - `npm run build` clean (59/59 static pages).
 
 ---
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,49 @@
+# Progress - Phase 63: BA Pemeriksaan Lampiran Landscape
+
+> Document updated: 2026-05-27
+> Status: **WIP LOCAL** (siap user visual check; belum commit/push/PR)
+
+---
+
+## Issue #378: Make BA Pemeriksaan lampiran landscape
+
+### Completed So Far:
+- [x] **Issue Created**: Issue #378 `fix(bmn): make BA Pemeriksaan lampiran landscape`.
+- [x] **Branch Created**: local branch `issue/378-ba-pemeriksaan-lampiran-landscape`.
+- [x] **Landscape lampiran**: BA Pemeriksaan lampiran now uses named A4 landscape pages instead of portrait `.doc-page`.
+- [x] **Manual pagination**: selected assets are chunked manually, following the Nota Dinas/KPKNL pattern instead of relying on browser table splitting.
+- [x] **Final page rule**: final lampiran page includes the TTD block and carries selected assets; for many assets the final page is capped at 6 assets, with a minimum of 1 asset kept together with TTD.
+- [x] **Seven asset edge case**: BA Pemeriksaan lampiran with 7+ assets now forces at least 1 asset onto the final TTD page, so the signature block does not fall alone.
+- [x] **Tall row handling**: final-page pagination estimates row height from long asset names/brand/type text; if 6 assets are too tall, fewer assets are kept on the TTD page.
+- [x] **Continuation page safety**: continuation page capacity reduced to 12 assets so browser print does not push a single overflow row onto its own page.
+- [x] **No `${ttd_pengirim}` placeholder**: BA Pemeriksaan lampiran signature block only renders Pelaksana Kegiatan/pemeriksa and Kepala Balai text.
+- [x] **Landscape TTD layout**: final page uses a wider landscape grid with pemeriksa names in two columns and Kepala Balai on the right.
+- [x] **Lampiran details**: `Lampiran` meta text is editable, stays on one full-width line, and defaults to `PEMERIKSAAN BARANG MILIK NEGARA BERUPA ALAT ANGKUTAN BERMOTOR`.
+- [x] **Table details**: column-number row `1` through `11` appears only on continuation pages; `Nilai Buku` always renders centered `-`.
+- [x] **Nota/KPKNL shared lampiran**: first landscape lampiran page no longer shows the `1` through `11` column-number row; continuation pages still show it.
+- [x] **Nota/KPKNL overflow safety**: shared continuation page capacity reduced to 10 assets and paginator avoids leaving a single asset alone on a middle page.
+
+### Pending:
+- [ ] User visual check at `/bmn/auction-candidates`.
+- [ ] Commit/push/PR after user approval.
+- [ ] Deploy to SSH production when user is ready.
+
+### Key Files:
+- `frontend/src/app/bmn/auction-candidates/_components/BaPemeriksaanDocument.tsx`
+- `frontend/src/app/bmn/auction-candidates/_components/AssetLampiranLandscapeTable.tsx`
+
+### Validation:
+- [x] `npx eslint "src/app/bmn/auction-candidates/_components/BaPemeriksaanDocument.tsx" --max-warnings=0` clean
+- [x] `npx tsc --noEmit` clean
+- [x] `npm run build` clean (59/59 static pages)
+
+### Git Status Notes:
+- Current branch: `issue/378-ba-pemeriksaan-lampiran-landscape`
+- Work is local and not committed/pushed yet.
+- There are unrelated untracked local files already present; do not add them accidentally.
+
+---
+
 # Progress - Phase 62: Kertas Kerja Analisis Nilai Taksiran BMN
 
 > Document updated: 2026-05-27

--- a/frontend/src/app/bmn/auction-candidates/_components/AssetLampiranLandscapeTable.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/AssetLampiranLandscapeTable.tsx
@@ -27,7 +27,7 @@ interface LampiranPage {
 
 function buildLampiranPages(assets: AuctionAsset[]): LampiranPage[] {
   const firstPageLimit = 8;
-  const continuationPageLimit = 12;
+  const continuationPageLimit = 10;
   const lastPageLimit = 4;
   const pages: LampiranPage[] = [];
 
@@ -76,7 +76,12 @@ function buildLampiranPages(assets: AuctionAsset[]): LampiranPage[] {
       let remainingMiddle = middleCount;
 
       while (remainingMiddle > 0) {
-        const pageSize = Math.min(continuationPageLimit, remainingMiddle);
+        let pageSize = Math.min(continuationPageLimit, remainingMiddle);
+
+        if (remainingMiddle > 1 && remainingMiddle - pageSize === 1) {
+          pageSize -= 1;
+        }
+
         pushPage(assets.slice(cursor, cursor + pageSize), cursor, false);
         cursor += pageSize;
         remainingMiddle -= pageSize;
@@ -166,19 +171,21 @@ export function AssetLampiranLandscapeTable({
           <col style={{ width: "13%" }} />
         </colgroup>
         <thead>
-          <tr className={`${prefix}lamp-column-number-row`}>
-            <th>1</th>
-            <th>2</th>
-            <th>3</th>
-            <th>4</th>
-            <th>5</th>
-            <th>6</th>
-            <th>7</th>
-            <th>8</th>
-            <th>9</th>
-            <th>10</th>
-            <th>11</th>
-          </tr>
+          {!page.includeMeta && (
+            <tr className={`${prefix}lamp-column-number-row`}>
+              <th>1</th>
+              <th>2</th>
+              <th>3</th>
+              <th>4</th>
+              <th>5</th>
+              <th>6</th>
+              <th>7</th>
+              <th>8</th>
+              <th>9</th>
+              <th>10</th>
+              <th>11</th>
+            </tr>
+          )}
           <tr>
             <th>No</th>
             <th>Kode Barang</th>

--- a/frontend/src/app/bmn/auction-candidates/_components/BaPemeriksaanDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/BaPemeriksaanDocument.tsx
@@ -19,9 +19,112 @@ interface BaPemeriksaanDocumentProps {
   kepalaBalai: SkKepalaBalai;
 }
 
+interface BaLampiranPage {
+  assets: AuctionAsset[];
+  startIndex: number;
+  includeMeta: boolean;
+  includeSignature: boolean;
+}
+
 function buildNomorText(number: string, today: Date) {
   const month = String(today.getMonth() + 1).padStart(2, "0");
   return `BA.${number.trim() || "158"}/K.18/TU/KAP.06.01/${month}/${today.getFullYear()}`;
+}
+
+function buildBaLampiranPages(assets: AuctionAsset[]): BaLampiranPage[] {
+  const singlePageWithSignatureLimit = 6;
+  const firstPageLimit = 12;
+  const continuationPageLimit = 12;
+  const lastPageLimit = 6;
+  const lastPageUnitLimit = 9;
+  const pages: BaLampiranPage[] = [];
+
+  const pushPage = (
+    pageAssets: AuctionAsset[],
+    startIndex: number,
+    includeMeta: boolean,
+  ) => {
+    pages.push({
+      assets: pageAssets,
+      startIndex,
+      includeMeta,
+      includeSignature: false,
+    });
+  };
+
+  const estimateRowUnits = (asset: AuctionAsset) => {
+    const maxLineCount = Math.max(
+      Math.ceil((asset.nama_barang || "").length / 18),
+      Math.ceil((asset.merk_tipe || "").length / 16),
+      Math.ceil((asset.no_polisi || "").length / 10),
+      Math.ceil((asset.kondisi || "").length / 14),
+      1,
+    );
+
+    return Math.min(4, maxLineCount);
+  };
+  const getFinalPageUnits = (pageAssets: AuctionAsset[]) =>
+    pageAssets.reduce((total, asset) => total + estimateRowUnits(asset), 0);
+
+  if (
+    assets.length <= singlePageWithSignatureLimit &&
+    getFinalPageUnits(assets) <= lastPageUnitLimit
+  ) {
+    pushPage(assets, 0, true);
+  } else {
+    const lastPageOptions = Array.from(
+      { length: Math.min(lastPageLimit, assets.length - 1) },
+      (_, index) => index + 1,
+    );
+    const getNonSignatureStats = (count: number) => {
+      if (count <= firstPageLimit) {
+        return { pageCount: 1, lastChunkSize: count };
+      }
+
+      const remainingAfterFirst = count - firstPageLimit;
+      return {
+        pageCount: 1 + Math.ceil(remainingAfterFirst / continuationPageLimit),
+        lastChunkSize: remainingAfterFirst % continuationPageLimit || continuationPageLimit,
+      };
+    };
+    const [safeLastPageSize = Math.min(lastPageLimit, assets.length - 1)] =
+      lastPageOptions.sort((a, b) => {
+        const finalAssetsA = assets.slice(assets.length - a);
+        const finalAssetsB = assets.slice(assets.length - b);
+        const fitsA = getFinalPageUnits(finalAssetsA) <= lastPageUnitLimit;
+        const fitsB = getFinalPageUnits(finalAssetsB) <= lastPageUnitLimit;
+        const statsA = getNonSignatureStats(assets.length - a);
+        const statsB = getNonSignatureStats(assets.length - b);
+        const hasSingleNonSignatureA = statsA.lastChunkSize === 1;
+        const hasSingleNonSignatureB = statsB.lastChunkSize === 1;
+
+        if (fitsA !== fitsB) return fitsA ? -1 : 1;
+        if (statsA.pageCount !== statsB.pageCount) return statsA.pageCount - statsB.pageCount;
+        if (hasSingleNonSignatureA !== hasSingleNonSignatureB) {
+          return hasSingleNonSignatureA ? 1 : -1;
+        }
+        return a - b;
+      });
+    const lastStartIndex = assets.length - safeLastPageSize;
+
+    let cursor = 0;
+    while (cursor < lastStartIndex) {
+      const limit = cursor === 0 ? firstPageLimit : continuationPageLimit;
+      const pageSize = Math.min(limit, lastStartIndex - cursor);
+      pushPage(assets.slice(cursor, cursor + pageSize), cursor, cursor === 0);
+      cursor += pageSize;
+    }
+
+    pushPage(assets.slice(lastStartIndex), lastStartIndex, false);
+  }
+
+  if (pages.length === 0) {
+    pushPage([], 0, true);
+  }
+
+  pages[pages.length - 1].includeSignature = true;
+
+  return pages;
 }
 
 export function handlePrintBaPemeriksaan() {
@@ -38,7 +141,8 @@ export function handlePrintBaPemeriksaan() {
       <head>
         <title>Berita Acara Pemeriksaan BMN</title>
         <style>
-          @page { size: A4; margin: 0 0 28mm 0; }
+          @page ba-pem-portrait { size: A4 portrait; margin: 0 0 28mm 0; }
+          @page ba-pem-landscape { size: A4 landscape; margin: 0 0 20mm 0; }
           * { box-sizing: border-box; }
           body {
             margin: 0; padding: 0; background: white; color: black;
@@ -47,7 +151,7 @@ export function handlePrintBaPemeriksaan() {
           }
           p { margin: 0; padding: 0; }
           article { margin: 0; }
-          .doc-page { width: 210mm; box-sizing: border-box; margin: 0 auto; padding: 5mm 20mm 0; }
+          .doc-page { width: 210mm; box-sizing: border-box; margin: 0 auto; padding: 5mm 20mm 0; page: ba-pem-portrait; }
           .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; text-align: center; }
           .doc-header img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
           .doc-body { width: 166mm; margin-left: auto; margin-right: auto; text-align: justify; text-justify: inter-word; }
@@ -63,39 +167,26 @@ export function handlePrintBaPemeriksaan() {
           .pemeriksa-row .colon { text-align: center; }
           .doc-editable { outline: none; border-bottom: none !important; }
 
-          /* Lampiran (landscape/portrait) */
-          .ba-pem-lampiran {
-            page-break-before: always;
-            break-before: page;
-            padding-top: 18mm !important;
-          }
-          .ba-pem-lamp-meta { font-size: 11pt; line-height: 1.4; }
+          .ba-pem-page-landscape { width: 297mm; margin: 0 auto; padding: 10mm 16mm 20mm; page: ba-pem-landscape; page-break-before: always; break-before: page; }
+          .ba-pem-lamp-root { width: 258mm; margin: 0 auto; font-family: 'Bookman Old Style', Georgia, serif; }
+          .ba-pem-lamp-meta { width: 100%; font-size: 10.5pt; line-height: 1.35; }
           .ba-pem-lamp-meta .meta-row { display: grid; grid-template-columns: 22mm 5mm minmax(0, 1fr); }
           .ba-pem-lamp-meta .meta-row .colon { text-align: center; }
+          .ba-pem-lamp-meta .lampiran-title { white-space: nowrap; }
           table.ba-pem-table { border-collapse: collapse; width: 100%; font-size: 8.5pt; text-align: center; margin-top: 0.75rem; table-layout: fixed; }
           table.ba-pem-table th, table.ba-pem-table td { border: 1px solid #000; padding: 4px 3px; vertical-align: middle; overflow-wrap: anywhere; word-break: normal; }
+          table.ba-pem-table td.doc-editable { border: 1px solid #000 !important; }
+          table.ba-pem-table tbody tr:last-child td { border-bottom: 1px solid #000 !important; }
           table.ba-pem-table thead { display: table-header-group; }
           table.ba-pem-table tr { break-inside: avoid; page-break-inside: avoid; }
-          .ba-pem-ttd-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 12mm;
-            margin-top: 1.5rem;
-            break-inside: avoid;
-            page-break-inside: avoid;
-          }
+          .ba-pem-column-number-row th { font-weight: normal; }
+          .ba-pem-ttd-grid { display: grid; grid-template-columns: 2fr 1fr; gap: 16mm; margin-top: 9mm; break-inside: avoid; page-break-inside: avoid; }
           .ba-pem-ttd-grid p { margin: 0; padding: 0; line-height: 1.3; }
-          .ba-pem-ttd-pelaksana .ba-pem-pemeriksa-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            row-gap: 1.4rem;
-            column-gap: 6mm;
-            margin-top: 5.5rem;
-          }
+          .ba-pem-pemeriksa-grid { display: grid; grid-template-columns: 1fr 1fr; row-gap: 9mm; column-gap: 12mm; margin-top: 24mm; }
           .ba-pem-pemeriksa-cell p { margin: 0; line-height: 1.25; }
           .ba-pem-pemeriksa-cell .name { font-weight: bold; }
           .ba-pem-ttd-kepala { text-align: left; }
-          .ba-pem-ttd-kepala .kepala-name-block { margin-top: 5.5rem; }
+          .ba-pem-ttd-kepala .kepala-name-block { margin-top: 24mm; }
           .ba-pem-ttd-kepala .kepala-name-block p { line-height: 1.25; }
           .ba-pem-ttd-kepala .kepala-name-block .name { font-weight: bold; }
         </style>
@@ -120,10 +211,8 @@ export function BaPemeriksaanDocument({
   const nomorText = buildNomorText(number, today);
   const { day, dateText, month, yearText } = getSpelledDate(today);
   const tanggalLong = formatDateLong(today);
+  const lampiranPages = buildBaLampiranPages(assets);
 
-  // Pelaksana Kegiatan grid: split list into two columns
-  // Layout sesuai contoh: kolom kiri = index 0, 1 ; kolom kanan = index 2, 3
-  // (urut atas-bawah per kolom mengikuti gambar referensi: 1, 2 di kiri; 3, 4 di kanan)
   const half = Math.ceil(pemeriksaList.length / 2);
   const colA = pemeriksaList.slice(0, half);
   const colB = pemeriksaList.slice(half);
@@ -134,13 +223,25 @@ export function BaPemeriksaanDocument({
         .ba-pemeriksaan-print-root .doc-editable { outline: none; border-bottom: 1px dashed transparent; transition: border-bottom-color 0.15s ease; }
         .ba-pemeriksaan-print-root .doc-editable:hover { border-bottom-color: #94a3b8; }
         .ba-pemeriksaan-print-root .doc-editable:focus { border-bottom-color: #64748b; }
-        .ba-pemeriksaan-print-root table.ba-pem-table { border-collapse: collapse; width: 100%; font-size: 8.5pt; text-align: center; table-layout: fixed; }
+        .ba-pemeriksaan-print-root .doc-page { page: ba-pem-portrait; }
+        .ba-pemeriksaan-print-root .ba-pem-page-landscape { width: 297mm !important; max-width: 297mm !important; padding: 10mm 16mm 20mm !important; page: ba-pem-landscape; page-break-before: always; break-before: page; }
+        .ba-pemeriksaan-print-root .ba-pem-lamp-root { width: 258mm; margin: 0 auto; font-family: 'Bookman Old Style', Georgia, serif; }
+        .ba-pemeriksaan-print-root .ba-pem-lamp-meta { width: 100%; font-size: 10.5pt; line-height: 1.35; }
+        .ba-pemeriksaan-print-root .ba-pem-lamp-meta .meta-row { display: grid; grid-template-columns: 22mm 5mm minmax(0, 1fr); }
+        .ba-pemeriksaan-print-root .ba-pem-lamp-meta .meta-row .colon { text-align: center; }
+        .ba-pemeriksaan-print-root .ba-pem-lamp-meta .lampiran-title { white-space: nowrap; }
+        .ba-pemeriksaan-print-root table.ba-pem-table { border-collapse: collapse; width: 100%; font-size: 8.5pt; text-align: center; margin-top: 0.75rem; table-layout: fixed; }
         .ba-pemeriksaan-print-root table.ba-pem-table th,
         .ba-pemeriksaan-print-root table.ba-pem-table td { border: 1px solid #000; padding: 4px 3px; vertical-align: middle; overflow-wrap: anywhere; }
-        .ba-pemeriksaan-print-root .ba-pem-ttd-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12mm; margin-top: 1.5rem; }
-        .ba-pemeriksaan-print-root .ba-pem-pemeriksa-grid { display: grid; grid-template-columns: 1fr 1fr; row-gap: 1.4rem; column-gap: 6mm; margin-top: 5.5rem; }
+        .ba-pemeriksaan-print-root table.ba-pem-table td.doc-editable { border: 1px solid #000 !important; }
+        .ba-pemeriksaan-print-root table.ba-pem-table tbody tr:last-child td { border-bottom: 1px solid #000 !important; }
+        .ba-pemeriksaan-print-root .ba-pem-column-number-row th { font-weight: normal; }
+        .ba-pemeriksaan-print-root .ba-pem-ttd-grid { display: grid; grid-template-columns: 2fr 1fr; gap: 16mm; margin-top: 9mm; }
+        .ba-pemeriksaan-print-root .ba-pem-pemeriksa-grid { display: grid; grid-template-columns: 1fr 1fr; row-gap: 9mm; column-gap: 12mm; margin-top: 24mm; }
+        .ba-pemeriksaan-print-root .ba-pem-ttd-kepala .kepala-name-block { margin-top: 24mm; }
         @media print {
-          @page { size: A4; margin: 0 0 28mm 0; }
+          @page ba-pem-portrait { size: A4 portrait; margin: 0 0 28mm 0; }
+          @page ba-pem-landscape { size: A4 landscape; margin: 0 0 20mm 0; }
           body * { visibility: hidden; }
           .ba-pemeriksaan-print-root, .ba-pemeriksaan-print-root * { visibility: visible; }
           .ba-pemeriksaan-print-root {
@@ -149,19 +250,18 @@ export function BaPemeriksaanDocument({
             font-family: 'Bookman Old Style', Georgia, serif;
             font-size: 11pt; line-height: 1.5; margin: 0; padding: 0;
           }
-          .doc-page { width: 210mm; margin: 0 auto; padding: 5mm 20mm 0; box-shadow: none !important; }
+          .doc-page { width: 210mm; margin: 0 auto; padding: 5mm 20mm 0; box-shadow: none !important; page: ba-pem-portrait; }
           .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; }
           .doc-header img { max-width: 196mm !important; }
           .doc-body { width: 166mm; margin-left: auto; margin-right: auto; }
           .doc-editable { border-bottom: none !important; }
           .pemeriksa-item { break-inside: avoid; page-break-inside: avoid; }
-          .ba-pem-lampiran { page-break-before: always; break-before: page; padding-top: 18mm !important; }
+          .ba-pem-page-landscape { box-shadow: none !important; padding: 10mm 16mm 20mm !important; page: ba-pem-landscape; page-break-before: always; break-before: page; }
           table.ba-pem-table tr { break-inside: avoid; page-break-inside: avoid; }
           .ba-pem-ttd-grid { break-inside: avoid; page-break-inside: avoid; }
         }
       `}</style>
 
-      {/* ─── Halaman 1: Berita Acara ─────────────────────── */}
       <article
         className="doc-page mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
         style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.5" }}
@@ -222,118 +322,142 @@ export function BaPemeriksaanDocument({
         </div>
       </article>
 
-      {/* ─── Halaman 2+: Lampiran (Tabel + TTD) ─────────────────────── */}
-      <article
-        className="doc-page ba-pem-lampiran mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
-        style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.4" }}
-      >
-        <div className="ba-pem-lamp-meta mx-auto w-[166mm]">
-          <div className="meta-row grid grid-cols-[22mm_5mm_minmax(0,1fr)]">
-            <span>Lampiran</span>
-            <span className="colon text-center">:</span>
-            <span></span>
-          </div>
-          <div className="meta-row grid grid-cols-[22mm_5mm_minmax(0,1fr)]">
-            <span>Nomor</span>
-            <span className="colon text-center">:</span>
-            <span contentEditable suppressContentEditableWarning className="doc-editable">{nomorText}</span>
-          </div>
-          <div className="meta-row grid grid-cols-[22mm_5mm_minmax(0,1fr)]">
-            <span>Tanggal</span>
-            <span className="colon text-center">:</span>
-            <span contentEditable suppressContentEditableWarning className="doc-editable">{tanggalLong}</span>
-          </div>
-        </div>
-
-        <table className="ba-pem-table mx-auto mt-3 w-[166mm]">
-          <colgroup>
-            <col style={{ width: "5%" }} />
-            <col style={{ width: "10%" }} />
-            <col style={{ width: "5%" }} />
-            <col style={{ width: "11%" }} />
-            <col style={{ width: "11%" }} />
-            <col style={{ width: "8%" }} />
-            <col style={{ width: "7%" }} />
-            <col style={{ width: "11%" }} />
-            <col style={{ width: "8%" }} />
-            <col style={{ width: "11%" }} />
-            <col style={{ width: "8%" }} />
-          </colgroup>
-          <thead>
-            <tr>
-              <th>No</th>
-              <th>Kode Barang</th>
-              <th>NUP</th>
-              <th>Nama Barang</th>
-              <th>Merk / Type</th>
-              <th>No Polisi</th>
-              <th>Tahun Perolehan</th>
-              <th>Nilai Perolehan (Rp)</th>
-              <th>Nilai Buku</th>
-              <th>Nilai Taksiran (Rp)</th>
-              <th>Kondisi</th>
-            </tr>
-          </thead>
-          <tbody>
-            {assets.length === 0 ? (
-              <tr>
-                <td colSpan={11} style={{ padding: "12px", color: "#94a3b8" }}>
-                  Belum ada aset terpilih.
-                </td>
-              </tr>
-            ) : (
-              assets.map((asset, index) => (
-                <tr key={asset.id}>
-                  <td>{index + 1}.</td>
-                  <td contentEditable suppressContentEditableWarning className="doc-editable" style={{ wordBreak: "break-all" }}>{asset.kode_barang}</td>
-                  <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.nup}</td>
-                  <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.nama_barang}</td>
-                  <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.merk_tipe || ""}</td>
-                  <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.no_polisi || ""}</td>
-                  <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.tahun_perolehan ?? ""}</td>
-                  <td contentEditable suppressContentEditableWarning className="doc-editable" style={{ textAlign: "right" }}>{asset.nilai_perolehan ? formatPlainRupiah(asset.nilai_perolehan) : ""}</td>
-                  <td contentEditable suppressContentEditableWarning className="doc-editable" style={{ textAlign: "right" }}>{asset.nilai_buku ? formatPlainRupiah(asset.nilai_buku) : "-"}</td>
-                  <td contentEditable suppressContentEditableWarning className="doc-editable" style={{ textAlign: "right" }}></td>
-                  <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.kondisi}</td>
-                </tr>
-              ))
+      {lampiranPages.map((page, pageIndex) => (
+        <article
+          className="ba-pem-page-landscape mx-auto max-w-[297mm] bg-white text-black shadow-xl ring-1 ring-zinc-200"
+          key={`ba-pem-lampiran-${pageIndex}`}
+          style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.4" }}
+        >
+          <div className="ba-pem-lamp-root">
+            {page.includeMeta && (
+              <div className="ba-pem-lamp-meta">
+                <div className="meta-row">
+                  <span>Lampiran</span>
+                  <span className="colon">:</span>
+                  <span contentEditable suppressContentEditableWarning className="doc-editable lampiran-title">
+                    PEMERIKSAAN BARANG MILIK NEGARA BERUPA ALAT ANGKUTAN BERMOTOR
+                  </span>
+                </div>
+                <div className="meta-row">
+                  <span>Nomor</span>
+                  <span className="colon">:</span>
+                  <span contentEditable suppressContentEditableWarning className="doc-editable">{nomorText}</span>
+                </div>
+                <div className="meta-row">
+                  <span>Tanggal</span>
+                  <span className="colon">:</span>
+                  <span contentEditable suppressContentEditableWarning className="doc-editable">{tanggalLong}</span>
+                </div>
+              </div>
             )}
-          </tbody>
-        </table>
 
-        {/* TTD — 2 kolom (Pelaksana Kegiatan kiri, Mengetahui Kepala Balai kanan) */}
-        <div className="ba-pem-ttd-grid mx-auto w-[166mm]">
-          <div className="ba-pem-ttd-pelaksana">
-            <p>Samarinda, {tanggalLong}</p>
-            <p>Pelaksana Kegiatan,</p>
+            <table className="ba-pem-table">
+              <colgroup>
+                <col style={{ width: "4%" }} />
+                <col style={{ width: "10%" }} />
+                <col style={{ width: "5%" }} />
+                <col style={{ width: "12%" }} />
+                <col style={{ width: "11%" }} />
+                <col style={{ width: "8%" }} />
+                <col style={{ width: "7%" }} />
+                <col style={{ width: "12%" }} />
+                <col style={{ width: "8%" }} />
+                <col style={{ width: "13%" }} />
+                <col style={{ width: "10%" }} />
+              </colgroup>
+              <thead>
+                {pageIndex > 0 && (
+                  <tr className="ba-pem-column-number-row">
+                    <th>1</th>
+                    <th>2</th>
+                    <th>3</th>
+                    <th>4</th>
+                    <th>5</th>
+                    <th>6</th>
+                    <th>7</th>
+                    <th>8</th>
+                    <th>9</th>
+                    <th>10</th>
+                    <th>11</th>
+                  </tr>
+                )}
+                <tr>
+                  <th>No</th>
+                  <th>Kode Barang</th>
+                  <th>NUP</th>
+                  <th>Nama Barang</th>
+                  <th>Merk / Type</th>
+                  <th>No Polisi</th>
+                  <th>Tahun Perolehan</th>
+                  <th>Nilai Perolehan (Rp)</th>
+                  <th>Nilai Buku</th>
+                  <th>Nilai Taksiran (Rp)</th>
+                  <th>Kondisi</th>
+                </tr>
+              </thead>
+              <tbody>
+                {page.assets.length === 0 ? (
+                  <tr>
+                    <td colSpan={11} style={{ padding: "12px", color: "#94a3b8" }}>
+                      Belum ada aset terpilih.
+                    </td>
+                  </tr>
+                ) : (
+                  page.assets.map((asset, index) => (
+                    <tr key={asset.id}>
+                      <td>{page.startIndex + index + 1}.</td>
+                      <td contentEditable suppressContentEditableWarning className="doc-editable" style={{ wordBreak: "break-all" }}>{asset.kode_barang}</td>
+                      <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.nup}</td>
+                      <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.nama_barang}</td>
+                      <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.merk_tipe || ""}</td>
+                      <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.no_polisi || ""}</td>
+                      <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.tahun_perolehan ?? ""}</td>
+                      <td contentEditable suppressContentEditableWarning className="doc-editable" style={{ textAlign: "right" }}>{asset.nilai_perolehan ? formatPlainRupiah(asset.nilai_perolehan) : ""}</td>
+                      <td contentEditable suppressContentEditableWarning className="doc-editable" style={{ textAlign: "center" }}>-</td>
+                      <td contentEditable suppressContentEditableWarning className="doc-editable" style={{ textAlign: "right" }}></td>
+                      <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.kondisi}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
 
-            <div className="ba-pem-pemeriksa-grid">
-              {colA.map((p, index) => (
-                <div className="ba-pem-pemeriksa-cell" key={p.id}>
-                  <p className="name">{index + 1}. {p.nama}</p>
-                  <p style={{ paddingLeft: "5mm" }}>NIP. {p.nip}</p>
+            {page.includeSignature && (
+              <div className="ba-pem-ttd-grid">
+                <div className="ba-pem-ttd-pelaksana">
+                  <p>Samarinda, {tanggalLong}</p>
+                  <p>Pelaksana Kegiatan,</p>
+
+                  <div className="ba-pem-pemeriksa-grid">
+                    {colA.map((p, index) => (
+                      <div className="ba-pem-pemeriksa-cell" key={p.id}>
+                        <p className="name">{index + 1}. {p.nama}</p>
+                        <p style={{ paddingLeft: "5mm" }}>NIP. {p.nip}</p>
+                      </div>
+                    ))}
+                    {colB.map((p, index) => (
+                      <div className="ba-pem-pemeriksa-cell" key={p.id}>
+                        <p className="name">{index + 1 + colA.length}. {p.nama}</p>
+                        <p style={{ paddingLeft: "5mm" }}>NIP. {p.nip}</p>
+                      </div>
+                    ))}
+                  </div>
                 </div>
-              ))}
-              {colB.map((p, index) => (
-                <div className="ba-pem-pemeriksa-cell" key={p.id}>
-                  <p className="name">{index + 1 + colA.length}. {p.nama}</p>
-                  <p style={{ paddingLeft: "5mm" }}>NIP. {p.nip}</p>
+
+                <div className="ba-pem-ttd-kepala">
+                  <p>Mengetahui,</p>
+                  <p>Kepala Balai,</p>
+
+                  <div className="kepala-name-block">
+                    <p className="name">{kepalaBalai.nama}</p>
+                    <p>NIP. {kepalaBalai.nip}</p>
+                  </div>
                 </div>
-              ))}
-            </div>
+              </div>
+            )}
           </div>
-
-          <div className="ba-pem-ttd-kepala">
-            <p>Mengetahui,</p>
-            <p>Kepala Balai,</p>
-
-            <div className="kepala-name-block">
-              <p className="name">{kepalaBalai.nama}</p>
-              <p>NIP. {kepalaBalai.nip}</p>
-            </div>
-          </div>
-        </div>
-      </article>
+        </article>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
Closes #378

## Summary
- Make BA Pemeriksaan lampiran print as A4 landscape with manual pagination.
- Keep the final BA lampiran page with selected asset rows plus 5-person signature block, without `${ttd_pengirim}`.
- Cap BA final TTD page at 6 assets and account for long asset text so signatures do not fall alone.
- Hide `1-11` column-number row on the first Nota Dinas/KPKNL lampiran page; keep it on continuation pages.
- Reduce shared Nota Dinas/KPKNL continuation page capacity to avoid single-row overflow pages.
- Update HANDOFF/progress notes.

## Validation
- `npx eslint src/app/bmn/auction-candidates/_components/{AssetLampiranLandscapeTable,BaPemeriksaanDocument}.tsx --max-warnings=0`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`