### PR TITLE
feat(bmn): approve import review changes per field (#398)

### DIFF
--- a/backend/app/Modules/Bmn/Controllers/ImportReviewController.php
+++ b/backend/app/Modules/Bmn/Controllers/ImportReviewController.php
@@ -5,6 +5,7 @@ namespace App\Modules\Bmn\Controllers;
 use App\Http\Controllers\Controller;
 use App\Modules\Bmn\Imports\AssetStagingImport;
 use App\Modules\Bmn\Models\Asset;
+use App\Modules\Bmn\Models\AssetUpdate;
 use App\Modules\Bmn\Models\ImportBatch;
 use App\Modules\Bmn\Models\ImportStaging;
 use Exception;
@@ -330,6 +331,17 @@ class ImportReviewController extends Controller
                                 $updateData[$field] = $values['new'];
                             }
                             if (!empty($updateData)) {
+                                foreach ($updateData as $field => $newValue) {
+                                    AssetUpdate::create([
+                                        'asset_id' => $asset->id,
+                                        'user_id' => $request->user()->id,
+                                        'field_changed' => $field,
+                                        'old_value' => $this->historyValue($changedFields[$field]['old'] ?? $asset->{$field}),
+                                        'new_value' => $this->historyValue($newValue),
+                                        'alasan_perubahan' => "Import review: {$batch->filename}",
+                                    ]);
+                                }
+
                                 $asset->update($updateData);
                                 $updated++;
                             }
@@ -402,6 +414,19 @@ class ImportReviewController extends Controller
         }
 
         return false;
+    }
+
+    private function historyValue($value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format('Y-m-d');
+        }
+
+        return (string) $value;
     }
 
     private function buildFilteredRowsQuery(ImportBatch $batch, Request $request)

--- a/backend/app/Modules/Bmn/Controllers/ImportReviewController.php
+++ b/backend/app/Modules/Bmn/Controllers/ImportReviewController.php
@@ -136,11 +136,50 @@ class ImportReviewController extends Controller
             'selected' => 'required|boolean',
         ]);
 
-        ImportStaging::whereIn('id', $request->ids)
+        $rows = ImportStaging::whereIn('id', $request->ids)
             ->whereIn('diff_status', ['new', 'updated'])
-            ->update(['selected' => $request->selected]);
+            ->get();
+
+        foreach ($rows as $row) {
+            $updates = ['selected' => $request->selected];
+
+            if ($row->diff_status === 'updated') {
+                $updates['changed_fields'] = $this->setAllFieldSelection($row->changed_fields ?? [], $request->boolean('selected'));
+            }
+
+            $row->update($updates);
+        }
 
         return response()->json(['message' => 'Seleksi diperbarui.']);
+    }
+
+    /**
+     * Step 2bb: Toggle approval of one changed field in an updated row.
+     */
+    public function toggleFieldSelection(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'row_id' => 'required|string|exists:bmn_import_staging,id',
+            'field' => 'required|string|max:255',
+            'selected' => 'required|boolean',
+        ]);
+
+        $row = ImportStaging::where('diff_status', 'updated')
+            ->whereHas('batch', fn ($query) => $query->where('status', 'pending'))
+            ->findOrFail($validated['row_id']);
+
+        $changedFields = $row->changed_fields ?? [];
+        if (!array_key_exists($validated['field'], $changedFields)) {
+            return response()->json(['error' => 'Kolom perubahan tidak ditemukan.'], 422);
+        }
+
+        $changedFields[$validated['field']]['selected'] = $validated['selected'];
+        $row->update([
+            'changed_fields' => $changedFields,
+            'selected' => $this->hasSelectedChangedField($changedFields),
+        ]);
+
+        return response()->json(['message' => 'Seleksi kolom diperbarui.']);
     }
 
     /**
@@ -161,9 +200,19 @@ class ImportReviewController extends Controller
 
         if ($validated['action'] === 'select_changed') {
             // Select ALL changed rows (new + updated)
-            $selected = (clone $baseQuery)
+            $rows = (clone $baseQuery)
                 ->whereIn('diff_status', ['new', 'updated'])
-                ->update(['selected' => true]);
+                ->get();
+
+            $selected = 0;
+            foreach ($rows as $row) {
+                $updates = ['selected' => true];
+                if ($row->diff_status === 'updated') {
+                    $updates['changed_fields'] = $this->setAllFieldSelection($row->changed_fields ?? [], true);
+                }
+                $row->update($updates);
+                $selected++;
+            }
 
             return response()->json([
                 'message' => "{$selected} baris (baru + update) dipilih.",
@@ -173,9 +222,17 @@ class ImportReviewController extends Controller
 
         if ($validated['action'] === 'select_new_only') {
             // Clear all, then select only new rows
-            (clone $baseQuery)
+            $changedRows = (clone $baseQuery)
                 ->where('diff_status', '!=', 'unchanged')
-                ->update(['selected' => false]);
+                ->get();
+
+            foreach ($changedRows as $row) {
+                $updates = ['selected' => false];
+                if ($row->diff_status === 'updated') {
+                    $updates['changed_fields'] = $this->setAllFieldSelection($row->changed_fields ?? [], false);
+                }
+                $row->update($updates);
+            }
 
             $selected = (clone $baseQuery)
                 ->where('diff_status', 'new')
@@ -187,9 +244,19 @@ class ImportReviewController extends Controller
             ]);
         }
 
-        $affected = $baseQuery
+        $rows = $baseQuery
             ->where('diff_status', '!=', 'unchanged')
-            ->update(['selected' => false]);
+            ->get();
+
+        $affected = 0;
+        foreach ($rows as $row) {
+            $updates = ['selected' => false];
+            if ($row->diff_status === 'updated') {
+                $updates['changed_fields'] = $this->setAllFieldSelection($row->changed_fields ?? [], false);
+            }
+            $row->update($updates);
+            $affected++;
+        }
 
         return response()->json([
             'message' => 'Seleksi massal diperbarui.',
@@ -257,12 +324,15 @@ class ImportReviewController extends Controller
                             $changedFields = $row->changed_fields ?? [];
                             $updateData = [];
                             foreach ($changedFields as $field => $values) {
+                                if (($values['selected'] ?? true) === false) {
+                                    continue;
+                                }
                                 $updateData[$field] = $values['new'];
                             }
                             if (!empty($updateData)) {
                                 $asset->update($updateData);
+                                $updated++;
                             }
-                            $updated++;
                         }
                     }
                 }
@@ -312,6 +382,26 @@ class ImportReviewController extends Controller
             ->paginate($request->integer('per_page', 10));
 
         return response()->json($batches);
+    }
+
+    private function setAllFieldSelection(array $changedFields, bool $selected): array
+    {
+        foreach ($changedFields as $field => $values) {
+            $changedFields[$field]['selected'] = $selected;
+        }
+
+        return $changedFields;
+    }
+
+    private function hasSelectedChangedField(array $changedFields): bool
+    {
+        foreach ($changedFields as $values) {
+            if (($values['selected'] ?? true) !== false) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function buildFilteredRowsQuery(ImportBatch $batch, Request $request)

--- a/backend/app/Modules/Bmn/Routes/api.php
+++ b/backend/app/Modules/Bmn/Routes/api.php
@@ -51,6 +51,7 @@ Route::prefix('import-review')->group(function () {
     Route::post('/{batchId}/approve', [ImportReviewController::class, 'approve']);
     Route::post('/{batchId}/reject', [ImportReviewController::class, 'reject']);
     Route::post('/toggle-selection', [ImportReviewController::class, 'toggleSelection']);
+    Route::post('/toggle-field-selection', [ImportReviewController::class, 'toggleFieldSelection']);
     Route::post('/bulk-selection', [ImportReviewController::class, 'bulkSelection']);
 });
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -102,7 +102,7 @@ git push origin main
 
 ## Status Saat Ini
 
-- [ ] Issue #398: BMN Import Review approve per changed field. Branch `issue/398-import-review-per-field-approval` WIP siap PR/testing. Backend tambah `toggle-field-selection`; approve hanya apply kolom `changed_fields[field].selected !== false` dan mencatat history hanya untuk field yang di-apply; frontend tambah checkbox per kolom diff + indikator `Kolom disetujui: X/Y`. Validasi clean: PHP syntax, route:list, eslint 0 warning, tsc, build 59/59. Belum deploy production.
+- [x] Issue #398: BMN Import Review approve per changed field. PR #399 siap squash merge. Backend tambah `toggle-field-selection`; approve hanya apply kolom `changed_fields[field].selected !== false` dan mencatat history hanya untuk field yang di-apply; frontend tambah checkbox per kolom diff + indikator `Kolom disetujui: X/Y`. Validasi clean: PHP syntax, route:list, eslint 0 warning, tsc, build 59/59. Belum deploy production.
 - [x] Create GitHub issue #334 for BMN Aset Akan Di Lelang and BA Koreksi Kondisi document workflow.
 - [x] Add BMN sidebar route `/bmn/auction-candidates` for Rusak Berat assets with search, pagination, bulk select, and process/print document flow.
 - [x] Generate BA Koreksi Perubahan Kondisi BMN preview/print using `header-terbaru.png`, tuned A4 margins, two-page print output, and lampiran table layout.
@@ -169,7 +169,7 @@ git push origin main
 | Field | Value |
 |-------|-------|
 | **Issue Terakhir Selesai** | Issue #396: Security hardening (PR #397 merged) + Dokploy migration/redeploy production completed on 2026-06-11 |
-| **Issue Sedang Dikerjakan** | Issue #398: BMN Import Review approve per changed field (WIP siap PR/testing) |
+| **Issue Sedang Dikerjakan** | Issue #398: BMN Import Review approve per changed field (PR #399 siap squash merge) |
 | **Branch Aktif** | `issue/398-import-review-per-field-approval` |
 | **Commit Terakhir di Main** | `2d0c075` (deploy: add Dokploy compose file) |
 | **Commit Production Server** | Dokploy compose at `2d0c075`; issue #398 belum deploy production |

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -102,7 +102,7 @@ git push origin main
 
 ## Status Saat Ini
 
-- [ ] Issue #398: BMN Import Review approve per changed field. Branch `issue/398-import-review-per-field-approval` WIP siap PR/testing. Backend tambah `toggle-field-selection`; approve hanya apply kolom `changed_fields[field].selected !== false`; frontend tambah checkbox per kolom diff + indikator `Kolom disetujui: X/Y`. Validasi clean: PHP syntax, route:list, eslint 0 warning, tsc, build 59/59. Belum deploy production.
+- [ ] Issue #398: BMN Import Review approve per changed field. Branch `issue/398-import-review-per-field-approval` WIP siap PR/testing. Backend tambah `toggle-field-selection`; approve hanya apply kolom `changed_fields[field].selected !== false` dan mencatat history hanya untuk field yang di-apply; frontend tambah checkbox per kolom diff + indikator `Kolom disetujui: X/Y`. Validasi clean: PHP syntax, route:list, eslint 0 warning, tsc, build 59/59. Belum deploy production.
 - [x] Create GitHub issue #334 for BMN Aset Akan Di Lelang and BA Koreksi Kondisi document workflow.
 - [x] Add BMN sidebar route `/bmn/auction-candidates` for Rusak Berat assets with search, pagination, bulk select, and process/print document flow.
 - [x] Generate BA Koreksi Perubahan Kondisi BMN preview/print using `header-terbaru.png`, tuned A4 margins, two-page print output, and lampiran table layout.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -102,6 +102,7 @@ git push origin main
 
 ## Status Saat Ini
 
+- [ ] Issue #398: BMN Import Review approve per changed field. Branch `issue/398-import-review-per-field-approval` WIP siap PR/testing. Backend tambah `toggle-field-selection`; approve hanya apply kolom `changed_fields[field].selected !== false`; frontend tambah checkbox per kolom diff + indikator `Kolom disetujui: X/Y`. Validasi clean: PHP syntax, route:list, eslint 0 warning, tsc, build 59/59. Belum deploy production.
 - [x] Create GitHub issue #334 for BMN Aset Akan Di Lelang and BA Koreksi Kondisi document workflow.
 - [x] Add BMN sidebar route `/bmn/auction-candidates` for Rusak Berat assets with search, pagination, bulk select, and process/print document flow.
 - [x] Generate BA Koreksi Perubahan Kondisi BMN preview/print using `header-terbaru.png`, tuned A4 margins, two-page print output, and lampiran table layout.
@@ -167,12 +168,12 @@ git push origin main
 
 | Field | Value |
 |-------|-------|
-| **Issue Terakhir Selesai** | Issue #396: Security hardening (PR #397 merged, akan aktif setelah Dokploy redeploy) |
-| **Issue Sedang Dikerjakan** | Migrasi VPS ke Dokploy (paused — DNS propagasi pending, lanjut besok) |
-| **Branch Aktif** | `main` |
-| **Commit Terakhir di Main** | `6c06307` (kode) + `eef13ad` (docs) + `50dfeab` (gitignore) |
-| **Commit Production Server** | N/A — VPS sudah di-wipe, Dokploy fresh install (dashboard `http://15.135.114.1:3000`, belum redeploy app) |
-| **Status** | Phase 1 (backup) ✅, Phase 2 (wipe, free 15.75GB) ✅, Phase 3 (install Dokploy v0.29.5) ✅, Phase 4 (redeploy app) **paused — DNS `dokploy.bksdakaltim.net` belum propagasi**. Production app currently **DOWN** (intentional — sedang migrasi). Dashboard Dokploy live di IP. |
+| **Issue Terakhir Selesai** | Issue #396: Security hardening (PR #397 merged) + Dokploy migration/redeploy production completed on 2026-06-11 |
+| **Issue Sedang Dikerjakan** | Issue #398: BMN Import Review approve per changed field (WIP siap PR/testing) |
+| **Branch Aktif** | `issue/398-import-review-per-field-approval` |
+| **Commit Terakhir di Main** | `2d0c075` (deploy: add Dokploy compose file) |
+| **Commit Production Server** | Dokploy compose at `2d0c075`; issue #398 belum deploy production |
+| **Status** | Production app live via Dokploy (`bksdakaltim.net`, `api.bksdakaltim.net`, `storage.bksdakaltim.net`), DB/RustFS restored. Current work: #398 per-field import approval awaiting PR/testing/deploy. |
 | **Model Terakhir** | Claude Opus 4.7 |
 | **Timestamp** | 2026-05-29T20:00:00+08:00 |
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -17,6 +17,7 @@
 - Pilihan kolom disimpan backward-compatible di JSON `changed_fields[field].selected`.
 - Data staging lama yang belum punya `selected` tetap dianggap terpilih.
 - `approve()` sekarang hanya apply changed field dengan `selected !== false`.
+- Setiap field yang benar-benar di-apply dari import review dicatat ke `bmn_asset_updates` dengan alasan `Import review: <filename>`, jadi tab Riwayat aset hanya menampilkan kolom yang disetujui.
 - Row checkbox dan bulk selection tetap berfungsi: pilih row = semua kolom update dipilih; batal row = semua kolom update batal.
 - `updated` counter hanya bertambah jika ada minimal satu kolom yang benar-benar di-update.
 - Frontend: setiap diff kolom pada baris `Update` punya checkbox dan indikator `Kolom disetujui: X/Y`.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,15 +1,16 @@
 # Progress - Phase 73: BMN Import Review Per-Field Approval
 
 > Document updated: 2026-06-11
-> Status: Issue #398 **WIP - branch siap PR/testing** (`issue/398-import-review-per-field-approval`). Production Dokploy sudah live; issue #398 belum deploy production.
+> Status: Issue #398 **READY TO MERGE** (PR #399, branch `issue/398-import-review-per-field-approval`). Production Dokploy sudah live; issue #398 belum deploy production.
 
 ---
 
 ## Issue #398: Approve perubahan Import Review BMN per kolom
 
-### Status: WIP - siap PR/testing
+### Status: READY TO MERGE
 - GitHub Issue: #398 `feat(bmn): approve import review changes per field`
 - Branch: `issue/398-import-review-per-field-approval`
+- PR: #399 `feat(bmn): approve import review changes per field (#398)`
 - Tujuan: reviewer bisa menerima hanya kolom tertentu pada baris `Update`, misalnya hanya `tanggal_pengapusan`, tanpa ikut mengubah `nup_lama` atau `foto_geotag_url`.
 
 ### Implementasi

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,37 @@
+# Progress - Phase 73: BMN Import Review Per-Field Approval
+
+> Document updated: 2026-06-11
+> Status: Issue #398 **WIP - branch siap PR/testing** (`issue/398-import-review-per-field-approval`). Production Dokploy sudah live; issue #398 belum deploy production.
+
+---
+
+## Issue #398: Approve perubahan Import Review BMN per kolom
+
+### Status: WIP - siap PR/testing
+- GitHub Issue: #398 `feat(bmn): approve import review changes per field`
+- Branch: `issue/398-import-review-per-field-approval`
+- Tujuan: reviewer bisa menerima hanya kolom tertentu pada baris `Update`, misalnya hanya `tanggal_pengapusan`, tanpa ikut mengubah `nup_lama` atau `foto_geotag_url`.
+
+### Implementasi
+- Backend: tambah endpoint `POST /api/bmn/import-review/toggle-field-selection`.
+- Pilihan kolom disimpan backward-compatible di JSON `changed_fields[field].selected`.
+- Data staging lama yang belum punya `selected` tetap dianggap terpilih.
+- `approve()` sekarang hanya apply changed field dengan `selected !== false`.
+- Row checkbox dan bulk selection tetap berfungsi: pilih row = semua kolom update dipilih; batal row = semua kolom update batal.
+- `updated` counter hanya bertambah jika ada minimal satu kolom yang benar-benar di-update.
+- Frontend: setiap diff kolom pada baris `Update` punya checkbox dan indikator `Kolom disetujui: X/Y`.
+- Label ditambah untuk `nup_lama`, `tanggal_pengapusan`, dan `foto_geotag_url`.
+
+### Validasi
+- `php -l backend/app/Modules/Bmn/Controllers/ImportReviewController.php` clean.
+- `php -l backend/app/Modules/Bmn/Routes/api.php` clean.
+- `cd backend; php artisan route:list` clean dan route toggle-field terdaftar.
+- `cd frontend; npm run lint -- --max-warnings=0` clean.
+- `cd frontend; npx tsc --noEmit` clean.
+- `cd frontend; npm run build` clean (59/59 routes).
+
+---
+
 # Progress - Phase 72: Security Hardening + Migrasi VPS ke Dokploy
 
 > Document updated: 2026-05-29 (malam)

--- a/frontend/src/app/bmn/import-review/[batchId]/page.tsx
+++ b/frontend/src/app/bmn/import-review/[batchId]/page.tsx
@@ -28,6 +28,7 @@ import React from "react";
 interface ChangedField {
   old: string | number | null;
   new: string | number | null;
+  selected?: boolean;
 }
 
 interface StagingRow {
@@ -70,6 +71,9 @@ interface RowsPagination {
 
 // Human-readable field labels
 const FIELD_LABELS: Record<string, string> = {
+  nup_lama: "NUP Lama",
+  tanggal_pengapusan: "Tanggal Penghapusan",
+  foto_geotag_url: "Foto Geotag URL",
   nama_barang: "Nama Barang",
   jenis_bmn: "Jenis BMN",
   merk: "Merk",
@@ -122,6 +126,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
   const [isApproving, setIsApproving] = useState(false);
   const [isRejecting, setIsRejecting] = useState(false);
   const [bulkAction, setBulkAction] = useState<"select_changed" | "clear_changed" | "select_new_only" | null>(null);
+  const [fieldAction, setFieldAction] = useState<string | null>(null);
 
   const handleStatusFilterChange = (nextFilter: "all" | "new" | "updated" | "unchanged") => {
     setPage(1);
@@ -167,6 +172,23 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
       queryClient.invalidateQueries({ queryKey: ["bmn-import-batch", batchId] });
     } catch {
       toast.error("Gagal mengubah seleksi.");
+    }
+  };
+
+  const handleToggleField = async (rowId: string, field: string, selected: boolean) => {
+    const actionKey = `${rowId}:${field}`;
+    setFieldAction(actionKey);
+    try {
+      await api.post("/bmn/import-review/toggle-field-selection", {
+        row_id: rowId,
+        field,
+        selected,
+      });
+      queryClient.invalidateQueries({ queryKey: ["bmn-import-batch", batchId] });
+    } catch {
+      toast.error("Gagal mengubah seleksi kolom.");
+    } finally {
+      setFieldAction(null);
     }
   };
 
@@ -497,7 +519,13 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
                         <span className="text-xs text-slate-400">Tidak ada perubahan</span>
                       )}
                       {row.diff_status === "updated" && row.changed_fields && (
-                        <DiffFields fields={row.changed_fields} />
+                        <DiffFields
+                          fields={row.changed_fields}
+                          rowId={row.id}
+                          isPending={isPending}
+                          fieldAction={fieldAction}
+                          onToggleField={handleToggleField}
+                        />
                       )}
                     </td>
                   </tr>
@@ -568,16 +596,48 @@ function DiffStatusBadge({ status }: { status: string }) {
   }
 }
 
-function DiffFields({ fields }: { fields: Record<string, ChangedField> }) {
+function DiffFields({
+  fields,
+  rowId,
+  isPending,
+  fieldAction,
+  onToggleField,
+}: {
+  fields: Record<string, ChangedField>;
+  rowId: string;
+  isPending: boolean;
+  fieldAction: string | null;
+  onToggleField: (rowId: string, field: string, selected: boolean) => void;
+}) {
   const [expanded, setExpanded] = useState(false);
   const entries = Object.entries(fields);
   const visible = expanded ? entries : entries.slice(0, 4);
   const remaining = entries.length - 4;
+  const selectedCount = entries.filter(([, values]) => values.selected !== false).length;
 
   return (
-    <div className="space-y-1">
+    <div className="space-y-1.5">
+      {isPending && (
+        <div className="mb-1 text-[10px] font-medium text-slate-500">
+          Kolom disetujui: <span className="text-slate-700">{selectedCount}</span>/{entries.length}
+        </div>
+      )}
       {visible.map(([field, values]) => (
-        <div key={field} className="flex items-center gap-2 text-xs">
+        <div
+          key={field}
+          className={cn(
+            "flex items-center gap-2 text-xs",
+            values.selected === false && "opacity-50"
+          )}
+        >
+          {isPending && (
+            <Checkbox
+              checked={values.selected !== false}
+              disabled={fieldAction === `${rowId}:${field}`}
+              onCheckedChange={(checked) => onToggleField(rowId, field, checked === true)}
+              className="size-3.5 shrink-0"
+            />
+          )}
           <span className="text-slate-500 font-medium min-w-[100px]">
             {FIELD_LABELS[field] || field}:
           </span>


### PR DESCRIPTION
Closes #398

## Summary
- Add per-field approval state for updated BMN import review rows via changed_fields[field].selected
- Add toggle-field-selection API endpoint and make approve() apply only selected changed columns
- Add per-column checkboxes and selected-column counts in the import review diff UI
- Update HANDOFF.md and progress.md

## Validation
- php -l backend/app/Modules/Bmn/Controllers/ImportReviewController.php
- php -l backend/app/Modules/Bmn/Routes/api.php
- cd backend; php artisan route:list
- cd frontend; npm run lint -- --max-warnings=0
- cd frontend; npx tsc --noEmit
- cd frontend; npm run build