### PR TITLE
fix(bmn): change KOP and make all document numbers fully editable (#380)

### DIFF
--- a/frontend/src/app/bmn/auction-candidates/_components/BaPemeriksaanDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/BaPemeriksaanDocument.tsx
@@ -12,6 +12,7 @@ import type { PemeriksaAnggota } from "../_lib/pemeriksa-defaults";
 
 interface BaPemeriksaanDocumentProps {
   number: string;
+  kap: string;
   pemeriksaList: PemeriksaAnggota[];
   stNumber: string;
   stTanggal: string;
@@ -26,9 +27,9 @@ interface BaLampiranPage {
   includeSignature: boolean;
 }
 
-function buildNomorText(number: string, today: Date) {
+function buildNomorText(number: string, kap: string, today: Date) {
   const month = String(today.getMonth() + 1).padStart(2, "0");
-  return `BA.${number.trim() || "158"}/K.18/TU/KAP.06.01/${month}/${today.getFullYear()}`;
+  return `BA.${number.trim() || "____"}/K.18/TU/${kap.trim() || "KAP.06.01"}/B/${month}/${today.getFullYear()}`;
 }
 
 function buildBaLampiranPages(assets: AuctionAsset[]): BaLampiranPage[] {
@@ -201,6 +202,7 @@ export function handlePrintBaPemeriksaan() {
 
 export function BaPemeriksaanDocument({
   number,
+  kap,
   pemeriksaList,
   stNumber,
   stTanggal,
@@ -208,7 +210,7 @@ export function BaPemeriksaanDocument({
   kepalaBalai,
 }: BaPemeriksaanDocumentProps) {
   const today = new Date();
-  const nomorText = buildNomorText(number, today);
+  const nomorText = buildNomorText(number, kap, today);
   const { day, dateText, month, yearText } = getSpelledDate(today);
   const tanggalLong = formatDateLong(today);
   const lampiranPages = buildBaLampiranPages(assets);
@@ -268,7 +270,7 @@ export function BaPemeriksaanDocument({
       >
         <div className="doc-header -mx-18 text-center">
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
+          <img src="/header-terbaru.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
         </div>
 
         <div className="doc-title mt-2 text-center font-bold leading-snug">

--- a/frontend/src/app/bmn/auction-candidates/_components/DocumentNumberInputs.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/DocumentNumberInputs.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { ChevronDown, Settings2 } from "lucide-react";
-import { formatDateLong, getSkNumberSuffix } from "../_lib/auction-helpers";
+import { formatDateLong } from "../_lib/auction-helpers";
 
 interface DocumentNumberInputsProps {
   baNumber: string;
@@ -11,24 +11,44 @@ interface DocumentNumberInputsProps {
   setBaKap: (value: string) => void;
   skNumber: string;
   setSkNumber: (value: string) => void;
+  skKap: string;
+  setSkKap: (value: string) => void;
   skPanitiaNumber: string;
   setSkPanitiaNumber: (value: string) => void;
+  skPanitiaKap: string;
+  setSkPanitiaKap: (value: string) => void;
   skTimPenilaiNumber: string;
   setSkTimPenilaiNumber: (value: string) => void;
+  skTimPenilaiKap: string;
+  setSkTimPenilaiKap: (value: string) => void;
   sptjLimitNumber: string;
   setSptjLimitNumber: (value: string) => void;
+  sptjLimitKap: string;
+  setSptjLimitKap: (value: string) => void;
   sptjmNumber: string;
   setSptjmNumber: (value: string) => void;
+  sptjmKap: string;
+  setSptjmKap: (value: string) => void;
   spTugasNumber: string;
   setSpTugasNumber: (value: string) => void;
+  spTugasKap: string;
+  setSpTugasKap: (value: string) => void;
   skKebenaranNumber: string;
   setSkKebenaranNumber: (value: string) => void;
+  skKebenaranKap: string;
+  setSkKebenaranKap: (value: string) => void;
   baPemeriksaanNumber: string;
   setBaPemeriksaanNumber: (value: string) => void;
+  baPemeriksaanKap: string;
+  setBaPemeriksaanKap: (value: string) => void;
   notaDinasNumber: string;
   setNotaDinasNumber: (value: string) => void;
+  notaDinasKap: string;
+  setNotaDinasKap: (value: string) => void;
   permohonanKpknlNumber: string;
   setPermohonanKpknlNumber: (value: string) => void;
+  permohonanKpknlKap: string;
+  setPermohonanKpknlKap: (value: string) => void;
   stNumber: string;
   setStNumber: (value: string) => void;
   stTanggal: string;
@@ -48,24 +68,44 @@ export function DocumentNumberInputs({
   setBaKap,
   skNumber,
   setSkNumber,
+  skKap,
+  setSkKap,
   skPanitiaNumber,
   setSkPanitiaNumber,
+  skPanitiaKap,
+  setSkPanitiaKap,
   skTimPenilaiNumber,
   setSkTimPenilaiNumber,
+  skTimPenilaiKap,
+  setSkTimPenilaiKap,
   sptjLimitNumber,
   setSptjLimitNumber,
+  sptjLimitKap,
+  setSptjLimitKap,
   sptjmNumber,
   setSptjmNumber,
+  sptjmKap,
+  setSptjmKap,
   spTugasNumber,
   setSpTugasNumber,
+  spTugasKap,
+  setSpTugasKap,
   skKebenaranNumber,
   setSkKebenaranNumber,
+  skKebenaranKap,
+  setSkKebenaranKap,
   baPemeriksaanNumber,
   setBaPemeriksaanNumber,
+  baPemeriksaanKap,
+  setBaPemeriksaanKap,
   notaDinasNumber,
   setNotaDinasNumber,
+  notaDinasKap,
+  setNotaDinasKap,
   permohonanKpknlNumber,
   setPermohonanKpknlNumber,
+  permohonanKpknlKap,
+  setPermohonanKpknlKap,
   stNumber,
   setStNumber,
   stTanggal,
@@ -73,7 +113,6 @@ export function DocumentNumberInputs({
 }: DocumentNumberInputsProps) {
   const [open, setOpen] = useState(false);
   const monthSuffix = `${String(new Date().getMonth() + 1).padStart(2, "0")}/${new Date().getFullYear()}`;
-  const skSuffix = getSkNumberSuffix();
 
   return (
     <div className="rounded-2xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
@@ -140,7 +179,14 @@ export function DocumentNumberInputs({
                   placeholder="____"
                   className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
                 />
-                <span className="truncate">/{skSuffix}</span>
+                <span>/K.18/TU/</span>
+                <input
+                  type="text"
+                  value={skKap}
+                  onChange={(e) => setSkKap(e.target.value)}
+                  className="w-20 bg-transparent text-center font-semibold outline-none"
+                />
+                <span>/B/{monthSuffix}</span>
               </div>
             </div>
 
@@ -159,7 +205,14 @@ export function DocumentNumberInputs({
                   placeholder="____"
                   className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
                 />
-                <span className="truncate">/{skSuffix}</span>
+                <span>/K.18/TU/</span>
+                <input
+                  type="text"
+                  value={skPanitiaKap}
+                  onChange={(e) => setSkPanitiaKap(e.target.value)}
+                  className="w-20 bg-transparent text-center font-semibold outline-none"
+                />
+                <span>/B/{monthSuffix}</span>
               </div>
             </div>
 
@@ -175,10 +228,17 @@ export function DocumentNumberInputs({
                   type="text"
                   value={skTimPenilaiNumber}
                   onChange={(e) => setSkTimPenilaiNumber(e.target.value)}
-                  placeholder="107"
+                  placeholder="____"
                   className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
                 />
-                <span className="truncate">/K.18/TU/KAP.06.01/B/{monthSuffix}</span>
+                <span>/K.18/TU/</span>
+                <input
+                  type="text"
+                  value={skTimPenilaiKap}
+                  onChange={(e) => setSkTimPenilaiKap(e.target.value)}
+                  className="w-20 bg-transparent text-center font-semibold outline-none"
+                />
+                <span>/B/{monthSuffix}</span>
               </div>
             </div>
 
@@ -194,10 +254,17 @@ export function DocumentNumberInputs({
                   type="text"
                   value={sptjLimitNumber}
                   onChange={(e) => setSptjLimitNumber(e.target.value)}
-                  placeholder="41"
-                  className="mx-1 w-12 bg-transparent text-center font-semibold outline-none"
+                  placeholder="____"
+                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
                 />
-                <span className="truncate">/K.18/TU/KAP.06.01/{monthSuffix}</span>
+                <span>/K.18/TU/</span>
+                <input
+                  type="text"
+                  value={sptjLimitKap}
+                  onChange={(e) => setSptjLimitKap(e.target.value)}
+                  className="w-20 bg-transparent text-center font-semibold outline-none"
+                />
+                <span>/B/{monthSuffix}</span>
               </div>
             </div>
 
@@ -213,10 +280,17 @@ export function DocumentNumberInputs({
                   type="text"
                   value={sptjmNumber}
                   onChange={(e) => setSptjmNumber(e.target.value)}
-                  placeholder="202"
-                  className="mx-1 w-12 bg-transparent text-center font-semibold outline-none"
+                  placeholder="____"
+                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
                 />
-                <span className="truncate">/K.18/TU/KAP.06.01/{monthSuffix}</span>
+                <span>/K.18/TU/</span>
+                <input
+                  type="text"
+                  value={sptjmKap}
+                  onChange={(e) => setSptjmKap(e.target.value)}
+                  className="w-20 bg-transparent text-center font-semibold outline-none"
+                />
+                <span>/B/{monthSuffix}</span>
               </div>
             </div>
 
@@ -232,10 +306,17 @@ export function DocumentNumberInputs({
                   type="text"
                   value={spTugasNumber}
                   onChange={(e) => setSpTugasNumber(e.target.value)}
-                  placeholder="40"
-                  className="mx-1 w-12 bg-transparent text-center font-semibold outline-none"
+                  placeholder="____"
+                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
                 />
-                <span className="truncate">/K.18/TU/KAP.06.01/{monthSuffix}</span>
+                <span>/K.18/TU/</span>
+                <input
+                  type="text"
+                  value={spTugasKap}
+                  onChange={(e) => setSpTugasKap(e.target.value)}
+                  className="w-20 bg-transparent text-center font-semibold outline-none"
+                />
+                <span>/B/{monthSuffix}</span>
               </div>
             </div>
 
@@ -251,10 +332,17 @@ export function DocumentNumberInputs({
                   type="text"
                   value={skKebenaranNumber}
                   onChange={(e) => setSkKebenaranNumber(e.target.value)}
-                  placeholder="200"
-                  className="mx-1 w-12 bg-transparent text-center font-semibold outline-none"
+                  placeholder="____"
+                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
                 />
-                <span className="truncate">/K.18/TU/KAP.06.01/{monthSuffix}</span>
+                <span>/K.18/TU/</span>
+                <input
+                  type="text"
+                  value={skKebenaranKap}
+                  onChange={(e) => setSkKebenaranKap(e.target.value)}
+                  className="w-20 bg-transparent text-center font-semibold outline-none"
+                />
+                <span>/B/{monthSuffix}</span>
               </div>
             </div>
 
@@ -270,10 +358,17 @@ export function DocumentNumberInputs({
                   type="text"
                   value={baPemeriksaanNumber}
                   onChange={(e) => setBaPemeriksaanNumber(e.target.value)}
-                  placeholder="158"
-                  className="mx-1 w-12 bg-transparent text-center font-semibold outline-none"
+                  placeholder="____"
+                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
                 />
-                <span className="truncate">/K.18/TU/KAP.06.01/{monthSuffix}</span>
+                <span>/K.18/TU/</span>
+                <input
+                  type="text"
+                  value={baPemeriksaanKap}
+                  onChange={(e) => setBaPemeriksaanKap(e.target.value)}
+                  className="w-20 bg-transparent text-center font-semibold outline-none"
+                />
+                <span>/B/{monthSuffix}</span>
               </div>
             </div>
 
@@ -289,10 +384,17 @@ export function DocumentNumberInputs({
                   type="text"
                   value={notaDinasNumber}
                   onChange={(e) => setNotaDinasNumber(e.target.value)}
-                  placeholder="270"
-                  className="mx-1 w-12 bg-transparent text-center font-semibold outline-none"
+                  placeholder="____"
+                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
                 />
-                <span className="truncate">/K.18/TU/KAP.06.01/B/{monthSuffix}</span>
+                <span>/K.18/TU/</span>
+                <input
+                  type="text"
+                  value={notaDinasKap}
+                  onChange={(e) => setNotaDinasKap(e.target.value)}
+                  className="w-20 bg-transparent text-center font-semibold outline-none"
+                />
+                <span>/B/{monthSuffix}</span>
               </div>
             </div>
 
@@ -308,10 +410,17 @@ export function DocumentNumberInputs({
                   type="text"
                   value={permohonanKpknlNumber}
                   onChange={(e) => setPermohonanKpknlNumber(e.target.value)}
-                  placeholder="331"
-                  className="mx-1 w-12 bg-transparent text-center font-semibold outline-none"
+                  placeholder="____"
+                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
                 />
-                <span className="truncate">/K.18/TU/KAP.06.01/B/{monthSuffix}</span>
+                <span>/K.18/TU/</span>
+                <input
+                  type="text"
+                  value={permohonanKpknlKap}
+                  onChange={(e) => setPermohonanKpknlKap(e.target.value)}
+                  className="w-20 bg-transparent text-center font-semibold outline-none"
+                />
+                <span>/B/{monthSuffix}</span>
               </div>
             </div>
           </div>

--- a/frontend/src/app/bmn/auction-candidates/_components/NotaDinasDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/NotaDinasDocument.tsx
@@ -12,6 +12,7 @@ import type { SkBuilderItem, SkKepalaBalai } from "../_lib/sk-defaults";
 
 interface NotaDinasDocumentProps {
   number: string;
+  kap: string;
   assets: AuctionAsset[];
   kepalaBalai: SkKepalaBalai;
   perihal: string;
@@ -24,9 +25,9 @@ interface NotaDinasDocumentProps {
 
 const LAMPIRAN_TITLE = "Persetujuan Pemindahtanganan BMN dengan Penjualan Pada Balai KSDA Kalimantan Timur";
 
-function buildNomor(number: string, today: Date) {
+function buildNomor(number: string, kap: string, today: Date) {
   const month = String(today.getMonth() + 1).padStart(2, "0");
-  return `ND.${(number || "270").trim()}/K.18/TU/KAP.06.01/B/${month}/${today.getFullYear()}`;
+  return `ND.${(number || "").trim() || "____"}/K.18/TU/${kap.trim() || "KAP.06.01"}/B/${month}/${today.getFullYear()}`;
 }
 
 export function handlePrintNotaDinas() {
@@ -105,6 +106,7 @@ export function handlePrintNotaDinas() {
 
 export function NotaDinasDocument({
   number,
+  kap,
   assets,
   kepalaBalai,
   perihal,
@@ -115,7 +117,7 @@ export function NotaDinasDocument({
   nilaiTaksiran,
 }: NotaDinasDocumentProps) {
   const today = new Date();
-  const nomorText = buildNomor(number, today);
+  const nomorText = buildNomor(number, kap, today);
   const tanggalLong = formatDateLong(today);
 
   const totalPerolehan = assets.reduce(
@@ -194,7 +196,7 @@ export function NotaDinasDocument({
       >
         <div className="nd-kop -mx-18 text-center">
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
+          <img src="/header-terbaru.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
         </div>
 
         <div className="nd-title">

--- a/frontend/src/app/bmn/auction-candidates/_components/PermohonanKpknlDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/PermohonanKpknlDocument.tsx
@@ -8,6 +8,7 @@ import type { SkBuilderItem, SkKepalaBalai } from "../_lib/sk-defaults";
 
 interface PermohonanKpknlDocumentProps {
   number: string;
+  kap: string;
   assets: AuctionAsset[];
   kepalaBalai: SkKepalaBalai;
   perihal: string;
@@ -19,9 +20,9 @@ interface PermohonanKpknlDocumentProps {
 
 const LAMPIRAN_TITLE = "Persetujuan Pemindahtanganan BMN dengan Penjualan Melalui Lelang Pada Balai KSDA Kalimantan Timur";
 
-function buildNomor(number: string, today: Date) {
+function buildNomor(number: string, kap: string, today: Date) {
   const month = String(today.getMonth() + 1).padStart(2, "0");
-  return `S.${(number || "331").trim()}/K.18/TU/KAP.06.01/B/${month}/${today.getFullYear()}`;
+  return `S.${(number || "").trim() || "____"}/K.18/TU/${kap.trim() || "KAP.06.01"}/B/${month}/${today.getFullYear()}`;
 }
 
 export function handlePrintPermohonanKpknl() {
@@ -101,6 +102,7 @@ export function handlePrintPermohonanKpknl() {
 
 export function PermohonanKpknlDocument({
   number,
+  kap,
   assets,
   kepalaBalai,
   perihal,
@@ -110,7 +112,7 @@ export function PermohonanKpknlDocument({
   kesimpulan,
 }: PermohonanKpknlDocumentProps) {
   const today = new Date();
-  const nomorText = buildNomor(number, today);
+  const nomorText = buildNomor(number, kap, today);
   const tanggalLong = formatDateLong(today);
 
   return (
@@ -181,7 +183,7 @@ export function PermohonanKpknlDocument({
       >
         <div className="pkpknl-kop -mx-18 text-center">
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
+          <img src="/header-terbaru.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
         </div>
 
         <div className="pkpknl-meta-grid">

--- a/frontend/src/app/bmn/auction-candidates/_components/SkKebenaranDokumenDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkKebenaranDokumenDocument.tsx
@@ -7,13 +7,14 @@ import type { SkKepalaBalai } from "../_lib/sk-defaults";
 
 interface SkKebenaranDokumenDocumentProps {
   number: string;
+  kap: string;
   assets: AuctionAsset[];
   kepalaBalai: SkKepalaBalai;
 }
 
-function buildNomorText(number: string, today: Date) {
+function buildNomorText(number: string, kap: string, today: Date) {
   const month = String(today.getMonth() + 1).padStart(2, "0");
-  return `KT.${number.trim() || "200"}/K.18/TU/KAP.06.01/${month}/${today.getFullYear()}`;
+  return `KT.${number.trim() || "____"}/K.18/TU/${kap.trim() || "KAP.06.01"}/B/${month}/${today.getFullYear()}`;
 }
 
 export function handlePrintSkKebenaran() {
@@ -67,9 +68,9 @@ export function handlePrintSkKebenaran() {
   setTimeout(() => printWindow.print(), 500);
 }
 
-export function SkKebenaranDokumenDocument({ number, assets, kepalaBalai }: SkKebenaranDokumenDocumentProps) {
+export function SkKebenaranDokumenDocument({ number, kap, assets, kepalaBalai }: SkKebenaranDokumenDocumentProps) {
   const today = new Date();
-  const nomorText = buildNomorText(number, today);
+  const nomorText = buildNomorText(number, kap, today);
 
   return (
     <div id="sk-kebenaran-print-root" className="sk-kebenaran-print-root">
@@ -105,7 +106,7 @@ export function SkKebenaranDokumenDocument({ number, assets, kepalaBalai }: SkKe
       >
         <div className="doc-header -mx-18 text-center">
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
+          <img src="/header-terbaru.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
         </div>
 
         <div className="doc-title mt-2 text-center font-bold leading-snug">

--- a/frontend/src/app/bmn/auction-candidates/_components/SkPanitiaDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkPanitiaDocument.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { toast } from "sonner";
-import { formatDateLong, getSkNumberSuffix } from "../_lib/auction-helpers";
+import { formatDateLong } from "../_lib/auction-helpers";
 import type {
   SkBuilderItem,
   SkKepalaBalai,
@@ -11,6 +11,7 @@ import type { PanitiaAnggota } from "../_lib/sk-panitia-defaults";
 
 interface SkPanitiaDocumentProps {
   skNumber: string;
+  skKap: string;
   menimbang: SkBuilderItem[];
   mengingat: SkBuilderItem[];
   memutuskan: SkMemutuskan;
@@ -465,6 +466,7 @@ export function handlePrintSkPanitia() {
 
 export function SkPanitiaDocument({
   skNumber,
+  skKap,
   menimbang,
   mengingat,
   memutuskan,
@@ -473,7 +475,8 @@ export function SkPanitiaDocument({
   susunanPanitia,
 }: SkPanitiaDocumentProps) {
   const today = new Date();
-  const skNumberText = `SK.${skNumber.trim() || "____"}/${getSkNumberSuffix(today)}`;
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  const skNumberText = `SK.${skNumber.trim() || "____"}/K.18/TU/${skKap.trim() || "KAP.05.01"}/B/${month}/${today.getFullYear()}`;
 
   const mengingatTexts = mengingat.map((m) => m.text);
 

--- a/frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx
@@ -6,7 +6,6 @@ import type { AuctionAsset, AttachmentPage } from "../_lib/auction-helpers";
 import {
   formatPlainRupiah,
   formatDateLong,
-  getSkNumberSuffix,
 } from "../_lib/auction-helpers";
 import type {
   SkBuilderItem,
@@ -17,6 +16,7 @@ import type {
 interface SkPenghentianDocumentProps {
   assets: AuctionAsset[];
   skNumber: string;
+  skKap: string;
   menimbang: SkBuilderItem[];
   mengingat: SkBuilderItem[];
   memutuskan: SkMemutuskan;
@@ -451,6 +451,7 @@ export function handlePrintSk(orderedSelectedAssets: AuctionAsset[], _skNumber: 
 export function SkPenghentianDocument({
   assets,
   skNumber,
+  skKap,
   menimbang,
   mengingat,
   memutuskan,
@@ -458,7 +459,8 @@ export function SkPenghentianDocument({
   tembusan,
 }: SkPenghentianDocumentProps) {
   const today = new Date();
-  const skNumberText = `SK.${skNumber.trim() || "____"}/${getSkNumberSuffix(today)}`;
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  const skNumberText = `SK.${skNumber.trim() || "____"}/K.18/TU/${skKap.trim() || "KAP.05.01"}/B/${month}/${today.getFullYear()}`;
   const totalNilai = assets.reduce((sum, a) => sum + (a.nilai_perolehan || 0), 0);
   const attachmentPages = useMemo<AttachmentPage[]>(() => {
     const firstPageLimit = 15;

--- a/frontend/src/app/bmn/auction-candidates/_components/SkTimPenilaiDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkTimPenilaiDocument.tsx
@@ -10,18 +10,13 @@ import type {
 
 interface SkTimPenilaiDocumentProps {
   skNumber: string;
+  skKap: string;
   menimbang: SkBuilderItem[];
   mengingat: SkBuilderItem[];
   memutuskan: SkTimPenilaiMemutuskan;
   kepalaBalai: SkKepalaBalai;
   tembusan: SkBuilderItem[];
   susunanTimPenilai: TimPenilaiAnggota[];
-}
-
-// SK Tim Penilai uses a custom KAP suffix (KAP.06.01/B) — different from getSkNumberSuffix() which is KAP.05.
-function getTimPenilaiNumberSuffix(date = new Date()) {
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  return `K.18/TU/KAP.06.01/B/${month}/${date.getFullYear()}`;
 }
 
 function renderKeduaText(text: string) {
@@ -483,6 +478,7 @@ export function handlePrintSkTimPenilai() {
 
 export function SkTimPenilaiDocument({
   skNumber,
+  skKap,
   menimbang,
   mengingat,
   memutuskan,
@@ -491,7 +487,8 @@ export function SkTimPenilaiDocument({
   susunanTimPenilai,
 }: SkTimPenilaiDocumentProps) {
   const today = new Date();
-  const skNumberText = `SK.${skNumber.trim() || "____"}/${getTimPenilaiNumberSuffix(today)}`;
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  const skNumberText = `SK.${skNumber.trim() || "____"}/K.18/TU/${skKap.trim() || "KAP.06.01"}/B/${month}/${today.getFullYear()}`;
   const mengingatTexts = mengingat.map((m) => m.text);
 
   const pageStyle: React.CSSProperties = {

--- a/frontend/src/app/bmn/auction-candidates/_components/SpTugasDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SpTugasDocument.tsx
@@ -6,12 +6,13 @@ import type { SkKepalaBalai } from "../_lib/sk-defaults";
 
 interface SpTugasDocumentProps {
   number: string;
+  kap: string;
   kepalaBalai: SkKepalaBalai;
 }
 
-function buildNomorText(number: string, today: Date) {
+function buildNomorText(number: string, kap: string, today: Date) {
   const month = String(today.getMonth() + 1).padStart(2, "0");
-  return `SM.${number.trim() || "40"}/K.18/TU/KAP.06.01/${month}/${today.getFullYear()}`;
+  return `SM.${number.trim() || "____"}/K.18/TU/${kap.trim() || "KAP.06.01"}/B/${month}/${today.getFullYear()}`;
 }
 
 export function handlePrintSpTugas() {
@@ -62,9 +63,9 @@ export function handlePrintSpTugas() {
   setTimeout(() => printWindow.print(), 500);
 }
 
-export function SpTugasDocument({ number, kepalaBalai }: SpTugasDocumentProps) {
+export function SpTugasDocument({ number, kap, kepalaBalai }: SpTugasDocumentProps) {
   const today = new Date();
-  const nomorText = buildNomorText(number, today);
+  const nomorText = buildNomorText(number, kap, today);
 
   return (
     <div id="sp-tugas-print-root" className="sp-tugas-print-root">

--- a/frontend/src/app/bmn/auction-candidates/_components/SptjLimitDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SptjLimitDocument.tsx
@@ -6,12 +6,13 @@ import type { SkKepalaBalai } from "../_lib/sk-defaults";
 
 interface SptjLimitDocumentProps {
   number: string;
+  kap: string;
   kepalaBalai: SkKepalaBalai;
 }
 
-function buildNomorText(number: string, today: Date) {
+function buildNomorText(number: string, kap: string, today: Date) {
   const month = String(today.getMonth() + 1).padStart(2, "0");
-  return `SM.${number.trim() || "41"}/K.18/TU/KAP.06.01/${month}/${today.getFullYear()}`;
+  return `SM.${number.trim() || "____"}/K.18/TU/${kap.trim() || "KAP.06.01"}/B/${month}/${today.getFullYear()}`;
 }
 
 export function handlePrintSptjLimit() {
@@ -72,9 +73,9 @@ export function handlePrintSptjLimit() {
   setTimeout(() => printWindow.print(), 500);
 }
 
-export function SptjLimitDocument({ number, kepalaBalai }: SptjLimitDocumentProps) {
+export function SptjLimitDocument({ number, kap, kepalaBalai }: SptjLimitDocumentProps) {
   const today = new Date();
-  const nomorText = buildNomorText(number, today);
+  const nomorText = buildNomorText(number, kap, today);
 
   return (
     <div id="sptj-limit-print-root" className="sptj-limit-print-root">

--- a/frontend/src/app/bmn/auction-candidates/_components/SptjmDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SptjmDocument.tsx
@@ -6,12 +6,13 @@ import type { SkKepalaBalai } from "../_lib/sk-defaults";
 
 interface SptjmDocumentProps {
   number: string;
+  kap: string;
   kepalaBalai: SkKepalaBalai;
 }
 
-function buildNomorText(number: string, today: Date) {
+function buildNomorText(number: string, kap: string, today: Date) {
   const month = String(today.getMonth() + 1).padStart(2, "0");
-  return `SPTJM.${number.trim() || "202"}/K.18/TU/KAP.06.01/${month}/${today.getFullYear()}`;
+  return `SPTJM.${number.trim() || "____"}/K.18/TU/${kap.trim() || "KAP.06.01"}/B/${month}/${today.getFullYear()}`;
 }
 
 export function handlePrintSptjm() {
@@ -66,9 +67,9 @@ export function handlePrintSptjm() {
   setTimeout(() => printWindow.print(), 500);
 }
 
-export function SptjmDocument({ number, kepalaBalai }: SptjmDocumentProps) {
+export function SptjmDocument({ number, kap, kepalaBalai }: SptjmDocumentProps) {
   const today = new Date();
-  const nomorText = buildNomorText(number, today);
+  const nomorText = buildNomorText(number, kap, today);
 
   return (
     <div id="sptjm-print-root" className="sptjm-print-root">

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/BaPemeriksaanSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/BaPemeriksaanSection.tsx
@@ -12,6 +12,7 @@ import type { EmployeeOption } from "../../_hooks/useEmployeeOptions";
 interface BaPemeriksaanSectionProps {
   assets: AuctionAsset[];
   number: string;
+  kap: string;
   stNumber: string;
   stTanggal: string;
   kepalaBalai: SkKepalaBalai;
@@ -27,6 +28,7 @@ interface BaPemeriksaanSectionProps {
 export function BaPemeriksaanSection({
   assets,
   number,
+  kap,
   stNumber,
   stTanggal,
   kepalaBalai,
@@ -64,6 +66,7 @@ export function BaPemeriksaanSection({
         <div>
           <BaPemeriksaanDocument
             number={number}
+            kap={kap}
             pemeriksaList={pemeriksaList}
             stNumber={stNumber}
             stTanggal={stTanggal}

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/NotaDinasSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/NotaDinasSection.tsx
@@ -10,6 +10,7 @@ import { newSkBuilderItem } from "../../_lib/sk-defaults";
 interface NotaDinasSectionProps {
   assets: AuctionAsset[];
   number: string;
+  kap: string;
   kepalaBalai: SkKepalaBalai;
   perihal: string;
   setPerihal: (v: string) => void;
@@ -32,6 +33,7 @@ const inputCls =
 export function NotaDinasSection({
   assets,
   number,
+  kap,
   kepalaBalai,
   perihal,
   setPerihal,
@@ -139,6 +141,7 @@ export function NotaDinasSection({
         <div>
           <NotaDinasDocument
             number={number}
+            kap={kap}
             assets={assets}
             kepalaBalai={kepalaBalai}
             perihal={perihal}

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/PermohonanKpknlSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/PermohonanKpknlSection.tsx
@@ -10,6 +10,7 @@ import { newSkBuilderItem } from "../../_lib/sk-defaults";
 interface PermohonanKpknlSectionProps {
   assets: AuctionAsset[];
   number: string;
+  kap: string;
   kepalaBalai: SkKepalaBalai;
   perihal: string;
   setPerihal: (v: string) => void;
@@ -30,6 +31,7 @@ const inputCls =
 export function PermohonanKpknlSection({
   assets,
   number,
+  kap,
   kepalaBalai,
   perihal,
   setPerihal,
@@ -123,6 +125,7 @@ export function PermohonanKpknlSection({
         <div>
           <PermohonanKpknlDocument
             number={number}
+            kap={kap}
             assets={assets}
             kepalaBalai={kepalaBalai}
             perihal={perihal}

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/SkKebenaranSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/SkKebenaranSection.tsx
@@ -9,11 +9,12 @@ import type { SkKepalaBalai } from "../../_lib/sk-defaults";
 interface SkKebenaranSectionProps {
   assets: AuctionAsset[];
   number: string;
+  kap: string;
   kepalaBalai: SkKepalaBalai;
   onPrint: () => void;
 }
 
-export function SkKebenaranSection({ assets, number, kepalaBalai, onPrint }: SkKebenaranSectionProps) {
+export function SkKebenaranSection({ assets, number, kap, kepalaBalai, onPrint }: SkKebenaranSectionProps) {
   return (
     <section id="sk-kebenaran-preview" className="space-y-4">
       <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
@@ -28,6 +29,7 @@ export function SkKebenaranSection({ assets, number, kepalaBalai, onPrint }: SkK
       </div>
       <SkKebenaranDokumenDocument
         number={number}
+        kap={kap}
         assets={assets}
         kepalaBalai={kepalaBalai}
       />

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/SkPanitiaSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/SkPanitiaSection.tsx
@@ -11,6 +11,7 @@ import type { EmployeeOption } from "../../_hooks/useEmployeeOptions";
 
 interface SkPanitiaSectionProps {
   skPanitiaNumber: string;
+  skPanitiaKap: string;
   panitiaMenimbang: SkBuilderItem[];
   setPanitiaMenimbang: (items: SkBuilderItem[]) => void;
   panitiaMengingat: SkBuilderItem[];
@@ -32,6 +33,7 @@ interface SkPanitiaSectionProps {
 
 export function SkPanitiaSection({
   skPanitiaNumber,
+  skPanitiaKap,
   panitiaMenimbang,
   setPanitiaMenimbang,
   panitiaMengingat,
@@ -89,6 +91,7 @@ export function SkPanitiaSection({
         <div>
           <SkPanitiaDocument
             skNumber={skPanitiaNumber}
+            skKap={skPanitiaKap}
             menimbang={panitiaMenimbang}
             mengingat={panitiaMengingat}
             memutuskan={panitiaMemutuskan}

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/SkPenghentianSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/SkPenghentianSection.tsx
@@ -10,6 +10,7 @@ import type { SkBuilderItem, SkKepalaBalai, SkMemutuskan } from "../../_lib/sk-d
 interface SkPenghentianSectionProps {
   assets: AuctionAsset[];
   skNumber: string;
+  skKap: string;
   menimbang: SkBuilderItem[];
   setMenimbang: (items: SkBuilderItem[]) => void;
   mengingat: SkBuilderItem[];
@@ -26,6 +27,7 @@ interface SkPenghentianSectionProps {
 export function SkPenghentianSection({
   assets,
   skNumber,
+  skKap,
   menimbang,
   setMenimbang,
   mengingat,
@@ -69,6 +71,7 @@ export function SkPenghentianSection({
           <SkPenghentianDocument
             assets={assets}
             skNumber={skNumber}
+            skKap={skKap}
             menimbang={menimbang}
             mengingat={mengingat}
             memutuskan={memutuskan}

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/SkTimPenilaiSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/SkTimPenilaiSection.tsx
@@ -14,6 +14,7 @@ import type { EmployeeOption } from "../../_hooks/useEmployeeOptions";
 
 interface SkTimPenilaiSectionProps {
   skTimPenilaiNumber: string;
+  skTimPenilaiKap: string;
   timPenilaiMenimbang: SkBuilderItem[];
   setTimPenilaiMenimbang: (items: SkBuilderItem[]) => void;
   timPenilaiMengingat: SkBuilderItem[];
@@ -35,6 +36,7 @@ interface SkTimPenilaiSectionProps {
 
 export function SkTimPenilaiSection({
   skTimPenilaiNumber,
+  skTimPenilaiKap,
   timPenilaiMenimbang,
   setTimPenilaiMenimbang,
   timPenilaiMengingat,
@@ -92,6 +94,7 @@ export function SkTimPenilaiSection({
         <div>
           <SkTimPenilaiDocument
             skNumber={skTimPenilaiNumber}
+            skKap={skTimPenilaiKap}
             menimbang={timPenilaiMenimbang}
             mengingat={timPenilaiMengingat}
             memutuskan={timPenilaiMemutuskan}

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/SpTugasSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/SpTugasSection.tsx
@@ -7,11 +7,12 @@ import type { SkKepalaBalai } from "../../_lib/sk-defaults";
 
 interface SpTugasSectionProps {
   number: string;
+  kap: string;
   kepalaBalai: SkKepalaBalai;
   onPrint: () => void;
 }
 
-export function SpTugasSection({ number, kepalaBalai, onPrint }: SpTugasSectionProps) {
+export function SpTugasSection({ number, kap, kepalaBalai, onPrint }: SpTugasSectionProps) {
   return (
     <section id="sp-tugas-preview" className="space-y-4">
       <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
@@ -24,7 +25,7 @@ export function SpTugasSection({ number, kepalaBalai, onPrint }: SpTugasSectionP
           Cetak / Save PDF
         </Button>
       </div>
-      <SpTugasDocument number={number} kepalaBalai={kepalaBalai} />
+      <SpTugasDocument number={number} kap={kap} kepalaBalai={kepalaBalai} />
     </section>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/SptjLimitSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/SptjLimitSection.tsx
@@ -7,11 +7,12 @@ import type { SkKepalaBalai } from "../../_lib/sk-defaults";
 
 interface SptjLimitSectionProps {
   number: string;
+  kap: string;
   kepalaBalai: SkKepalaBalai;
   onPrint: () => void;
 }
 
-export function SptjLimitSection({ number, kepalaBalai, onPrint }: SptjLimitSectionProps) {
+export function SptjLimitSection({ number, kap, kepalaBalai, onPrint }: SptjLimitSectionProps) {
   return (
     <section id="sptj-limit-preview" className="space-y-4">
       <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
@@ -24,7 +25,7 @@ export function SptjLimitSection({ number, kepalaBalai, onPrint }: SptjLimitSect
           Cetak / Save PDF
         </Button>
       </div>
-      <SptjLimitDocument number={number} kepalaBalai={kepalaBalai} />
+      <SptjLimitDocument number={number} kap={kap} kepalaBalai={kepalaBalai} />
     </section>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/SptjmSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/SptjmSection.tsx
@@ -7,11 +7,12 @@ import type { SkKepalaBalai } from "../../_lib/sk-defaults";
 
 interface SptjmSectionProps {
   number: string;
+  kap: string;
   kepalaBalai: SkKepalaBalai;
   onPrint: () => void;
 }
 
-export function SptjmSection({ number, kepalaBalai, onPrint }: SptjmSectionProps) {
+export function SptjmSection({ number, kap, kepalaBalai, onPrint }: SptjmSectionProps) {
   return (
     <section id="sptjm-preview" className="space-y-4">
       <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
@@ -24,7 +25,7 @@ export function SptjmSection({ number, kepalaBalai, onPrint }: SptjmSectionProps
           Cetak / Save PDF
         </Button>
       </div>
-      <SptjmDocument number={number} kepalaBalai={kepalaBalai} />
+      <SptjmDocument number={number} kap={kap} kepalaBalai={kepalaBalai} />
     </section>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/_hooks/useDocumentNumbers.ts
+++ b/frontend/src/app/bmn/auction-candidates/_hooks/useDocumentNumbers.ts
@@ -10,43 +10,76 @@ export interface UseDocumentNumbersResult {
   setBaKap: React.Dispatch<React.SetStateAction<string>>;
   skNumber: string;
   setSkNumber: React.Dispatch<React.SetStateAction<string>>;
+  skKap: string;
+  setSkKap: React.Dispatch<React.SetStateAction<string>>;
   skPanitiaNumber: string;
   setSkPanitiaNumber: React.Dispatch<React.SetStateAction<string>>;
+  skPanitiaKap: string;
+  setSkPanitiaKap: React.Dispatch<React.SetStateAction<string>>;
   skTimPenilaiNumber: string;
   setSkTimPenilaiNumber: React.Dispatch<React.SetStateAction<string>>;
+  skTimPenilaiKap: string;
+  setSkTimPenilaiKap: React.Dispatch<React.SetStateAction<string>>;
   sptjLimitNumber: string;
   setSptjLimitNumber: React.Dispatch<React.SetStateAction<string>>;
+  sptjLimitKap: string;
+  setSptjLimitKap: React.Dispatch<React.SetStateAction<string>>;
   sptjmNumber: string;
   setSptjmNumber: React.Dispatch<React.SetStateAction<string>>;
+  sptjmKap: string;
+  setSptjmKap: React.Dispatch<React.SetStateAction<string>>;
   spTugasNumber: string;
   setSpTugasNumber: React.Dispatch<React.SetStateAction<string>>;
+  spTugasKap: string;
+  setSpTugasKap: React.Dispatch<React.SetStateAction<string>>;
   skKebenaranNumber: string;
   setSkKebenaranNumber: React.Dispatch<React.SetStateAction<string>>;
+  skKebenaranKap: string;
+  setSkKebenaranKap: React.Dispatch<React.SetStateAction<string>>;
   baPemeriksaanNumber: string;
   setBaPemeriksaanNumber: React.Dispatch<React.SetStateAction<string>>;
+  baPemeriksaanKap: string;
+  setBaPemeriksaanKap: React.Dispatch<React.SetStateAction<string>>;
   notaDinasNumber: string;
   setNotaDinasNumber: React.Dispatch<React.SetStateAction<string>>;
+  notaDinasKap: string;
+  setNotaDinasKap: React.Dispatch<React.SetStateAction<string>>;
   permohonanKpknlNumber: string;
   setPermohonanKpknlNumber: React.Dispatch<React.SetStateAction<string>>;
+  permohonanKpknlKap: string;
+  setPermohonanKpknlKap: React.Dispatch<React.SetStateAction<string>>;
   stNumber: string;
   setStNumber: React.Dispatch<React.SetStateAction<string>>;
   stTanggal: string;
   setStTanggal: React.Dispatch<React.SetStateAction<string>>;
 }
 
+const DEFAULT_KAP = "KAP.06.01";
+const DEFAULT_SK_KAP = "KAP.05.01";
+
 export function useDocumentNumbers(): UseDocumentNumbersResult {
   const [baNumber, setBaNumber] = useState("");
-  const [baKap, setBaKap] = useState("KAP.06.01");
+  const [baKap, setBaKap] = useState(DEFAULT_KAP);
   const [skNumber, setSkNumber] = useState("");
+  const [skKap, setSkKap] = useState(DEFAULT_SK_KAP);
   const [skPanitiaNumber, setSkPanitiaNumber] = useState("");
-  const [skTimPenilaiNumber, setSkTimPenilaiNumber] = useState("107");
-  const [sptjLimitNumber, setSptjLimitNumber] = useState("41");
-  const [sptjmNumber, setSptjmNumber] = useState("202");
-  const [spTugasNumber, setSpTugasNumber] = useState("40");
-  const [skKebenaranNumber, setSkKebenaranNumber] = useState("200");
-  const [baPemeriksaanNumber, setBaPemeriksaanNumber] = useState("158");
-  const [notaDinasNumber, setNotaDinasNumber] = useState("270");
-  const [permohonanKpknlNumber, setPermohonanKpknlNumber] = useState("331");
+  const [skPanitiaKap, setSkPanitiaKap] = useState(DEFAULT_SK_KAP);
+  const [skTimPenilaiNumber, setSkTimPenilaiNumber] = useState("");
+  const [skTimPenilaiKap, setSkTimPenilaiKap] = useState(DEFAULT_KAP);
+  const [sptjLimitNumber, setSptjLimitNumber] = useState("");
+  const [sptjLimitKap, setSptjLimitKap] = useState(DEFAULT_KAP);
+  const [sptjmNumber, setSptjmNumber] = useState("");
+  const [sptjmKap, setSptjmKap] = useState(DEFAULT_KAP);
+  const [spTugasNumber, setSpTugasNumber] = useState("");
+  const [spTugasKap, setSpTugasKap] = useState(DEFAULT_KAP);
+  const [skKebenaranNumber, setSkKebenaranNumber] = useState("");
+  const [skKebenaranKap, setSkKebenaranKap] = useState(DEFAULT_KAP);
+  const [baPemeriksaanNumber, setBaPemeriksaanNumber] = useState("");
+  const [baPemeriksaanKap, setBaPemeriksaanKap] = useState(DEFAULT_KAP);
+  const [notaDinasNumber, setNotaDinasNumber] = useState("");
+  const [notaDinasKap, setNotaDinasKap] = useState(DEFAULT_KAP);
+  const [permohonanKpknlNumber, setPermohonanKpknlNumber] = useState("");
+  const [permohonanKpknlKap, setPermohonanKpknlKap] = useState(DEFAULT_KAP);
   const [stNumber, setStNumber] = useState("");
   const [stTanggal, setStTanggal] = useState(formatDateLong(new Date()));
 
@@ -57,24 +90,44 @@ export function useDocumentNumbers(): UseDocumentNumbersResult {
     setBaKap,
     skNumber,
     setSkNumber,
+    skKap,
+    setSkKap,
     skPanitiaNumber,
     setSkPanitiaNumber,
+    skPanitiaKap,
+    setSkPanitiaKap,
     skTimPenilaiNumber,
     setSkTimPenilaiNumber,
+    skTimPenilaiKap,
+    setSkTimPenilaiKap,
     sptjLimitNumber,
     setSptjLimitNumber,
+    sptjLimitKap,
+    setSptjLimitKap,
     sptjmNumber,
     setSptjmNumber,
+    sptjmKap,
+    setSptjmKap,
     spTugasNumber,
     setSpTugasNumber,
+    spTugasKap,
+    setSpTugasKap,
     skKebenaranNumber,
     setSkKebenaranNumber,
+    skKebenaranKap,
+    setSkKebenaranKap,
     baPemeriksaanNumber,
     setBaPemeriksaanNumber,
+    baPemeriksaanKap,
+    setBaPemeriksaanKap,
     notaDinasNumber,
     setNotaDinasNumber,
+    notaDinasKap,
+    setNotaDinasKap,
     permohonanKpknlNumber,
     setPermohonanKpknlNumber,
+    permohonanKpknlKap,
+    setPermohonanKpknlKap,
     stNumber,
     setStNumber,
     stTanggal,

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -288,6 +288,7 @@ export default function BmnAuctionCandidatesPage() {
         <SkPenghentianSection
           assets={orderedSelectedAssets}
           skNumber={docNumbers.skNumber}
+          skKap={docNumbers.skKap}
           menimbang={sk.menimbang}
           setMenimbang={sk.setMenimbang}
           mengingat={sk.mengingat}
@@ -305,6 +306,7 @@ export default function BmnAuctionCandidatesPage() {
       {docToggles.showSkPanitia && orderedIds.length > 0 && (
         <SkPanitiaSection
           skPanitiaNumber={docNumbers.skPanitiaNumber}
+          skPanitiaKap={docNumbers.skPanitiaKap}
           panitiaMenimbang={skPanitia.panitiaMenimbang}
           setPanitiaMenimbang={skPanitia.setPanitiaMenimbang}
           panitiaMengingat={skPanitia.panitiaMengingat}
@@ -328,6 +330,7 @@ export default function BmnAuctionCandidatesPage() {
       {docToggles.showSkTimPenilai && orderedIds.length > 0 && (
         <SkTimPenilaiSection
           skTimPenilaiNumber={docNumbers.skTimPenilaiNumber}
+          skTimPenilaiKap={docNumbers.skTimPenilaiKap}
           timPenilaiMenimbang={skTimPenilai.timPenilaiMenimbang}
           setTimPenilaiMenimbang={skTimPenilai.setTimPenilaiMenimbang}
           timPenilaiMengingat={skTimPenilai.timPenilaiMengingat}
@@ -351,6 +354,7 @@ export default function BmnAuctionCandidatesPage() {
       {docToggles.showSptjLimit && (
         <SptjLimitSection
           number={docNumbers.sptjLimitNumber}
+          kap={docNumbers.sptjLimitKap}
           kepalaBalai={sk.kepalaBalai}
           onPrint={handlePrintSptjLimitDoc}
         />
@@ -359,6 +363,7 @@ export default function BmnAuctionCandidatesPage() {
       {docToggles.showSptjm && (
         <SptjmSection
           number={docNumbers.sptjmNumber}
+          kap={docNumbers.sptjmKap}
           kepalaBalai={sk.kepalaBalai}
           onPrint={handlePrintSptjmDoc}
         />
@@ -367,6 +372,7 @@ export default function BmnAuctionCandidatesPage() {
       {docToggles.showSpTugas && (
         <SpTugasSection
           number={docNumbers.spTugasNumber}
+          kap={docNumbers.spTugasKap}
           kepalaBalai={sk.kepalaBalai}
           onPrint={handlePrintSpTugasDoc}
         />
@@ -376,6 +382,7 @@ export default function BmnAuctionCandidatesPage() {
         <SkKebenaranSection
           assets={orderedSelectedAssets}
           number={docNumbers.skKebenaranNumber}
+          kap={docNumbers.skKebenaranKap}
           kepalaBalai={sk.kepalaBalai}
           onPrint={handlePrintSkKebenaranDoc}
         />
@@ -385,6 +392,7 @@ export default function BmnAuctionCandidatesPage() {
         <BaPemeriksaanSection
           assets={orderedSelectedAssets}
           number={docNumbers.baPemeriksaanNumber}
+          kap={docNumbers.baPemeriksaanKap}
           stNumber={docNumbers.stNumber}
           stTanggal={docNumbers.stTanggal}
           kepalaBalai={sk.kepalaBalai}
@@ -402,6 +410,7 @@ export default function BmnAuctionCandidatesPage() {
         <NotaDinasSection
           assets={orderedSelectedAssets}
           number={docNumbers.notaDinasNumber}
+          kap={docNumbers.notaDinasKap}
           kepalaBalai={sk.kepalaBalai}
           perihal={notaKpknl.ndPerihal}
           setPerihal={notaKpknl.setNdPerihal}
@@ -423,6 +432,7 @@ export default function BmnAuctionCandidatesPage() {
         <PermohonanKpknlSection
           assets={orderedSelectedAssets}
           number={docNumbers.permohonanKpknlNumber}
+          kap={docNumbers.permohonanKpknlKap}
           kepalaBalai={sk.kepalaBalai}
           perihal={notaKpknl.pkPerihal}
           setPerihal={notaKpknl.setPkPerihal}


### PR DESCRIPTION
## Summary

Issue ini memperbaiki KOP dan menyamakan format nomor surat di seluruh dokumen `/bmn/auction-candidates`.

## KOP Changes (header-new.png → header-terbaru.png)
4 dokumen utama sekarang konsisten dengan BA Koreksi:
- BA Pemeriksaan BMN
- SK Kebenaran Fotokopi Dokumen
- Surat Permohonan Persetujuan KPKNL
- Nota Dinas Permohonan KSDAE

## Format Nomor Unified
Semua 11 dokumen sekarang punya format konsisten:
```
{prefix}.{nomor}/K.18/TU/{KAP}/B/{MM}/{YYYY}
```

Sebelumnya SK Penghentian dan SK Panitia tidak punya `/B/`. Sekarang ditambahkan.

## Editable KAP Everywhere
Sebelumnya hanya BA Koreksi yang KAP-nya editable. Sekarang **semua 11 dokumen** punya 2 input editable di panel "Pengaturan Nomor Surat":
1. Nomor (placeholder `____`)
2. KAP (default sesuai dokumen)

## Default Values
| Dokumen | Default KAP |
|---------|-------------|
| BA Koreksi | `KAP.06.01` |
| SK Penghentian | `KAP.05.01` *(khusus)* |
| SK Panitia | `KAP.05.01` *(khusus)* |
| SK Tim Penilai | `KAP.06.01` |
| SPTJ Limit | `KAP.06.01` |
| SPTJM | `KAP.06.01` |
| SP Tugas | `KAP.06.01` |
| SK Kebenaran | `KAP.06.01` |
| BA Pemeriksaan | `KAP.06.01` |
| Nota Dinas | `KAP.06.01` |
| Permohonan KPKNL | `KAP.06.01` |

Semua state nomor default kosong (placeholder `____`).

## Files Changed (23)
- 1 hook (`useDocumentNumbers.ts`) — tambah 11 pasang state KAP
- 1 panel UI (`DocumentNumberInputs.tsx`) — 2 input per dokumen
- 11 Document components — terima `kap` prop
- 9 Section wrappers — forward `kap` prop
- `page.tsx` — pass `kap` props ke setiap section

## Validation
- ✅ `npx eslint --max-warnings=0` clean
- ✅ `npx tsc --noEmit` clean
- ✅ `npm run build` clean (59/59 static pages)

Closes #380
