### PR TITLE
refactor(bmn): DRY shared components untuk dokumen auction-candidates (#394)

### DIFF
--- a/frontend/src/app/bmn/auction-candidates/_components/PernyataanDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/PernyataanDocument.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { formatDateLong } from "../_lib/auction-helpers";
+import type { SkKepalaBalai } from "../_lib/sk-defaults";
+
+interface PernyataanDocumentProps {
+  /** DOM id used as both the print root id and the scoped style class. */
+  rootId: string;
+  /** Document title rendered in the centered heading (e.g. "SURAT PERNYATAAN"). */
+  title: string;
+  /** Fully-built "Nomor" string shown beneath the title. */
+  nomorText: string;
+  /** Date used in the signature block; defaults to now. */
+  today?: Date;
+  kepalaBalai: SkKepalaBalai;
+  /** Document body (the paragraphs/list unique to each pernyataan). */
+  children: ReactNode;
+}
+
+/**
+ * Shared shell for the BMN "Surat Pernyataan" family. Renders the scoped print
+ * styles, KOP header, centered title + nomor, the body, and the Kepala Balai
+ * signature block. The identity block lives in {@link PernyataanIdentity}.
+ */
+export function PernyataanDocument({
+  rootId,
+  title,
+  nomorText,
+  today = new Date(),
+  kepalaBalai,
+  children,
+}: PernyataanDocumentProps) {
+  return (
+    <div id={rootId} className={rootId}>
+      <style jsx global>{`
+        .${rootId} .doc-editable { outline: none; border-bottom: 1px dashed transparent; transition: border-bottom-color 0.15s ease; }
+        .${rootId} .doc-editable:hover { border-bottom-color: #94a3b8; }
+        .${rootId} .doc-editable:focus { border-bottom-color: #64748b; }
+        @media print {
+          @page { size: A4; margin: 0 0 28mm 0; }
+          body * { visibility: hidden; }
+          .${rootId}, .${rootId} * { visibility: visible; }
+          .${rootId} {
+            position: absolute; left: 0; top: 0; width: 100%;
+            background: white; color: black;
+            font-family: 'Bookman Old Style', Georgia, serif;
+            font-size: 11pt; line-height: 1.4; margin: 0; padding: 0;
+          }
+          .doc-page { width: 210mm; margin: 0 auto; padding: 5mm 20mm 0; box-shadow: none !important; }
+          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; }
+          .doc-header img { max-width: 196mm !important; }
+          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; }
+          .doc-editable { border-bottom: none !important; }
+        }
+      `}</style>
+
+      <article
+        className="doc-page mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
+        style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.4" }}
+      >
+        <div className="doc-header -mx-18 text-center">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
+        </div>
+
+        <div className="doc-title mt-2 text-center font-bold leading-snug">
+          <p className="m-0">{title}</p>
+          <p className="m-0 font-normal">Nomor : {nomorText}</p>
+        </div>
+
+        <div className="doc-body doc-text-block mx-auto mt-4 w-[166mm] space-y-3 text-justify">
+          {children}
+        </div>
+
+        <div className="signature mt-6 ml-auto w-80">
+          <p className="m-0">Samarinda, {formatDateLong(today)}</p>
+          <p className="m-0">Kepala Balai,</p>
+          <div className="ttd-placeholder mt-8 box-border h-28 pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
+          <p contentEditable suppressContentEditableWarning className="doc-editable m-0 mt-8">{kepalaBalai.nama}</p>
+          <p contentEditable suppressContentEditableWarning className="doc-editable m-0">NIP. {kepalaBalai.nip}</p>
+        </div>
+      </article>
+    </div>
+  );
+}
+
+/**
+ * The "Yang bertanda tangan di bawah ini" identity grid shared by every
+ * surat-pernyataan document.
+ */
+export function PernyataanIdentity({ kepalaBalai }: { kepalaBalai: SkKepalaBalai }) {
+  return (
+    <div className="doc-identity grid grid-cols-[28mm_5mm_minmax(0,1fr)]">
+      <span>Nama</span>
+      <span className="colon text-center">:</span>
+      <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nama}</span>
+      <span>NIP</span>
+      <span className="colon text-center">:</span>
+      <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nip}</span>
+      <span>Pangkat/Gol</span>
+      <span className="colon text-center">:</span>
+      <span contentEditable suppressContentEditableWarning className="doc-editable">Pembina Tk.I / IV b</span>
+      <span>Jabatan</span>
+      <span className="colon text-center">:</span>
+      <span contentEditable suppressContentEditableWarning className="doc-editable">Kepala Balai KSDA Kalimantan Timur</span>
+    </div>
+  );
+}

--- a/frontend/src/app/bmn/auction-candidates/_components/SkPanitiaDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkPanitiaDocument.tsx
@@ -2,6 +2,7 @@
 
 import { toast } from "sonner";
 import { formatDateLong } from "../_lib/auction-helpers";
+import { runSkPagination } from "../_lib/sk-print";
 import type {
   SkBuilderItem,
   SkKepalaBalai,
@@ -195,272 +196,17 @@ export function handlePrintSkPanitia() {
   `);
   printWindow.document.close();
   printWindow.focus();
-  setTimeout(() => {
-    try {
-      const doc = printWindow.document;
-      const body = doc.body;
-      if (!body) { printWindow.print(); return; }
-
-      const paginationStyle = doc.createElement("style");
-      paginationStyle.textContent = `
-        @page skp-main { size: A4; margin: 0; }
-        @page skp-main:first { size: A4; margin: 0; }
-        .skp-print-root .skp-page.skp-main-document.skp-main-paginated {
-          height: 297mm !important;
-          min-height: 297mm !important;
-          padding: 5mm 20mm 28mm !important;
-          overflow: hidden !important;
-          position: relative !important;
-          box-shadow: none !important;
-        }
-        .skp-print-root .skp-page.skp-main-document.skp-main-paginated.skp-main-continuation-page {
-          padding-top: 18mm !important;
-        }
-        .skp-print-root .skp-main-document.skp-main-page-break {
-          page-break-after: always;
-          break-after: page;
-        }
-        .skp-main-paginated .skp-paginated-field-section + .skp-paginated-field-section {
-          margin-top: 0 !important;
-        }
-        .skp-main-paginated .skp-paginated-field-section.skp-section-start {
-          margin-top: 0.5rem !important;
-        }
-        .skp-continuation-word {
-          position: absolute !important;
-          right: 23mm !important;
-          bottom: 31mm !important;
-          width: 163mm !important;
-          height: 0 !important;
-          line-height: 11pt !important;
-          overflow: visible !important;
-          white-space: nowrap !important;
-          text-align: right !important;
-          margin: 0 !important;
-          padding: 0 !important;
-          font-weight: normal !important;
-          font-size: 11pt !important;
-          z-index: 20 !important;
-        }
-      `;
-      body.appendChild(paginationStyle);
-
-      void body.offsetHeight;
-
-      const mmToPx = 96 / 25.4;
-      const firstPageContentH = 264 * mmToPx;
-      const continuationContentH = 251 * mmToPx;
-      const markerReserveH = 9 * mmToPx;
-
-      const mainDoc = doc.querySelector(".skp-main-document");
-      if (!mainDoc) { printWindow.print(); return; }
-
-      const root = mainDoc.parentElement;
-      if (!root) { printWindow.print(); return; }
-
-      const continuationLabel = (num: string, text: string) => {
-        const firstWord = text.trim().split(/\s+/)[0] || "";
-        return `${num.trim()} ${firstWord ? `${firstWord}.....` : "....."}`;
-      };
-
-      const cloneElement = <T extends HTMLElement>(el: T) => el.cloneNode(true) as T;
-
-      const createFieldBlock = (
-        sectionLabel: string,
-        item: HTMLElement,
-        showSectionLabel: boolean,
-        marginTop = false,
-      ) => {
-        const section = doc.createElement("div");
-        section.className = "skp-field-section skp-paginated-field-section";
-        section.style.marginTop = marginTop ? "0.75rem" : "0";
-        if (marginTop) section.classList.add("skp-section-start");
-
-        const label = doc.createElement("div");
-        label.className = "skp-field-label";
-        label.textContent = showSectionLabel ? sectionLabel : "";
-
-        const colon = doc.createElement("div");
-        colon.className = "skp-field-colon";
-        colon.textContent = showSectionLabel ? ":" : "";
-
-        const list = doc.createElement("div");
-        list.className = "skp-mengingat-list";
-        const itemClone = cloneElement(item);
-        itemClone.style.paddingTop = "0";
-        list.appendChild(itemClone);
-
-        section.append(label, colon, list);
-        return section;
-      };
-
-      const createDecisionBlock = (rows: HTMLElement[]) => {
-        const table = doc.createElement("table");
-        table.className = "skp-mengingat-table";
-        table.style.borderCollapse = "collapse";
-
-        const tbody = doc.createElement("tbody");
-        rows.forEach((row) => tbody.appendChild(cloneElement(row)));
-        table.appendChild(tbody);
-        return table;
-      };
-
-      const createMemutuskanMenetapkanBlock = (heading: HTMLElement, row: HTMLElement) => {
-        const block = doc.createElement("div");
-        block.appendChild(cloneElement(heading));
-        block.appendChild(createDecisionBlock([row]));
-        return block;
-      };
-
-      const makePage = (isFirstPage: boolean) => {
-        const page = doc.createElement("article");
-        page.className = "skp-page skp-page-ttd skp-main-document skp-main-paginated mx-auto max-w-[210mm] bg-white px-24 py-9 text-black";
-        if (!isFirstPage) page.classList.add("skp-main-continuation-page");
-        page.style.cssText = [
-          "width: 210mm",
-          "height: 297mm",
-          "min-height: 297mm",
-          "margin: 0 auto",
-          `padding: ${isFirstPage ? "5mm" : "18mm"} 20mm 28mm`,
-          "overflow: hidden",
-          "position: relative",
-          "box-sizing: border-box",
-          "background: white",
-          "color: black",
-        ].join("; ");
-
-        const flow = doc.createElement("div");
-        flow.className = "skp-main-flow";
-        page.appendChild(flow);
-
-        const bodyWrap = doc.createElement("div");
-        bodyWrap.className = "skp-body";
-        flow.appendChild(bodyWrap);
-
-        return { page, flow, bodyWrap };
-      };
-
-      const addContinuationWord = (page: HTMLElement, label: string) => {
-        const contWord = doc.createElement("p");
-        contWord.className = "skp-continuation-word";
-        contWord.textContent = label;
-        page.appendChild(contWord);
-      };
-
-      const measureFlowContentHeight = (flow: HTMLElement) => {
-        const flowTop = flow.getBoundingClientRect().top;
-        return Array.from(flow.children).reduce((maxBottom, child) => {
-          const rect = (child as HTMLElement).getBoundingClientRect();
-          return Math.max(maxBottom, rect.bottom - flowTop);
-        }, 0);
-      };
-
-      const measureOuterHeight = (el: HTMLElement) => {
-        const rect = el.getBoundingClientRect();
-        const style = printWindow.getComputedStyle(el);
-        const marginTop = Number.parseFloat(style.marginTop || "0") || 0;
-        const marginBottom = Number.parseFloat(style.marginBottom || "0") || 0;
-        return rect.height + marginTop + marginBottom;
-      };
-
-      const contentWrap = mainDoc.querySelector<HTMLElement>(".skp-subtitle");
-      const contentSections = contentWrap?.querySelector<HTMLElement>("div");
-      const fieldSections = contentSections?.querySelectorAll<HTMLElement>(":scope > .skp-field-section");
-      const menimbangItems = fieldSections?.[0]?.querySelectorAll<HTMLElement>(".skp-mengingat-item") || [];
-      const mengingatItems = fieldSections?.[1]?.querySelectorAll<HTMLElement>(".skp-mengingat-item") || [];
-
-      const explicitMemutuskanHeading = mainDoc.querySelector<HTMLElement>(".skp-memutuskan");
-      const explicitMemRows = Array.from(mainDoc.querySelectorAll<HTMLElement>(".skp-mengingat-row"));
-      const ketigaGroup = mainDoc.querySelector<HTMLElement>(".skp-ketiga-group");
-
-      let currentPage = makePage(true);
-      root.insertBefore(currentPage.page, mainDoc);
-
-      const kop = mainDoc.querySelector<HTMLElement>(".skp-kop");
-      const title = mainDoc.querySelector<HTMLElement>(".skp-title");
-      const intro = doc.createElement("div");
-      intro.className = "skp-subtitle skp-body";
-      const introParagraphs = Array.from(contentWrap?.children || []).filter((child) => {
-        return child.tagName === "P" && !(child as HTMLElement).classList.contains("skp-memutuskan");
-      });
-      introParagraphs.forEach((child) => intro.appendChild(cloneElement(child as HTMLElement)));
-
-      const firstBody = currentPage.bodyWrap;
-      currentPage.flow.insertBefore(intro, firstBody);
-      if (title) currentPage.flow.insertBefore(cloneElement(title), intro);
-      if (kop) currentPage.flow.insertBefore(cloneElement(kop), currentPage.flow.firstChild);
-      let currentUsedHeight = measureFlowContentHeight(currentPage.flow);
-
-      const blocks: { el: HTMLElement; label: string }[] = [];
-      Array.from(menimbangItems).forEach((item, index) => {
-        const num = item.querySelector("div:first-child")?.textContent || "";
-        const text = item.querySelector(".skp-mengingat-text")?.textContent || "";
-        blocks.push({
-          el: createFieldBlock("Menimbang", item, index === 0),
-          label: continuationLabel(num, text),
-        });
-      });
-
-      Array.from(mengingatItems).forEach((item, index) => {
-        const num = item.querySelector("div:first-child")?.textContent || "";
-        const text = item.querySelector(".skp-mengingat-text")?.textContent || "";
-        blocks.push({
-          el: createFieldBlock("Mengingat", item, index === 0, index === 0),
-          label: continuationLabel(num, text),
-        });
-      });
-
-      if (explicitMemutuskanHeading && explicitMemRows[0]) {
-        const memutuskanBlock = createMemutuskanMenetapkanBlock(explicitMemutuskanHeading, explicitMemRows[0]);
-        blocks.push({ el: memutuskanBlock, label: "MEMUTUSKAN....." });
-      } else if (explicitMemutuskanHeading) {
-        blocks.push({ el: cloneElement(explicitMemutuskanHeading), label: "MEMUTUSKAN....." });
-      } else if (explicitMemRows[0]) {
-        blocks.push({ el: createDecisionBlock([explicitMemRows[0]]), label: "Menetapkan....." });
-      }
-      if (explicitMemRows[1]) {
-        blocks.push({ el: createDecisionBlock([explicitMemRows[1]]), label: "KESATU....." });
-      }
-      if (explicitMemRows[2]) {
-        blocks.push({ el: createDecisionBlock([explicitMemRows[2]]), label: "KEDUA....." });
-      }
-      if (ketigaGroup) {
-        blocks.push({ el: cloneElement(ketigaGroup), label: "KETIGA....." });
-      }
-
-      blocks.forEach((block, index) => {
-        const isLastBlock = index === blocks.length - 1;
-        const contentLimit = currentPage.page.classList.contains("skp-main-continuation-page")
-          ? continuationContentH
-          : firstPageContentH;
-        const maxFlowHeight = contentLimit - (isLastBlock ? 0 : markerReserveH);
-        const markerSafeHeight = contentLimit - markerReserveH;
-
-        currentPage.bodyWrap.appendChild(block.el);
-        const blockHeight = measureOuterHeight(block.el);
-        const flowHeight = currentUsedHeight + blockHeight;
-        const canMoveToNextPage = currentPage.bodyWrap.children.length > 1;
-        if ((flowHeight > maxFlowHeight || (!isLastBlock && flowHeight > markerSafeHeight)) && canMoveToNextPage) {
-          currentPage.bodyWrap.removeChild(block.el);
-          currentPage.page.classList.add("skp-main-page-break");
-          addContinuationWord(currentPage.page, block.label);
-
-          currentPage = makePage(false);
-          root.insertBefore(currentPage.page, mainDoc);
-          currentPage.bodyWrap.appendChild(block.el);
-          currentUsedHeight = measureOuterHeight(block.el);
-        } else {
-          currentUsedHeight = flowHeight;
-        }
-      });
-
-      root.removeChild(mainDoc);
-
-    } catch {
-      // Silently fail — print without continuation words
-    }
-    setTimeout(() => printWindow.print(), 300);
-  }, 600);
+  setTimeout(
+    () =>
+      runSkPagination(printWindow, {
+        prefix: "skp",
+        sectionStartMarginTop: "0.5rem",
+        decisionRowLabels: ["KESATU.....", "KEDUA....."],
+        finalGroupClass: "skp-ketiga-group",
+        finalGroupLabel: "KETIGA.....",
+      }),
+    600,
+  );
 }
 
 
@@ -751,7 +497,7 @@ export function SkPanitiaDocument({
               <tr className="skp-mengingat-row">
                 <td style={{ width: "28mm", verticalAlign: "top" }}>Menetapkan</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top" }}>:</td>
-                <td style={{ verticalAlign: "top", textTransform: "uppercase", textAlign: "justify" }}>
+                <td style={{ verticalAlign: "top", textTransform: "uppercase", textAlign: "justify", fontWeight: "bold" }}>
                   {memutuskan.menetapkan}
                 </td>
               </tr>

--- a/frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkPenghentianDocument.tsx
@@ -7,6 +7,7 @@ import {
   formatPlainRupiah,
   formatDateLong,
 } from "../_lib/auction-helpers";
+import { runSkPagination } from "../_lib/sk-print";
 import type {
   SkBuilderItem,
   SkKepalaBalai,
@@ -174,278 +175,17 @@ export function handlePrintSk(orderedSelectedAssets: AuctionAsset[], _skNumber: 
   printWindow.document.close();
   printWindow.focus();
   // Wait for full render, then inject continuation words at page breaks, then print
-  setTimeout(() => {
-    try {
-      const doc = printWindow.document;
-      const body = doc.body;
-      if (!body) { printWindow.print(); return; }
-
-      const paginationStyle = doc.createElement("style");
-      paginationStyle.textContent = `
-        @page sk-main { size: A4; margin: 0; }
-        @page sk-main:first { size: A4; margin: 0; }
-        .sk-print-root .sk-page.sk-main-document.sk-main-paginated {
-          height: 297mm !important;
-          min-height: 297mm !important;
-          padding: 5mm 20mm 28mm !important;
-          overflow: hidden !important;
-          position: relative !important;
-          box-shadow: none !important;
-        }
-        .sk-print-root .sk-page.sk-main-document.sk-main-paginated.sk-main-continuation-page {
-          padding-top: 18mm !important;
-        }
-        .sk-print-root .sk-main-document.sk-main-page-break {
-          page-break-after: always;
-          break-after: page;
-        }
-        .sk-main-paginated .sk-paginated-field-section + .sk-paginated-field-section {
-          margin-top: 0 !important;
-        }
-        .sk-main-paginated .sk-paginated-field-section.sk-section-start {
-          margin-top: 0.75rem !important;
-        }
-        .sk-continuation-word {
-          position: absolute !important;
-          right: 23mm !important;
-          bottom: 31mm !important;
-          width: 163mm !important;
-          height: 0 !important;
-          line-height: 11pt !important;
-          overflow: visible !important;
-          white-space: nowrap !important;
-          text-align: right !important;
-          margin: 0 !important;
-          padding: 0 !important;
-          font-weight: normal !important;
-          font-size: 11pt !important;
-          z-index: 20 !important;
-        }
-      `;
-      body.appendChild(paginationStyle);
-
-      // Force layout by reading offsetHeight
-      void body.offsetHeight;
-
-      // A4 page usable height calculation
-      // @page margin-bottom: 28mm, page padding-top: 5mm (first page)
-      // Total A4 = 297mm. Usable first page ≈ 297 - 28 - 5 = 264mm
-      // Continuation pages: 297 - 28 - 12 = 257mm (12mm top margin from @page sk-main)
-      const mmToPx = 96 / 25.4; // 1mm = 96/25.4 px at screen resolution
-      const firstPageContentH = 264 * mmToPx;
-      const continuationContentH = 251 * mmToPx;
-      const markerReserveH = 9 * mmToPx;
-
-      // Collect all breakable items from the main document section
-      const mainDoc = doc.querySelector(".sk-main-document");
-      if (!mainDoc) { printWindow.print(); return; }
-
-      const root = mainDoc.parentElement;
-      if (!root) { printWindow.print(); return; }
-
-      const continuationLabel = (num: string, text: string) => {
-        const firstWord = text.trim().split(/\s+/)[0] || "";
-        return `${num.trim()} ${firstWord ? `${firstWord}.....` : "....."}`;
-      };
-
-      const cloneElement = <T extends HTMLElement>(el: T) => el.cloneNode(true) as T;
-
-      const createFieldBlock = (
-        sectionLabel: string,
-        item: HTMLElement,
-        showSectionLabel: boolean,
-        marginTop = false,
-      ) => {
-        const section = doc.createElement("div");
-        section.className = "sk-field-section sk-paginated-field-section";
-        section.style.marginTop = marginTop ? "0.75rem" : "0";
-        if (marginTop) section.classList.add("sk-section-start");
-
-        const label = doc.createElement("div");
-        label.className = "sk-field-label";
-        label.textContent = showSectionLabel ? sectionLabel : "";
-
-        const colon = doc.createElement("div");
-        colon.className = "sk-field-colon";
-        colon.textContent = showSectionLabel ? ":" : "";
-
-        const list = doc.createElement("div");
-        list.className = "sk-mengingat-list";
-        const itemClone = cloneElement(item);
-        itemClone.style.paddingTop = "0";
-        list.appendChild(itemClone);
-
-        section.append(label, colon, list);
-        return section;
-      };
-
-      const createDecisionBlock = (rows: HTMLElement[]) => {
-        const table = doc.createElement("table");
-        table.className = "sk-mengingat-table";
-        table.style.borderCollapse = "collapse";
-
-        const tbody = doc.createElement("tbody");
-        rows.forEach((row) => tbody.appendChild(cloneElement(row)));
-        table.appendChild(tbody);
-        return table;
-      };
-
-      const createMemutuskanMenetapkanBlock = (heading: HTMLElement, row: HTMLElement) => {
-        const block = doc.createElement("div");
-        block.appendChild(cloneElement(heading));
-        block.appendChild(createDecisionBlock([row]));
-        return block;
-      };
-
-      const makePage = (isFirstPage: boolean) => {
-        const page = doc.createElement("article");
-        page.className = "sk-page sk-page-ttd sk-main-document sk-main-paginated mx-auto max-w-[210mm] bg-white px-24 py-9 text-black";
-        if (!isFirstPage) page.classList.add("sk-main-continuation-page");
-        page.style.cssText = [
-          "width: 210mm",
-          "height: 297mm",
-          "min-height: 297mm",
-          "margin: 0 auto",
-          `padding: ${isFirstPage ? "5mm" : "18mm"} 20mm 28mm`,
-          "overflow: hidden",
-          "position: relative",
-          "box-sizing: border-box",
-          "background: white",
-          "color: black",
-        ].join("; ");
-
-        const flow = doc.createElement("div");
-        flow.className = "sk-main-flow";
-        page.appendChild(flow);
-
-        const bodyWrap = doc.createElement("div");
-        bodyWrap.className = "sk-body";
-        flow.appendChild(bodyWrap);
-
-        return { page, flow, bodyWrap };
-      };
-
-      const addContinuationWord = (page: HTMLElement, label: string) => {
-        const contWord = doc.createElement("p");
-        contWord.className = "sk-continuation-word";
-        contWord.textContent = label;
-        page.appendChild(contWord);
-      };
-
-      const measureFlowContentHeight = (flow: HTMLElement) => {
-        const flowTop = flow.getBoundingClientRect().top;
-        return Array.from(flow.children).reduce((maxBottom, child) => {
-          const rect = (child as HTMLElement).getBoundingClientRect();
-          return Math.max(maxBottom, rect.bottom - flowTop);
-        }, 0);
-      };
-
-      const measureOuterHeight = (el: HTMLElement) => {
-        const rect = el.getBoundingClientRect();
-        const style = printWindow.getComputedStyle(el);
-        const marginTop = Number.parseFloat(style.marginTop || "0") || 0;
-        const marginBottom = Number.parseFloat(style.marginBottom || "0") || 0;
-        return rect.height + marginTop + marginBottom;
-      };
-
-      const contentWrap = mainDoc.querySelector<HTMLElement>(".sk-subtitle");
-      const contentSections = contentWrap?.querySelector<HTMLElement>("div");
-      const fieldSections = contentSections?.querySelectorAll<HTMLElement>(":scope > .sk-field-section");
-      const menimbangItems = fieldSections?.[0]?.querySelectorAll<HTMLElement>(".sk-mengingat-item") || [];
-      const mengingatItems = fieldSections?.[1]?.querySelectorAll<HTMLElement>(".sk-mengingat-item") || [];
-
-      const explicitMemutuskanHeading = mainDoc.querySelector<HTMLElement>(".sk-memutuskan");
-      const explicitMemRows = Array.from(mainDoc.querySelectorAll<HTMLElement>(".sk-mengingat-row"));
-      const ketigaGroup = mainDoc.querySelector<HTMLElement>(".sk-ketiga-group");
-
-      let currentPage = makePage(true);
-      root.insertBefore(currentPage.page, mainDoc);
-
-      const kop = mainDoc.querySelector<HTMLElement>(".sk-kop");
-      const title = mainDoc.querySelector<HTMLElement>(".sk-title");
-      const intro = doc.createElement("div");
-      intro.className = "sk-subtitle sk-body";
-      const introParagraphs = Array.from(contentWrap?.children || []).filter((child) => {
-        return child.tagName === "P" && !(child as HTMLElement).classList.contains("sk-memutuskan");
-      });
-      introParagraphs.forEach((child) => intro.appendChild(cloneElement(child as HTMLElement)));
-
-      const firstBody = currentPage.bodyWrap;
-      currentPage.flow.insertBefore(intro, firstBody);
-      if (title) currentPage.flow.insertBefore(cloneElement(title), intro);
-      if (kop) currentPage.flow.insertBefore(cloneElement(kop), currentPage.flow.firstChild);
-      let currentUsedHeight = measureFlowContentHeight(currentPage.flow);
-
-      const blocks: { el: HTMLElement; label: string }[] = [];
-      Array.from(menimbangItems).forEach((item, index) => {
-        const num = item.querySelector("div:first-child")?.textContent || "";
-        const text = item.querySelector(".sk-mengingat-text")?.textContent || "";
-        blocks.push({
-          el: createFieldBlock("Menimbang", item, index === 0),
-          label: continuationLabel(num, text),
-        });
-      });
-
-      Array.from(mengingatItems).forEach((item, index) => {
-        const num = item.querySelector("div:first-child")?.textContent || "";
-        const text = item.querySelector(".sk-mengingat-text")?.textContent || "";
-        blocks.push({
-          el: createFieldBlock("Mengingat", item, index === 0, index === 0),
-          label: continuationLabel(num, text),
-        });
-      });
-
-      if (explicitMemutuskanHeading && explicitMemRows[0]) {
-        const memutuskanBlock = createMemutuskanMenetapkanBlock(explicitMemutuskanHeading, explicitMemRows[0]);
-        blocks.push({ el: memutuskanBlock, label: "MEMUTUSKAN....." });
-      } else if (explicitMemutuskanHeading) {
-        blocks.push({ el: cloneElement(explicitMemutuskanHeading), label: "MEMUTUSKAN....." });
-      } else if (explicitMemRows[0]) {
-        blocks.push({ el: createDecisionBlock([explicitMemRows[0]]), label: "Menetapkan....." });
-      }
-      if (explicitMemRows[1]) {
-        blocks.push({ el: createDecisionBlock([explicitMemRows[1]]), label: "KESATU....." });
-      }
-      if (explicitMemRows[2]) {
-        blocks.push({ el: createDecisionBlock([explicitMemRows[2]]), label: "KEDUA....." });
-      }
-      if (ketigaGroup) {
-        blocks.push({ el: cloneElement(ketigaGroup), label: "KETIGA....." });
-      }
-
-      blocks.forEach((block, index) => {
-        const isLastBlock = index === blocks.length - 1;
-        const contentLimit = currentPage.page.classList.contains("sk-main-continuation-page")
-          ? continuationContentH
-          : firstPageContentH;
-        const maxFlowHeight = contentLimit - (isLastBlock ? 0 : markerReserveH);
-        const markerSafeHeight = contentLimit - markerReserveH;
-
-        currentPage.bodyWrap.appendChild(block.el);
-        const blockHeight = measureOuterHeight(block.el);
-        const flowHeight = currentUsedHeight + blockHeight;
-        const canMoveToNextPage = currentPage.bodyWrap.children.length > 1;
-        if ((flowHeight > maxFlowHeight || (!isLastBlock && flowHeight > markerSafeHeight)) && canMoveToNextPage) {
-          currentPage.bodyWrap.removeChild(block.el);
-          currentPage.page.classList.add("sk-main-page-break");
-          addContinuationWord(currentPage.page, block.label);
-
-          currentPage = makePage(false);
-          root.insertBefore(currentPage.page, mainDoc);
-          currentPage.bodyWrap.appendChild(block.el);
-          currentUsedHeight = measureOuterHeight(block.el);
-        } else {
-          currentUsedHeight = flowHeight;
-        }
-      });
-
-      root.removeChild(mainDoc);
-
-    } catch {
-      // Silently fail — print without continuation words
-    }
-    setTimeout(() => printWindow.print(), 300);
-  }, 600);
+  setTimeout(
+    () =>
+      runSkPagination(printWindow, {
+        prefix: "sk",
+        sectionStartMarginTop: "0.75rem",
+        decisionRowLabels: ["KESATU.....", "KEDUA....."],
+        finalGroupClass: "sk-ketiga-group",
+        finalGroupLabel: "KETIGA.....",
+      }),
+    600,
+  );
 }
 
 export function SkPenghentianDocument({
@@ -972,7 +712,7 @@ export function SkPenghentianDocument({
               <tr className="sk-mengingat-row">
                 <td style={{ width: "28mm", verticalAlign: "top" }}>Menetapkan</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top" }}>:</td>
-                <td style={{ verticalAlign: "top", textTransform: "uppercase", textAlign: "justify" }}>
+                <td style={{ verticalAlign: "top", textTransform: "uppercase", textAlign: "justify", fontWeight: "bold" }}>
                   {memutuskan.menetapkan}
                 </td>
               </tr>

--- a/frontend/src/app/bmn/auction-candidates/_components/SkTimPenilaiDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkTimPenilaiDocument.tsx
@@ -2,6 +2,7 @@
 
 import { toast } from "sonner";
 import { formatDateLong } from "../_lib/auction-helpers";
+import { runSkPagination } from "../_lib/sk-print";
 import type { SkBuilderItem, SkKepalaBalai } from "../_lib/sk-defaults";
 import type {
   SkTimPenilaiMemutuskan,
@@ -188,292 +189,20 @@ export function handlePrintSkTimPenilai() {
   printWindow.document.close();
   printWindow.focus();
 
-  // JS pagination: split main page into explicit A4 pages,
-  // inject continuation words at page breaks, with bottom safe area for BSrE
-  // and top safe area on continuation pages.
-  setTimeout(() => {
-    try {
-      const doc = printWindow.document;
-      const body = doc.body;
-      if (!body) {
-        printWindow.print();
-        return;
-      }
-
-      const paginationStyle = doc.createElement("style");
-      paginationStyle.textContent = `
-        @page sktp-main { size: A4; margin: 0; }
-        @page sktp-main:first { size: A4; margin: 0; }
-        .sktp-print-root .sktp-page.sktp-main-document.sktp-main-paginated {
-          height: 297mm !important;
-          min-height: 297mm !important;
-          padding: 5mm 20mm 28mm !important;
-          overflow: hidden !important;
-          position: relative !important;
-          box-shadow: none !important;
-        }
-        .sktp-print-root .sktp-page.sktp-main-document.sktp-main-paginated.sktp-main-continuation-page {
-          padding-top: 18mm !important;
-        }
-        .sktp-print-root .sktp-main-document.sktp-main-page-break {
-          page-break-after: always;
-          break-after: page;
-        }
-        .sktp-main-paginated .sktp-paginated-field-section + .sktp-paginated-field-section {
-          margin-top: 0 !important;
-        }
-        .sktp-main-paginated .sktp-paginated-field-section.sktp-section-start {
-          margin-top: 0.5rem !important;
-        }
-        .sktp-continuation-word {
-          position: absolute !important;
-          right: 23mm !important;
-          bottom: 31mm !important;
-          width: 163mm !important;
-          height: 0 !important;
-          line-height: 11pt !important;
-          overflow: visible !important;
-          white-space: nowrap !important;
-          text-align: right !important;
-          margin: 0 !important;
-          padding: 0 !important;
-          font-weight: normal !important;
-          font-size: 11pt !important;
-          z-index: 20 !important;
-        }
-      `;
-      body.appendChild(paginationStyle);
-
-      void body.offsetHeight;
-
-      const mmToPx = 96 / 25.4;
-      const firstPageContentH = 264 * mmToPx;
-      const continuationContentH = 251 * mmToPx;
-      const markerReserveH = 9 * mmToPx;
-
-      const mainDoc = doc.querySelector(".sktp-main-document");
-      if (!mainDoc) {
-        printWindow.print();
-        return;
-      }
-
-      const root = mainDoc.parentElement;
-      if (!root) {
-        printWindow.print();
-        return;
-      }
-
-      const continuationLabel = (num: string, text: string) => {
-        const firstWord = text.trim().split(/\s+/)[0] || "";
-        return `${num.trim()} ${firstWord ? `${firstWord}.....` : "....."}`;
-      };
-
-      const cloneElement = <T extends HTMLElement>(el: T) => el.cloneNode(true) as T;
-
-      const createFieldBlock = (
-        sectionLabel: string,
-        item: HTMLElement,
-        showSectionLabel: boolean,
-        marginTop = false,
-      ) => {
-        const section = doc.createElement("div");
-        section.className = "sktp-field-section sktp-paginated-field-section";
-        section.style.marginTop = marginTop ? "0.75rem" : "0";
-        if (marginTop) section.classList.add("sktp-section-start");
-
-        const label = doc.createElement("div");
-        label.className = "sktp-field-label";
-        label.textContent = showSectionLabel ? sectionLabel : "";
-
-        const colon = doc.createElement("div");
-        colon.className = "sktp-field-colon";
-        colon.textContent = showSectionLabel ? ":" : "";
-
-        const list = doc.createElement("div");
-        list.className = "sktp-mengingat-list";
-        const itemClone = cloneElement(item);
-        itemClone.style.paddingTop = "0";
-        list.appendChild(itemClone);
-
-        section.append(label, colon, list);
-        return section;
-      };
-
-      const createDecisionBlock = (rows: HTMLElement[]) => {
-        const table = doc.createElement("table");
-        table.className = "sktp-mengingat-table";
-        table.style.borderCollapse = "collapse";
-
-        const tbody = doc.createElement("tbody");
-        rows.forEach((row) => tbody.appendChild(cloneElement(row)));
-        table.appendChild(tbody);
-        return table;
-      };
-
-      const createMemutuskanMenetapkanBlock = (heading: HTMLElement, row: HTMLElement) => {
-        const block = doc.createElement("div");
-        block.appendChild(cloneElement(heading));
-        block.appendChild(createDecisionBlock([row]));
-        return block;
-      };
-
-      const makePage = (isFirstPage: boolean) => {
-        const page = doc.createElement("article");
-        page.className = "sktp-page sktp-page-ttd sktp-main-document sktp-main-paginated mx-auto max-w-[210mm] bg-white px-24 py-9 text-black";
-        if (!isFirstPage) page.classList.add("sktp-main-continuation-page");
-        page.style.cssText = [
-          "width: 210mm",
-          "height: 297mm",
-          "min-height: 297mm",
-          "margin: 0 auto",
-          `padding: ${isFirstPage ? "5mm" : "18mm"} 20mm 28mm`,
-          "overflow: hidden",
-          "position: relative",
-          "box-sizing: border-box",
-          "background: white",
-          "color: black",
-        ].join("; ");
-
-        const flow = doc.createElement("div");
-        flow.className = "sktp-main-flow";
-        page.appendChild(flow);
-
-        const bodyWrap = doc.createElement("div");
-        bodyWrap.className = "sktp-body";
-        flow.appendChild(bodyWrap);
-
-        return { page, flow, bodyWrap };
-      };
-
-      const addContinuationWord = (page: HTMLElement, label: string) => {
-        const contWord = doc.createElement("p");
-        contWord.className = "sktp-continuation-word";
-        contWord.textContent = label;
-        page.appendChild(contWord);
-      };
-
-      const measureFlowContentHeight = (flow: HTMLElement) => {
-        const flowTop = flow.getBoundingClientRect().top;
-        return Array.from(flow.children).reduce((maxBottom, child) => {
-          const rect = (child as HTMLElement).getBoundingClientRect();
-          return Math.max(maxBottom, rect.bottom - flowTop);
-        }, 0);
-      };
-
-      const measureOuterHeight = (el: HTMLElement) => {
-        const rect = el.getBoundingClientRect();
-        const style = printWindow.getComputedStyle(el);
-        const marginTop = Number.parseFloat(style.marginTop || "0") || 0;
-        const marginBottom = Number.parseFloat(style.marginBottom || "0") || 0;
-        return rect.height + marginTop + marginBottom;
-      };
-
-      const contentWrap = mainDoc.querySelector<HTMLElement>(".sktp-subtitle");
-      const contentSections = contentWrap?.querySelector<HTMLElement>("div");
-      const fieldSections = contentSections?.querySelectorAll<HTMLElement>(":scope > .sktp-field-section");
-      const menimbangItems = fieldSections?.[0]?.querySelectorAll<HTMLElement>(".sktp-mengingat-item") || [];
-      const mengingatItems = fieldSections?.[1]?.querySelectorAll<HTMLElement>(".sktp-mengingat-item") || [];
-
-      const explicitMemutuskanHeading = mainDoc.querySelector<HTMLElement>(".sktp-memutuskan");
-      const explicitMemRows = Array.from(mainDoc.querySelectorAll<HTMLElement>(".sktp-mengingat-row"));
-      const keempatGroup = mainDoc.querySelector<HTMLElement>(".sktp-keempat-group");
-
-      let currentPage = makePage(true);
-      root.insertBefore(currentPage.page, mainDoc);
-
-      const kop = mainDoc.querySelector<HTMLElement>(".sktp-kop");
-      const title = mainDoc.querySelector<HTMLElement>(".sktp-title");
-      const intro = doc.createElement("div");
-      intro.className = "sktp-subtitle sktp-body";
-      const introParagraphs = Array.from(contentWrap?.children || []).filter((child) => {
-        return child.tagName === "P" && !(child as HTMLElement).classList.contains("sktp-memutuskan");
-      });
-      introParagraphs.forEach((child) => intro.appendChild(cloneElement(child as HTMLElement)));
-
-      const firstBody = currentPage.bodyWrap;
-      currentPage.flow.insertBefore(intro, firstBody);
-      if (title) currentPage.flow.insertBefore(cloneElement(title), intro);
-      if (kop) currentPage.flow.insertBefore(cloneElement(kop), currentPage.flow.firstChild);
-      let currentUsedHeight = measureFlowContentHeight(currentPage.flow);
-
-      const blocks: { el: HTMLElement; label: string }[] = [];
-
-      // Menimbang items
-      Array.from(menimbangItems).forEach((item, index) => {
-        const num = item.querySelector("div:first-child")?.textContent || "";
-        const text = item.querySelector(".sktp-mengingat-text")?.textContent || "";
-        blocks.push({
-          el: createFieldBlock("Menimbang", item, index === 0),
-          label: continuationLabel(num || (index === 0 ? "" : ""), text),
-        });
-      });
-
-      // Mengingat items
-      Array.from(mengingatItems).forEach((item, index) => {
-        const num = item.querySelector("div:first-child")?.textContent || "";
-        const text = item.querySelector(".sktp-mengingat-text")?.textContent || "";
-        blocks.push({
-          el: createFieldBlock("Mengingat", item, index === 0, index === 0),
-          label: continuationLabel(num, text),
-        });
-      });
-
-      // Memutuskan + Menetapkan + KESATU + KEDUA + KETIGA + KEEMPAT
-      if (explicitMemutuskanHeading && explicitMemRows[0]) {
-        blocks.push({
-          el: createMemutuskanMenetapkanBlock(explicitMemutuskanHeading, explicitMemRows[0]),
-          label: "MEMUTUSKAN.....",
-        });
-      } else if (explicitMemutuskanHeading) {
-        blocks.push({ el: cloneElement(explicitMemutuskanHeading), label: "MEMUTUSKAN....." });
-      } else if (explicitMemRows[0]) {
-        blocks.push({ el: createDecisionBlock([explicitMemRows[0]]), label: "Menetapkan....." });
-      }
-      if (explicitMemRows[1]) {
-        blocks.push({ el: createDecisionBlock([explicitMemRows[1]]), label: "KESATU....." });
-      }
-      if (explicitMemRows[2]) {
-        blocks.push({ el: createDecisionBlock([explicitMemRows[2]]), label: "KEDUA....." });
-      }
-      if (explicitMemRows[3]) {
-        blocks.push({ el: createDecisionBlock([explicitMemRows[3]]), label: "KETIGA....." });
-      }
-      if (keempatGroup) {
-        blocks.push({ el: cloneElement(keempatGroup), label: "KEEMPAT....." });
-      }
-
-      blocks.forEach((block, index) => {
-        const isLastBlock = index === blocks.length - 1;
-        const contentLimit = currentPage.page.classList.contains("sktp-main-continuation-page")
-          ? continuationContentH
-          : firstPageContentH;
-        const maxFlowHeight = contentLimit - (isLastBlock ? 0 : markerReserveH);
-        const markerSafeHeight = contentLimit - markerReserveH;
-
-        currentPage.bodyWrap.appendChild(block.el);
-        const blockHeight = measureOuterHeight(block.el);
-        const flowHeight = currentUsedHeight + blockHeight;
-        const canMoveToNextPage = currentPage.bodyWrap.children.length > 1;
-        if ((flowHeight > maxFlowHeight || (!isLastBlock && flowHeight > markerSafeHeight)) && canMoveToNextPage) {
-          currentPage.bodyWrap.removeChild(block.el);
-          currentPage.page.classList.add("sktp-main-page-break");
-          addContinuationWord(currentPage.page, block.label);
-
-          currentPage = makePage(false);
-          root.insertBefore(currentPage.page, mainDoc);
-          currentPage.bodyWrap.appendChild(block.el);
-          currentUsedHeight = measureOuterHeight(block.el);
-        } else {
-          currentUsedHeight = flowHeight;
-        }
-      });
-
-      root.removeChild(mainDoc);
-    } catch {
-      // Silently fail — print without continuation words
-    }
-    setTimeout(() => printWindow.print(), 300);
-  }, 600);
+  // JS pagination: split main page into explicit A4 pages, inject continuation
+  // words at page breaks, with bottom safe area for BSrE and top safe area on
+  // continuation pages. Shared with the other SK documents via runSkPagination.
+  setTimeout(
+    () =>
+      runSkPagination(printWindow, {
+        prefix: "sktp",
+        sectionStartMarginTop: "0.5rem",
+        decisionRowLabels: ["KESATU.....", "KEDUA.....", "KETIGA....."],
+        finalGroupClass: "sktp-keempat-group",
+        finalGroupLabel: "KEEMPAT.....",
+      }),
+    600,
+  );
 }
 
 export function SkTimPenilaiDocument({
@@ -704,7 +433,7 @@ export function SkTimPenilaiDocument({
               <tr className="sktp-mengingat-row">
                 <td style={{ width: "28mm", verticalAlign: "top" }}>Menetapkan</td>
                 <td style={{ width: "8mm", textAlign: "center", verticalAlign: "top" }}>:</td>
-                <td style={{ verticalAlign: "top", textTransform: "uppercase", textAlign: "justify" }}>
+                <td style={{ verticalAlign: "top", textTransform: "uppercase", textAlign: "justify", fontWeight: "bold" }}>
                   {memutuskan.menetapkan}
                 </td>
               </tr>

--- a/frontend/src/app/bmn/auction-candidates/_components/SpTugasDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SpTugasDocument.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { toast } from "sonner";
-import { formatDateLong } from "../_lib/auction-helpers";
 import type { SkKepalaBalai } from "../_lib/sk-defaults";
+import { buildPernyataanNomor, printPernyataan } from "../_lib/print-pernyataan";
+import { PernyataanDocument, PernyataanIdentity } from "./PernyataanDocument";
 
 interface SpTugasDocumentProps {
   number: string;
@@ -10,135 +10,38 @@ interface SpTugasDocumentProps {
   kepalaBalai: SkKepalaBalai;
 }
 
-function buildNomorText(number: string, kap: string, today: Date) {
-  const month = String(today.getMonth() + 1).padStart(2, "0");
-  return `SM.${number.trim() || "____"}/K.18/TU/${kap.trim() || "KAP.06.01"}/B/${month}/${today.getFullYear()}`;
-}
+const ROOT_ID = "sp-tugas-print-root";
 
 export function handlePrintSpTugas() {
-  const printContent = document.getElementById("sp-tugas-print-root");
-  if (!printContent) {
-    toast.error("Tidak ada dokumen Surat Pernyataan Kelancaran Tugas untuk dicetak.");
-    return;
-  }
-  const printWindow = window.open("", "_blank");
-  if (!printWindow) return;
-
-  printWindow.document.write(`
-    <html>
-      <head>
-        <title>Surat Pernyataan Tidak Mengganggu Kelancaran Tugas</title>
-        <style>
-          @page { size: A4; margin: 0 0 28mm 0; }
-          * { box-sizing: border-box; }
-          body {
-            margin: 0; padding: 0; background: white; color: black;
-            font-family: 'Bookman Old Style', Georgia, serif;
-            font-size: 11pt; line-height: 1.4;
-          }
-          p { margin: 0; padding: 0; }
-          article { margin: 0; }
-          .doc-page { width: 210mm; box-sizing: border-box; margin: 0 auto; padding: 5mm 20mm 0; }
-          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; text-align: center; }
-          .doc-header img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
-          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; text-align: justify; text-justify: inter-word; }
-          .doc-body p { text-align: justify; text-justify: inter-word; }
-          .doc-title { margin-top: 0.75rem; text-align: center; font-weight: 700; line-height: 1.3; }
-          .doc-title p { margin: 0; }
-          .doc-text-block { margin-top: 1rem; }
-          .doc-text-block > * + * { margin-top: 0.85rem; }
-          .doc-identity { display: grid; grid-template-columns: 28mm 5mm minmax(0, 1fr); row-gap: 0.2rem; }
-          .doc-identity .colon { text-align: center; }
-          .signature { width: 20rem; margin-left: auto; margin-top: 1.5rem; }
-          .signature p { margin: 0; padding: 0; line-height: 1.3; }
-          .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; margin-top: 2rem; margin-bottom: 2rem; }
-          .doc-editable { outline: none; border-bottom: none !important; }
-        </style>
-      </head>
-      <body>${printContent.innerHTML}</body>
-    </html>
-  `);
-  printWindow.document.close();
-  printWindow.focus();
-  setTimeout(() => printWindow.print(), 500);
+  printPernyataan({
+    rootId: ROOT_ID,
+    title: "Surat Pernyataan Tidak Mengganggu Kelancaran Tugas",
+    emptyMessage: "Tidak ada dokumen Surat Pernyataan Kelancaran Tugas untuk dicetak.",
+  });
 }
 
 export function SpTugasDocument({ number, kap, kepalaBalai }: SpTugasDocumentProps) {
   const today = new Date();
-  const nomorText = buildNomorText(number, kap, today);
+  const nomorText = buildPernyataanNomor("SM", number, kap, today);
 
   return (
-    <div id="sp-tugas-print-root" className="sp-tugas-print-root">
-      <style jsx global>{`
-        .sp-tugas-print-root .doc-editable { outline: none; border-bottom: 1px dashed transparent; transition: border-bottom-color 0.15s ease; }
-        .sp-tugas-print-root .doc-editable:hover { border-bottom-color: #94a3b8; }
-        .sp-tugas-print-root .doc-editable:focus { border-bottom-color: #64748b; }
-        @media print {
-          @page { size: A4; margin: 0 0 28mm 0; }
-          body * { visibility: hidden; }
-          .sp-tugas-print-root, .sp-tugas-print-root * { visibility: visible; }
-          .sp-tugas-print-root {
-            position: absolute; left: 0; top: 0; width: 100%;
-            background: white; color: black;
-            font-family: 'Bookman Old Style', Georgia, serif;
-            font-size: 11pt; line-height: 1.4; margin: 0; padding: 0;
-          }
-          .doc-page { width: 210mm; margin: 0 auto; padding: 5mm 20mm 0; box-shadow: none !important; }
-          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; }
-          .doc-header img { max-width: 196mm !important; }
-          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; }
-          .doc-editable { border-bottom: none !important; }
-        }
-      `}</style>
-
-      <article
-        className="doc-page mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
-        style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.4" }}
-      >
-        <div className="doc-header -mx-18 text-center">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
-        </div>
-
-        <div className="doc-title mt-2 text-center font-bold leading-snug">
-          <p className="m-0">SURAT PERNYATAAN</p>
-          <p className="m-0 font-normal">Nomor : {nomorText}</p>
-        </div>
-
-        <div className="doc-body doc-text-block mx-auto mt-4 w-[166mm] space-y-3 text-justify">
-          <p contentEditable suppressContentEditableWarning className="doc-editable">
-            Yang bertanda tangan di bawah ini :
-          </p>
-          <div className="doc-identity grid grid-cols-[28mm_5mm_minmax(0,1fr)]">
-            <span>Nama</span>
-            <span className="colon text-center">:</span>
-            <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nama}</span>
-            <span>NIP</span>
-            <span className="colon text-center">:</span>
-            <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nip}</span>
-            <span>Pangkat/Gol</span>
-            <span className="colon text-center">:</span>
-            <span contentEditable suppressContentEditableWarning className="doc-editable">Pembina Tk.I / IV b</span>
-            <span>Jabatan</span>
-            <span className="colon text-center">:</span>
-            <span contentEditable suppressContentEditableWarning className="doc-editable">Kepala Balai KSDA Kalimantan Timur</span>
-          </div>
-          <p contentEditable suppressContentEditableWarning className="doc-editable">
-            Dengan ini menyatakan bahwa dalam rangka kegiatan Penghapusan Barang Milik Negara (BMN) berupa Alat Angkutan Bermotor di lingkungan Balai Konservasi Sumber Daya Alam (BKSDA) Kalimantan Timur, saya selaku Kepala Balai menyatakan bahwa Barang Milik Negara yang akan dipindahtangankan dengan penjualan tidak mengganggu kelancaran tugas dinas.
-          </p>
-          <p contentEditable suppressContentEditableWarning className="doc-editable">
-            Demikian surat pernyataan ini dibuat dengan sebenarnya, untuk dapat dipergunakan sebagaimana mestinya.
-          </p>
-        </div>
-
-        <div className="signature mt-6 ml-auto w-80">
-          <p className="m-0">Samarinda, {formatDateLong(today)}</p>
-          <p className="m-0">Kepala Balai,</p>
-          <div className="ttd-placeholder mt-8 box-border h-28 pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
-          <p contentEditable suppressContentEditableWarning className="doc-editable m-0 mt-8">{kepalaBalai.nama}</p>
-          <p contentEditable suppressContentEditableWarning className="doc-editable m-0">NIP. {kepalaBalai.nip}</p>
-        </div>
-      </article>
-    </div>
+    <PernyataanDocument
+      rootId={ROOT_ID}
+      title="SURAT PERNYATAAN"
+      nomorText={nomorText}
+      today={today}
+      kepalaBalai={kepalaBalai}
+    >
+      <p contentEditable suppressContentEditableWarning className="doc-editable">
+        Yang bertanda tangan di bawah ini :
+      </p>
+      <PernyataanIdentity kepalaBalai={kepalaBalai} />
+      <p contentEditable suppressContentEditableWarning className="doc-editable">
+        Dengan ini menyatakan bahwa dalam rangka kegiatan Penghapusan Barang Milik Negara (BMN) berupa Alat Angkutan Bermotor di lingkungan Balai Konservasi Sumber Daya Alam (BKSDA) Kalimantan Timur, saya selaku Kepala Balai menyatakan bahwa Barang Milik Negara yang akan dipindahtangankan dengan penjualan tidak mengganggu kelancaran tugas dinas.
+      </p>
+      <p contentEditable suppressContentEditableWarning className="doc-editable">
+        Demikian surat pernyataan ini dibuat dengan sebenarnya, untuk dapat dipergunakan sebagaimana mestinya.
+      </p>
+    </PernyataanDocument>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/_components/SptjLimitDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SptjLimitDocument.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { toast } from "sonner";
-import { formatDateLong } from "../_lib/auction-helpers";
 import type { SkKepalaBalai } from "../_lib/sk-defaults";
+import { buildPernyataanNomor, printPernyataan } from "../_lib/print-pernyataan";
+import { PernyataanDocument, PernyataanIdentity } from "./PernyataanDocument";
 
 interface SptjLimitDocumentProps {
   number: string;
@@ -10,159 +10,52 @@ interface SptjLimitDocumentProps {
   kepalaBalai: SkKepalaBalai;
 }
 
-function buildNomorText(number: string, kap: string, today: Date) {
-  const month = String(today.getMonth() + 1).padStart(2, "0");
-  return `SM.${number.trim() || "____"}/K.18/TU/${kap.trim() || "KAP.06.01"}/B/${month}/${today.getFullYear()}`;
-}
+const ROOT_ID = "sptj-limit-print-root";
 
 export function handlePrintSptjLimit() {
-  const printContent = document.getElementById("sptj-limit-print-root");
-  if (!printContent) {
-    toast.error("Tidak ada dokumen Surat Pernyataan Tanggung Jawab Nilai Limit untuk dicetak.");
-    return;
-  }
-  const printWindow = window.open("", "_blank");
-  if (!printWindow) return;
-
-  printWindow.document.write(`
-    <html>
-      <head>
-        <title>Surat Pernyataan Tanggung Jawab Nilai Limit</title>
-        <style>
-          @page { size: A4; margin: 0 0 28mm 0; }
-          * { box-sizing: border-box; }
-          body {
-            margin: 0; padding: 0; background: white; color: black;
-            font-family: 'Bookman Old Style', Georgia, serif;
-            font-size: 11pt; line-height: 1.4;
-          }
-          p { margin: 0; padding: 0; }
-          article { margin: 0; }
-          .doc-page {
-            width: 210mm;
-            box-sizing: border-box;
-            margin: 0 auto;
-            padding: 5mm 20mm 0;
-          }
-          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; text-align: center; }
-          .doc-header img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
-          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; text-align: justify; text-justify: inter-word; }
-          .doc-body p { text-align: justify; text-justify: inter-word; }
-          .doc-title { margin-top: 0.75rem; text-align: center; font-weight: 700; line-height: 1.3; }
-          .doc-title p { margin: 0; }
-          .doc-text-block { margin-top: 1rem; }
-          .doc-text-block > * + * { margin-top: 0.85rem; }
-          .doc-identity { display: grid; grid-template-columns: 28mm 5mm minmax(0, 1fr); row-gap: 0.2rem; column-gap: 0; }
-          .doc-identity .colon { text-align: center; }
-          .doc-list { padding-left: 0; margin: 0; }
-          .doc-list-item { display: grid; grid-template-columns: 8mm minmax(0, 1fr); column-gap: 0; }
-          .doc-list-item + .doc-list-item { margin-top: 0.5rem; }
-          .doc-list-item .marker { }
-          .doc-list-item .text { text-align: justify; }
-          .signature { width: 20rem; margin-left: auto; margin-top: 1.5rem; }
-          .signature p { margin: 0; padding: 0; line-height: 1.3; }
-          .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; margin-top: 2rem; margin-bottom: 2rem; }
-          .doc-editable { outline: none; border-bottom: none !important; }
-        </style>
-      </head>
-      <body>${printContent.innerHTML}</body>
-    </html>
-  `);
-  printWindow.document.close();
-  printWindow.focus();
-  setTimeout(() => printWindow.print(), 500);
+  printPernyataan({
+    rootId: ROOT_ID,
+    title: "Surat Pernyataan Tanggung Jawab Nilai Limit",
+    emptyMessage: "Tidak ada dokumen Surat Pernyataan Tanggung Jawab Nilai Limit untuk dicetak.",
+  });
 }
 
 export function SptjLimitDocument({ number, kap, kepalaBalai }: SptjLimitDocumentProps) {
   const today = new Date();
-  const nomorText = buildNomorText(number, kap, today);
+  const nomorText = buildPernyataanNomor("SM", number, kap, today);
 
   return (
-    <div id="sptj-limit-print-root" className="sptj-limit-print-root">
-      <style jsx global>{`
-        .sptj-limit-print-root .doc-editable { outline: none; border-bottom: 1px dashed transparent; transition: border-bottom-color 0.15s ease; }
-        .sptj-limit-print-root .doc-editable:hover { border-bottom-color: #94a3b8; }
-        .sptj-limit-print-root .doc-editable:focus { border-bottom-color: #64748b; }
-        @media print {
-          @page { size: A4; margin: 0 0 28mm 0; }
-          body * { visibility: hidden; }
-          .sptj-limit-print-root, .sptj-limit-print-root * { visibility: visible; }
-          .sptj-limit-print-root {
-            position: absolute; left: 0; top: 0; width: 100%;
-            background: white; color: black;
-            font-family: 'Bookman Old Style', Georgia, serif;
-            font-size: 11pt; line-height: 1.4; margin: 0; padding: 0;
-          }
-          .doc-page { width: 210mm; margin: 0 auto; padding: 5mm 20mm 0; box-shadow: none !important; }
-          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; }
-          .doc-header img { max-width: 196mm !important; }
-          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; }
-          .doc-editable { border-bottom: none !important; }
-        }
-      `}</style>
-
-      <article
-        className="doc-page mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
-        style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.4" }}
-      >
-        <div className="doc-header -mx-18 text-center">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
-        </div>
-
-        <div className="doc-title mt-2 text-center font-bold leading-snug">
-          <p className="m-0">SURAT PERNYATAAN TANGGUNG JAWAB NILAI LIMIT</p>
-          <p className="m-0 font-normal">Nomor : {nomorText}</p>
-        </div>
-
-        <div className="doc-body doc-text-block mx-auto mt-4 w-[166mm] space-y-3 text-justify">
-          <p contentEditable suppressContentEditableWarning className="doc-editable">
-            Yang bertanda tangan di bawah ini :
-          </p>
-          <div className="doc-identity grid grid-cols-[28mm_5mm_minmax(0,1fr)]">
-            <span>Nama</span>
-            <span className="colon text-center">:</span>
-            <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nama}</span>
-            <span>NIP</span>
-            <span className="colon text-center">:</span>
-            <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nip}</span>
-            <span>Pangkat/Gol</span>
-            <span className="colon text-center">:</span>
-            <span contentEditable suppressContentEditableWarning className="doc-editable">Pembina Tk.I / IV b</span>
-            <span>Jabatan</span>
-            <span className="colon text-center">:</span>
-            <span contentEditable suppressContentEditableWarning className="doc-editable">Kepala Balai KSDA Kalimantan Timur</span>
-          </div>
-          <p contentEditable suppressContentEditableWarning className="doc-editable">
-            Dengan ini menyatakan sebagai berikut :
-          </p>
-          <ol className="doc-list space-y-2">
-            <li className="doc-list-item grid grid-cols-[8mm_minmax(0,1fr)]">
-              <span className="marker">1.</span>
-              <span contentEditable suppressContentEditableWarning className="doc-editable text text-justify">
-                Bertanggungjawab secara penuh atas kebenaran nilai limit yang kami ajukan dalam rangka penjualan, yang bukan merupakan nilai wajar hasil inventarisasi dan penilaian.
-              </span>
-            </li>
-            <li className="doc-list-item grid grid-cols-[8mm_minmax(0,1fr)]">
-              <span className="marker">2.</span>
-              <span contentEditable suppressContentEditableWarning className="doc-editable text text-justify">
-                Perhitungan nilai limit sebagaimana dimaksud pada angka 1 (satu), prinsip efisien, efektif dan menghasilkan manfaat yang optimal bagi negara (antara lain penurunan nilai barang dimaksud apabila tidak dilakukan penghapusan/pemindahtanganan, potensi biaya pemeliharaan yang harus dikeluarkan, ketersediaan ruangan yang sudah tidak memadai dan sebagainya).
-              </span>
-            </li>
-          </ol>
-          <p contentEditable suppressContentEditableWarning className="doc-editable">
-            Demikian pernyataan ini kami buat dengan keadaan sebenarnya untuk dapat dipergunakan sebagaimana mestinya.
-          </p>
-        </div>
-
-        <div className="signature mt-6 ml-auto w-80">
-          <p className="m-0">Samarinda, {formatDateLong(today)}</p>
-          <p className="m-0">Kepala Balai,</p>
-          <div className="ttd-placeholder mt-8 box-border h-28 pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
-          <p contentEditable suppressContentEditableWarning className="doc-editable m-0 mt-8">{kepalaBalai.nama}</p>
-          <p contentEditable suppressContentEditableWarning className="doc-editable m-0">NIP. {kepalaBalai.nip}</p>
-        </div>
-      </article>
-    </div>
+    <PernyataanDocument
+      rootId={ROOT_ID}
+      title="SURAT PERNYATAAN TANGGUNG JAWAB NILAI LIMIT"
+      nomorText={nomorText}
+      today={today}
+      kepalaBalai={kepalaBalai}
+    >
+      <p contentEditable suppressContentEditableWarning className="doc-editable">
+        Yang bertanda tangan di bawah ini :
+      </p>
+      <PernyataanIdentity kepalaBalai={kepalaBalai} />
+      <p contentEditable suppressContentEditableWarning className="doc-editable">
+        Dengan ini menyatakan sebagai berikut :
+      </p>
+      <ol className="doc-list space-y-2">
+        <li className="doc-list-item grid grid-cols-[8mm_minmax(0,1fr)]">
+          <span className="marker">1.</span>
+          <span contentEditable suppressContentEditableWarning className="doc-editable text text-justify">
+            Bertanggungjawab secara penuh atas kebenaran nilai limit yang kami ajukan dalam rangka penjualan, yang bukan merupakan nilai wajar hasil inventarisasi dan penilaian.
+          </span>
+        </li>
+        <li className="doc-list-item grid grid-cols-[8mm_minmax(0,1fr)]">
+          <span className="marker">2.</span>
+          <span contentEditable suppressContentEditableWarning className="doc-editable text text-justify">
+            Perhitungan nilai limit sebagaimana dimaksud pada angka 1 (satu), prinsip efisien, efektif dan menghasilkan manfaat yang optimal bagi negara (antara lain penurunan nilai barang dimaksud apabila tidak dilakukan penghapusan/pemindahtanganan, potensi biaya pemeliharaan yang harus dikeluarkan, ketersediaan ruangan yang sudah tidak memadai dan sebagainya).
+          </span>
+        </li>
+      </ol>
+      <p contentEditable suppressContentEditableWarning className="doc-editable">
+        Demikian pernyataan ini kami buat dengan keadaan sebenarnya untuk dapat dipergunakan sebagaimana mestinya.
+      </p>
+    </PernyataanDocument>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/_components/SptjmDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SptjmDocument.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { toast } from "sonner";
-import { formatDateLong } from "../_lib/auction-helpers";
 import type { SkKepalaBalai } from "../_lib/sk-defaults";
+import { buildPernyataanNomor, printPernyataan } from "../_lib/print-pernyataan";
+import { PernyataanDocument, PernyataanIdentity } from "./PernyataanDocument";
 
 interface SptjmDocumentProps {
   number: string;
@@ -10,153 +10,52 @@ interface SptjmDocumentProps {
   kepalaBalai: SkKepalaBalai;
 }
 
-function buildNomorText(number: string, kap: string, today: Date) {
-  const month = String(today.getMonth() + 1).padStart(2, "0");
-  return `SPTJM.${number.trim() || "____"}/K.18/TU/${kap.trim() || "KAP.06.01"}/B/${month}/${today.getFullYear()}`;
-}
+const ROOT_ID = "sptjm-print-root";
 
 export function handlePrintSptjm() {
-  const printContent = document.getElementById("sptjm-print-root");
-  if (!printContent) {
-    toast.error("Tidak ada dokumen SPTJM untuk dicetak.");
-    return;
-  }
-  const printWindow = window.open("", "_blank");
-  if (!printWindow) return;
-
-  printWindow.document.write(`
-    <html>
-      <head>
-        <title>Surat Pernyataan Tanggung Jawab Mutlak</title>
-        <style>
-          @page { size: A4; margin: 0 0 28mm 0; }
-          * { box-sizing: border-box; }
-          body {
-            margin: 0; padding: 0; background: white; color: black;
-            font-family: 'Bookman Old Style', Georgia, serif;
-            font-size: 11pt; line-height: 1.4;
-          }
-          p { margin: 0; padding: 0; }
-          article { margin: 0; }
-          .doc-page { width: 210mm; box-sizing: border-box; margin: 0 auto; padding: 5mm 20mm 0; }
-          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; text-align: center; }
-          .doc-header img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
-          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; text-align: justify; text-justify: inter-word; }
-          .doc-body p { text-align: justify; text-justify: inter-word; }
-          .doc-title { margin-top: 0.75rem; text-align: center; font-weight: 700; line-height: 1.3; }
-          .doc-title p { margin: 0; }
-          .doc-text-block { margin-top: 1rem; }
-          .doc-text-block > * + * { margin-top: 0.85rem; }
-          .doc-identity { display: grid; grid-template-columns: 28mm 5mm minmax(0, 1fr); row-gap: 0.2rem; }
-          .doc-identity .colon { text-align: center; }
-          .doc-list { padding-left: 0; margin: 0; }
-          .doc-list-item { display: grid; grid-template-columns: 8mm minmax(0, 1fr); }
-          .doc-list-item + .doc-list-item { margin-top: 0.5rem; }
-          .doc-list-item .text { text-align: justify; }
-          .signature { width: 20rem; margin-left: auto; margin-top: 1.5rem; }
-          .signature p { margin: 0; padding: 0; line-height: 1.3; }
-          .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; margin-top: 2rem; margin-bottom: 2rem; }
-          .doc-editable { outline: none; border-bottom: none !important; }
-        </style>
-      </head>
-      <body>${printContent.innerHTML}</body>
-    </html>
-  `);
-  printWindow.document.close();
-  printWindow.focus();
-  setTimeout(() => printWindow.print(), 500);
+  printPernyataan({
+    rootId: ROOT_ID,
+    title: "Surat Pernyataan Tanggung Jawab Mutlak",
+    emptyMessage: "Tidak ada dokumen SPTJM untuk dicetak.",
+  });
 }
 
 export function SptjmDocument({ number, kap, kepalaBalai }: SptjmDocumentProps) {
   const today = new Date();
-  const nomorText = buildNomorText(number, kap, today);
+  const nomorText = buildPernyataanNomor("SPTJM", number, kap, today);
 
   return (
-    <div id="sptjm-print-root" className="sptjm-print-root">
-      <style jsx global>{`
-        .sptjm-print-root .doc-editable { outline: none; border-bottom: 1px dashed transparent; transition: border-bottom-color 0.15s ease; }
-        .sptjm-print-root .doc-editable:hover { border-bottom-color: #94a3b8; }
-        .sptjm-print-root .doc-editable:focus { border-bottom-color: #64748b; }
-        @media print {
-          @page { size: A4; margin: 0 0 28mm 0; }
-          body * { visibility: hidden; }
-          .sptjm-print-root, .sptjm-print-root * { visibility: visible; }
-          .sptjm-print-root {
-            position: absolute; left: 0; top: 0; width: 100%;
-            background: white; color: black;
-            font-family: 'Bookman Old Style', Georgia, serif;
-            font-size: 11pt; line-height: 1.4; margin: 0; padding: 0;
-          }
-          .doc-page { width: 210mm; margin: 0 auto; padding: 5mm 20mm 0; box-shadow: none !important; }
-          .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; }
-          .doc-header img { max-width: 196mm !important; }
-          .doc-body { width: 166mm; margin-left: auto; margin-right: auto; }
-          .doc-editable { border-bottom: none !important; }
-        }
-      `}</style>
-
-      <article
-        className="doc-page mx-auto max-w-[210mm] bg-white px-24 py-9 text-black shadow-xl ring-1 ring-zinc-200"
-        style={{ fontFamily: "'Bookman Old Style', Georgia, serif", fontSize: "11pt", lineHeight: "1.4" }}
-      >
-        <div className="doc-header -mx-18 text-center">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/header-new.png" alt="Kop Surat" style={{ width: "196mm", maxWidth: "196mm", height: "auto", display: "block", margin: "0 auto" }} />
-        </div>
-
-        <div className="doc-title mt-2 text-center font-bold leading-snug">
-          <p className="m-0">SURAT PERNYATAAN TANGGUNG JAWAB MUTLAK</p>
-          <p className="m-0 font-normal">Nomor : {nomorText}</p>
-        </div>
-
-        <div className="doc-body doc-text-block mx-auto mt-4 w-[166mm] space-y-3 text-justify">
-          <p contentEditable suppressContentEditableWarning className="doc-editable">
-            Yang bertanda tangan dibawah ini :
-          </p>
-          <div className="doc-identity grid grid-cols-[28mm_5mm_minmax(0,1fr)]">
-            <span>Nama</span>
-            <span className="colon text-center">:</span>
-            <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nama}</span>
-            <span>NIP</span>
-            <span className="colon text-center">:</span>
-            <span contentEditable suppressContentEditableWarning className="doc-editable">{kepalaBalai.nip}</span>
-            <span>Pangkat/Gol</span>
-            <span className="colon text-center">:</span>
-            <span contentEditable suppressContentEditableWarning className="doc-editable">Pembina Tk.I / IV b</span>
-            <span>Jabatan</span>
-            <span className="colon text-center">:</span>
-            <span contentEditable suppressContentEditableWarning className="doc-editable">Kepala Balai KSDA Kalimantan Timur</span>
-          </div>
-          <p contentEditable suppressContentEditableWarning className="doc-editable">
-            Dengan ini menyatakan sebagai berikut :
-          </p>
-          <ol className="doc-list space-y-2">
-            <li className="doc-list-item grid grid-cols-[8mm_minmax(0,1fr)]">
-              <span>1.</span>
-              <span contentEditable suppressContentEditableWarning className="doc-editable text text-justify">
-                Bertanggung jawab secara penuh atas kebenaran permohonan yang diajukan baik materiil maupun formil;
-              </span>
-            </li>
-            <li className="doc-list-item grid grid-cols-[8mm_minmax(0,1fr)]">
-              <span>2.</span>
-              <span contentEditable suppressContentEditableWarning className="doc-editable text text-justify">
-                Bahwa Barang Milik Negara yang diusulkan pemindahtanganan dengan penjualan dalam kondisi rusak berat, tidak dapat digunakan dan dimanfaatkan lagi sehingga Barang Milik Negara dimaksud harus dilakukan penghapusan berdasarkan ketentuan perundangan yang berlaku.
-              </span>
-            </li>
-          </ol>
-          <p contentEditable suppressContentEditableWarning className="doc-editable">
-            Demikian pernyataan ini kami buat dengan keadaan sebenarnya untuk dapat dipergunakan sebagaimana mestinya.
-          </p>
-        </div>
-
-        <div className="signature mt-6 ml-auto w-80">
-          <p className="m-0">Samarinda, {formatDateLong(today)}</p>
-          <p className="m-0">Kepala Balai,</p>
-          <div className="ttd-placeholder mt-8 box-border h-28 pt-10 pl-[1.35cm] text-zinc-400">${"{ttd_pengirim}"}</div>
-          <p contentEditable suppressContentEditableWarning className="doc-editable m-0 mt-8">{kepalaBalai.nama}</p>
-          <p contentEditable suppressContentEditableWarning className="doc-editable m-0">NIP. {kepalaBalai.nip}</p>
-        </div>
-      </article>
-    </div>
+    <PernyataanDocument
+      rootId={ROOT_ID}
+      title="SURAT PERNYATAAN TANGGUNG JAWAB MUTLAK"
+      nomorText={nomorText}
+      today={today}
+      kepalaBalai={kepalaBalai}
+    >
+      <p contentEditable suppressContentEditableWarning className="doc-editable">
+        Yang bertanda tangan dibawah ini :
+      </p>
+      <PernyataanIdentity kepalaBalai={kepalaBalai} />
+      <p contentEditable suppressContentEditableWarning className="doc-editable">
+        Dengan ini menyatakan sebagai berikut :
+      </p>
+      <ol className="doc-list space-y-2">
+        <li className="doc-list-item grid grid-cols-[8mm_minmax(0,1fr)]">
+          <span>1.</span>
+          <span contentEditable suppressContentEditableWarning className="doc-editable text text-justify">
+            Bertanggung jawab secara penuh atas kebenaran permohonan yang diajukan baik materiil maupun formil;
+          </span>
+        </li>
+        <li className="doc-list-item grid grid-cols-[8mm_minmax(0,1fr)]">
+          <span>2.</span>
+          <span contentEditable suppressContentEditableWarning className="doc-editable text text-justify">
+            Bahwa Barang Milik Negara yang diusulkan pemindahtanganan dengan penjualan dalam kondisi rusak berat, tidak dapat digunakan dan dimanfaatkan lagi sehingga Barang Milik Negara dimaksud harus dilakukan penghapusan berdasarkan ketentuan perundangan yang berlaku.
+          </span>
+        </li>
+      </ol>
+      <p contentEditable suppressContentEditableWarning className="doc-editable">
+        Demikian pernyataan ini kami buat dengan keadaan sebenarnya untuk dapat dipergunakan sebagaimana mestinya.
+      </p>
+    </PernyataanDocument>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/_lib/print-pernyataan.ts
+++ b/frontend/src/app/bmn/auction-candidates/_lib/print-pernyataan.ts
@@ -1,0 +1,86 @@
+// Shared print helpers for the BMN "Surat Pernyataan" documents
+// (SPTJM, Tanggung Jawab Nilai Limit, Tidak Mengganggu Kelancaran Tugas).
+//
+// These three documents share an identical print layout. Keeping a single
+// source of truth here avoids drift between their print stylesheets and the
+// window-opening logic.
+
+import { toast } from "sonner";
+
+/**
+ * Canonical print stylesheet for the "Surat Pernyataan" family. This is the
+ * union of the rules previously duplicated across each document; the extra
+ * `.doc-list*` rules are harmless for documents that don't render a list.
+ */
+export const PERNYATAAN_PRINT_CSS = `
+  @page { size: A4; margin: 0 0 28mm 0; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 0; background: white; color: black;
+    font-family: 'Bookman Old Style', Georgia, serif;
+    font-size: 11pt; line-height: 1.4;
+  }
+  p { margin: 0; padding: 0; }
+  article { margin: 0; }
+  .doc-page { width: 210mm; box-sizing: border-box; margin: 0 auto; padding: 5mm 20mm 0; }
+  .doc-header { margin-top: -5mm; margin-left: -16mm; margin-right: -16mm; text-align: center; }
+  .doc-header img { width: 196mm !important; max-width: 196mm !important; height: auto !important; display: block; margin: 0 auto; }
+  .doc-body { width: 166mm; margin-left: auto; margin-right: auto; text-align: justify; text-justify: inter-word; }
+  .doc-body p { text-align: justify; text-justify: inter-word; }
+  .doc-title { margin-top: 0.75rem; text-align: center; font-weight: 700; line-height: 1.3; }
+  .doc-title p { margin: 0; }
+  .doc-text-block { margin-top: 1rem; }
+  .doc-text-block > * + * { margin-top: 0.85rem; }
+  .doc-identity { display: grid; grid-template-columns: 28mm 5mm minmax(0, 1fr); row-gap: 0.2rem; column-gap: 0; }
+  .doc-identity .colon { text-align: center; }
+  .doc-list { padding-left: 0; margin: 0; }
+  .doc-list-item { display: grid; grid-template-columns: 8mm minmax(0, 1fr); column-gap: 0; }
+  .doc-list-item + .doc-list-item { margin-top: 0.5rem; }
+  .doc-list-item .text { text-align: justify; }
+  .signature { width: 20rem; margin-left: auto; margin-top: 1.5rem; }
+  .signature p { margin: 0; padding: 0; line-height: 1.3; }
+  .ttd-placeholder { box-sizing: border-box; height: 112px; padding-top: 40px; padding-left: 1.35cm; color: #94a3b8; margin-top: 2rem; margin-bottom: 2rem; }
+  .doc-editable { outline: none; border-bottom: none !important; }
+`;
+
+/**
+ * Build the surat-pernyataan "Nomor" string. Only the leading prefix differs
+ * between document types (e.g. "SPTJM" vs "SM").
+ */
+export function buildPernyataanNomor(prefix: string, number: string, kap: string, today: Date): string {
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  return `${prefix}.${number.trim() || "____"}/K.18/TU/${kap.trim() || "KAP.06.01"}/B/${month}/${today.getFullYear()}`;
+}
+
+interface PrintPernyataanOptions {
+  /** DOM id of the on-screen print root to clone into the print window. */
+  rootId: string;
+  /** Title shown in the print window's <head>. */
+  title: string;
+  /** Toast message shown when the print root cannot be found. */
+  emptyMessage: string;
+}
+
+/** Open a print window for one of the surat-pernyataan documents. */
+export function printPernyataan({ rootId, title, emptyMessage }: PrintPernyataanOptions): void {
+  const printContent = document.getElementById(rootId);
+  if (!printContent) {
+    toast.error(emptyMessage);
+    return;
+  }
+  const printWindow = window.open("", "_blank");
+  if (!printWindow) return;
+
+  printWindow.document.write(`
+    <html>
+      <head>
+        <title>${title}</title>
+        <style>${PERNYATAAN_PRINT_CSS}</style>
+      </head>
+      <body>${printContent.innerHTML}</body>
+    </html>
+  `);
+  printWindow.document.close();
+  printWindow.focus();
+  setTimeout(() => printWindow.print(), 500);
+}

--- a/frontend/src/app/bmn/auction-candidates/_lib/sk-print.ts
+++ b/frontend/src/app/bmn/auction-candidates/_lib/sk-print.ts
@@ -1,0 +1,359 @@
+// Shared print-pagination engine for the BMN "SK" (Keputusan) documents:
+// SK Penghentian, SK Panitia, and SK Tim Penilai.
+//
+// All three documents render their main page (KOP + title + Menimbang +
+// Mengingat + MEMUTUSKAN + TTD) into a hidden print root, then run an
+// identical JS pagination pass inside the opened print window. The pass:
+//   1. measures the live A4 layout,
+//   2. re-flows the Menimbang / Mengingat / decision blocks into explicit
+//      297mm pages with a bottom safe area (for BSrE QR placement), and
+//   3. injects right-aligned "continuation words" at each page break.
+//
+// The only things that differ between documents are a CSS class prefix, the
+// `section-start` top margin, and the set of decision-row labels / final
+// "group" block. Those are expressed via {@link SkPaginationConfig} so the
+// algorithm itself lives in a single place.
+
+export interface SkPaginationConfig {
+  /** CSS class prefix without trailing dash, e.g. "sk", "skp", "sktp". */
+  prefix: string;
+  /** Top margin applied to the first item of each field section in print. */
+  sectionStartMarginTop: string;
+  /**
+   * Continuation labels for `explicitMemRows[1..]` (row 0 is always paired
+   * with the MEMUTUSKAN heading). e.g. ["KESATU.....", "KEDUA....."].
+   */
+  decisionRowLabels: string[];
+  /** Class of the final grouped decision block, e.g. "sk-ketiga-group". */
+  finalGroupClass: string;
+  /** Continuation label for the final grouped block, e.g. "KETIGA.....". */
+  finalGroupLabel: string;
+}
+
+/**
+ * Build the `<style>` markup (a single rules string) injected before the
+ * pagination pass. Kept identical to the inline versions previously embedded
+ * in each document, parameterised only by prefix and section margin.
+ */
+function buildPaginationStyle(p: string, sectionStartMarginTop: string): string {
+  return `
+        @page ${p}-main { size: A4; margin: 0; }
+        @page ${p}-main:first { size: A4; margin: 0; }
+        .${p}-print-root .${p}-page.${p}-main-document.${p}-main-paginated {
+          height: 297mm !important;
+          min-height: 297mm !important;
+          padding: 5mm 20mm 28mm !important;
+          overflow: hidden !important;
+          position: relative !important;
+          box-shadow: none !important;
+        }
+        .${p}-print-root .${p}-page.${p}-main-document.${p}-main-paginated.${p}-main-continuation-page {
+          padding-top: 18mm !important;
+        }
+        .${p}-print-root .${p}-main-document.${p}-main-page-break {
+          page-break-after: always;
+          break-after: page;
+        }
+        .${p}-main-paginated .${p}-paginated-field-section + .${p}-paginated-field-section {
+          margin-top: 0 !important;
+        }
+        .${p}-main-paginated .${p}-paginated-field-section.${p}-section-start {
+          margin-top: ${sectionStartMarginTop} !important;
+        }
+        .${p}-continuation-word {
+          position: absolute !important;
+          right: 23mm !important;
+          bottom: 31mm !important;
+          width: 163mm !important;
+          height: 0 !important;
+          line-height: 11pt !important;
+          overflow: visible !important;
+          white-space: nowrap !important;
+          text-align: right !important;
+          margin: 0 !important;
+          padding: 0 !important;
+          font-weight: normal !important;
+          font-size: 11pt !important;
+          z-index: 20 !important;
+        }
+      `;
+}
+
+/**
+ * Run the shared SK pagination pass inside an already-populated print window.
+ * Falls back to a plain `print()` if the expected DOM structure is missing.
+ *
+ * This should be called inside the `setTimeout(..., 600)` that waits for the
+ * print window's initial render, mirroring the original per-document code.
+ */
+export function runSkPagination(printWindow: Window, config: SkPaginationConfig): void {
+  const p = config.prefix;
+  try {
+    const doc = printWindow.document;
+    const body = doc.body;
+    if (!body) {
+      printWindow.print();
+      return;
+    }
+
+    const paginationStyle = doc.createElement("style");
+    paginationStyle.textContent = buildPaginationStyle(p, config.sectionStartMarginTop);
+    body.appendChild(paginationStyle);
+
+    // Force layout by reading offsetHeight
+    void body.offsetHeight;
+
+    const mmToPx = 96 / 25.4;
+    const firstPageContentH = 264 * mmToPx;
+    const continuationContentH = 251 * mmToPx;
+    const markerReserveH = 9 * mmToPx;
+
+    const mainDoc = doc.querySelector(`.${p}-main-document`);
+    if (!mainDoc) {
+      printWindow.print();
+      return;
+    }
+
+    const root = mainDoc.parentElement;
+    if (!root) {
+      printWindow.print();
+      return;
+    }
+
+    const continuationLabel = (num: string, text: string) => {
+      const firstWord = text.trim().split(/\s+/)[0] || "";
+      return `${num.trim()} ${firstWord ? `${firstWord}.....` : "....."}`;
+    };
+
+    const cloneElement = <T extends HTMLElement>(el: T) => el.cloneNode(true) as T;
+
+    const createFieldBlock = (
+      sectionLabel: string,
+      item: HTMLElement,
+      showSectionLabel: boolean,
+      marginTop = false,
+    ) => {
+      const section = doc.createElement("div");
+      section.className = `${p}-field-section ${p}-paginated-field-section`;
+      section.style.marginTop = marginTop ? "0.75rem" : "0";
+      if (marginTop) section.classList.add(`${p}-section-start`);
+
+      const label = doc.createElement("div");
+      label.className = `${p}-field-label`;
+      label.textContent = showSectionLabel ? sectionLabel : "";
+
+      const colon = doc.createElement("div");
+      colon.className = `${p}-field-colon`;
+      colon.textContent = showSectionLabel ? ":" : "";
+
+      const list = doc.createElement("div");
+      list.className = `${p}-mengingat-list`;
+      const itemClone = cloneElement(item);
+      itemClone.style.paddingTop = "0";
+      list.appendChild(itemClone);
+
+      section.append(label, colon, list);
+      return section;
+    };
+
+    const createDecisionBlock = (rows: HTMLElement[]) => {
+      const table = doc.createElement("table");
+      table.className = `${p}-mengingat-table`;
+      table.style.borderCollapse = "collapse";
+
+      const tbody = doc.createElement("tbody");
+      rows.forEach((row) => tbody.appendChild(cloneElement(row)));
+      table.appendChild(tbody);
+      return table;
+    };
+
+    const createMemutuskanMenetapkanBlock = (heading: HTMLElement, row: HTMLElement) => {
+      const block = doc.createElement("div");
+      block.appendChild(cloneElement(heading));
+      block.appendChild(createDecisionBlock([row]));
+      return block;
+    };
+
+    const makePage = (isFirstPage: boolean) => {
+      const page = doc.createElement("article");
+      page.className = `${p}-page ${p}-page-ttd ${p}-main-document ${p}-main-paginated mx-auto max-w-[210mm] bg-white px-24 py-9 text-black`;
+      if (!isFirstPage) page.classList.add(`${p}-main-continuation-page`);
+      page.style.cssText = [
+        "width: 210mm",
+        "height: 297mm",
+        "min-height: 297mm",
+        "margin: 0 auto",
+        `padding: ${isFirstPage ? "5mm" : "18mm"} 20mm 28mm`,
+        "overflow: hidden",
+        "position: relative",
+        "box-sizing: border-box",
+        "background: white",
+        "color: black",
+      ].join("; ");
+
+      const flow = doc.createElement("div");
+      flow.className = `${p}-main-flow`;
+      page.appendChild(flow);
+
+      const bodyWrap = doc.createElement("div");
+      bodyWrap.className = `${p}-body`;
+      flow.appendChild(bodyWrap);
+
+      return { page, flow, bodyWrap };
+    };
+
+    const addContinuationWord = (page: HTMLElement, label: string) => {
+      const contWord = doc.createElement("p");
+      contWord.className = `${p}-continuation-word`;
+      contWord.textContent = label;
+      page.appendChild(contWord);
+    };
+
+    const measureFlowContentHeight = (flow: HTMLElement) => {
+      const flowTop = flow.getBoundingClientRect().top;
+      return Array.from(flow.children).reduce((maxBottom, child) => {
+        const rect = (child as HTMLElement).getBoundingClientRect();
+        return Math.max(maxBottom, rect.bottom - flowTop);
+      }, 0);
+    };
+
+    const measureOuterHeight = (el: HTMLElement) => {
+      const rect = el.getBoundingClientRect();
+      const style = printWindow.getComputedStyle(el);
+      const marginTop = Number.parseFloat(style.marginTop || "0") || 0;
+      const marginBottom = Number.parseFloat(style.marginBottom || "0") || 0;
+      return rect.height + marginTop + marginBottom;
+    };
+
+    const contentWrap = mainDoc.querySelector<HTMLElement>(`.${p}-subtitle`);
+    const contentSections = contentWrap?.querySelector<HTMLElement>("div");
+    const fieldSections = contentSections?.querySelectorAll<HTMLElement>(`:scope > .${p}-field-section`);
+    const menimbangItems = fieldSections?.[0]?.querySelectorAll<HTMLElement>(`.${p}-mengingat-item`) || [];
+    const mengingatItems = fieldSections?.[1]?.querySelectorAll<HTMLElement>(`.${p}-mengingat-item`) || [];
+
+    const explicitMemutuskanHeading = mainDoc.querySelector<HTMLElement>(`.${p}-memutuskan`);
+    const explicitMemRows = Array.from(mainDoc.querySelectorAll<HTMLElement>(`.${p}-mengingat-row`));
+    const finalGroup = mainDoc.querySelector<HTMLElement>(`.${config.finalGroupClass}`);
+
+    let currentPage = makePage(true);
+    root.insertBefore(currentPage.page, mainDoc);
+
+    const kop = mainDoc.querySelector<HTMLElement>(`.${p}-kop`);
+    const title = mainDoc.querySelector<HTMLElement>(`.${p}-title`);
+    const intro = doc.createElement("div");
+    intro.className = `${p}-subtitle ${p}-body`;
+    const introParagraphs = Array.from(contentWrap?.children || []).filter((child) => {
+      return child.tagName === "P" && !(child as HTMLElement).classList.contains(`${p}-memutuskan`);
+    });
+    introParagraphs.forEach((child) => intro.appendChild(cloneElement(child as HTMLElement)));
+
+    const firstBody = currentPage.bodyWrap;
+    currentPage.flow.insertBefore(intro, firstBody);
+    if (title) currentPage.flow.insertBefore(cloneElement(title), intro);
+    if (kop) currentPage.flow.insertBefore(cloneElement(kop), currentPage.flow.firstChild);
+    let currentUsedHeight = measureFlowContentHeight(currentPage.flow);
+
+    const blocks: { el: HTMLElement; label: string }[] = [];
+
+    Array.from(menimbangItems).forEach((item, index) => {
+      const num = item.querySelector("div:first-child")?.textContent || "";
+      const text = item.querySelector(`.${p}-mengingat-text`)?.textContent || "";
+      blocks.push({
+        el: createFieldBlock("Menimbang", item, index === 0),
+        label: continuationLabel(num, text),
+      });
+    });
+
+    Array.from(mengingatItems).forEach((item, index) => {
+      const num = item.querySelector("div:first-child")?.textContent || "";
+      const text = item.querySelector(`.${p}-mengingat-text`)?.textContent || "";
+      blocks.push({
+        el: createFieldBlock("Mengingat", item, index === 0, index === 0),
+        label: continuationLabel(num, text),
+      });
+    });
+
+    if (explicitMemutuskanHeading && explicitMemRows[0]) {
+      blocks.push({
+        el: createMemutuskanMenetapkanBlock(explicitMemutuskanHeading, explicitMemRows[0]),
+        label: "MEMUTUSKAN.....",
+      });
+    } else if (explicitMemutuskanHeading) {
+      blocks.push({ el: cloneElement(explicitMemutuskanHeading), label: "MEMUTUSKAN....." });
+    } else if (explicitMemRows[0]) {
+      blocks.push({ el: createDecisionBlock([explicitMemRows[0]]), label: "Menetapkan....." });
+    }
+
+    config.decisionRowLabels.forEach((label, i) => {
+      const row = explicitMemRows[i + 1];
+      if (row) {
+        blocks.push({ el: createDecisionBlock([row]), label });
+      }
+    });
+
+    if (finalGroup) {
+      blocks.push({ el: cloneElement(finalGroup), label: config.finalGroupLabel });
+    }
+
+    blocks.forEach((block, index) => {
+      const isLastBlock = index === blocks.length - 1;
+      const contentLimit = currentPage.page.classList.contains(`${p}-main-continuation-page`)
+        ? continuationContentH
+        : firstPageContentH;
+      const maxFlowHeight = contentLimit - (isLastBlock ? 0 : markerReserveH);
+      const markerSafeHeight = contentLimit - markerReserveH;
+
+      currentPage.bodyWrap.appendChild(block.el);
+      const blockHeight = measureOuterHeight(block.el);
+      const flowHeight = currentUsedHeight + blockHeight;
+      const canMoveToNextPage = currentPage.bodyWrap.children.length > 1;
+      if ((flowHeight > maxFlowHeight || (!isLastBlock && flowHeight > markerSafeHeight)) && canMoveToNextPage) {
+        currentPage.bodyWrap.removeChild(block.el);
+        currentPage.page.classList.add(`${p}-main-page-break`);
+        addContinuationWord(currentPage.page, block.label);
+
+        currentPage = makePage(false);
+        root.insertBefore(currentPage.page, mainDoc);
+        currentPage.bodyWrap.appendChild(block.el);
+        currentUsedHeight = measureOuterHeight(block.el);
+      } else {
+        currentUsedHeight = flowHeight;
+      }
+    });
+
+    root.removeChild(mainDoc);
+  } catch {
+    // Silently fail — print without continuation words
+  }
+  setTimeout(() => printWindow.print(), 300);
+}
+
+/**
+ * Open a print window, write the document HTML + the supplied static print
+ * CSS, then schedule the shared pagination pass. Returns early (with a no-op)
+ * if the print root is missing or the window was blocked.
+ */
+export function openSkPrintWindow(options: {
+  rootId: string;
+  title: string;
+  printCss: string;
+  config: SkPaginationConfig;
+}): void {
+  const printContent = document.getElementById(options.rootId);
+  if (!printContent) return;
+  const printWindow = window.open("", "_blank");
+  if (!printWindow) return;
+
+  printWindow.document.write(`
+    <html>
+      <head>
+        <title>${options.title}</title>
+        <style>${options.printCss}</style>
+      </head>
+      <body>${printContent.innerHTML}</body>
+    </html>
+  `);
+  printWindow.document.close();
+  printWindow.focus();
+  setTimeout(() => runSkPagination(printWindow, options.config), 600);
+}


### PR DESCRIPTION
## Ringkasan

Refactor modul BMN `auction-candidates` dengan teknik DRY (single source of truth), melanjutkan pola refactor kepegawaian (#392). Menghilangkan dua sumber duplikasi terbesar tanpa mengubah perilaku output.

Closes #394

## Perubahan

### Surat Pernyataan (SPTJM, Nilai Limit, Tugas)
Tiga dokumen ~95% identik. Diekstrak:
- `_lib/print-pernyataan.ts` — shared print CSS, `buildPernyataanNomor`, `printPernyataan`
- `_components/PernyataanDocument.tsx` — shell bersama (KOP, judul/nomor, blok TTD) + `PernyataanIdentity`

| File | Sebelum | Sesudah |
|------|--------:|--------:|
| SptjmDocument.tsx | 151 | 61 |
| SptjLimitDocument.tsx | 157 | 61 |
| SpTugasDocument.tsx | 133 | 47 |

### SK documents (Penghentian, Panitia, Tim Penilai)
Engine pagination JS ~230 baris (continuation words, BSrE safe area, `measureFlowContentHeight`/`measureOuterHeight`, re-flow halaman) sebelumnya copy-paste 3x. Diekstrak ke `_lib/sk-print.ts` sebagai `runSkPagination(printWindow, config)`, terparameter hanya pada yang berbeda: prefix kelas (`sk`/`skp`/`sktp`), margin `section-start`, label baris keputusan, dan kelas grup final.

| File | Sebelum | Sesudah |
|------|--------:|--------:|
| SkPenghentianDocument.tsx | 1061 | 800 |
| SkPanitiaDocument.tsx | 893 | 638 |
| SkTimPenilaiDocument.tsx | 782 | 572 |

### Perbaikan tampilan
Isi baris "Menetapkan" pada MEMUTUSKAN kini **bold** di ketiga SK (heading MEMUTUSKAN tetap bold, label "Menetapkan" tetap normal). Berlaku di preview & cetak/PDF.

## Catatan
- Zero behavior change pada output cetak/PDF. CSS statis tiap dokumen sengaja dibiarkan inline agar tweak per-dokumen tetap aman.
- Nama handler ekspor (`handlePrintSk`, dll.) tidak berubah → `page.tsx` & section wrappers tidak perlu diedit.

## Validasi
- `npx eslint --max-warnings=0` ✅
- `npx tsc --noEmit` ✅
- `npm run build` ✅ (59/59)
- Test manual di browser oleh reviewer ✅
