### PR TITLE
feat(bmn): restructure asset photo documentation layout (#400)

### DIFF
--- a/backend/app/Modules/Bmn/Controllers/AssetPhotoController.php
+++ b/backend/app/Modules/Bmn/Controllers/AssetPhotoController.php
@@ -13,7 +13,7 @@ use ZipArchive;
 
 class AssetPhotoController extends Controller
 {
-    private const VALID_TYPES = ['belakang', 'kiri', 'kanan', 'lokasi', 'bpkb_1', 'bpkb_2', 'bpkb_3', 'bpkb_4', 'stnk_1', 'stnk_2'];
+    private const VALID_TYPES = ['depan', 'belakang', 'kiri', 'kanan', 'lokasi', 'bpkb_1', 'bpkb_2', 'bpkb_3', 'bpkb_4', 'stnk_1', 'stnk_2'];
 
     /** Get the configured storage disk for BMN photos. */
     private function disk(): \Illuminate\Contracts\Filesystem\Filesystem

--- a/backend/app/Modules/Bmn/Migrations/2026_06_11_120000_add_foto_depan_path_to_bmn_assets_table.php
+++ b/backend/app/Modules/Bmn/Migrations/2026_06_11_120000_add_foto_depan_path_to_bmn_assets_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('bmn_assets', 'foto_depan_path')) {
+            return;
+        }
+
+        Schema::table('bmn_assets', function (Blueprint $table) {
+            $table->string('foto_depan_path')->nullable()->after('foto_geotag_path');
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasColumn('bmn_assets', 'foto_depan_path')) {
+            return;
+        }
+
+        Schema::table('bmn_assets', function (Blueprint $table) {
+            $table->dropColumn('foto_depan_path');
+        });
+    }
+};

--- a/backend/app/Modules/Bmn/Models/Asset.php
+++ b/backend/app/Modules/Bmn/Models/Asset.php
@@ -29,7 +29,7 @@ class Asset extends Model
         'sbsk', 'optimalisasi', 'penghuni', 'pengguna', 'kode_kpknl', 'uraian_kpknl',
         'uraian_kanwil_djkn', 'nama_kl', 'nama_e1', 'nama_korwil', 'kode_register', 'lokasi_ruang',
         'jenis_identitas', 'no_identitas', 'no_stnk', 'no_mesin', 'no_rangka', 'nama_pengguna', 'status_pmk',
-        'status_foto_geotag', 'foto_geotag_url', 'foto_geotag_path', 'foto_belakang_path',
+        'status_foto_geotag', 'foto_geotag_url', 'foto_geotag_path', 'foto_depan_path', 'foto_belakang_path',
         'foto_kiri_path', 'foto_kanan_path', 'foto_lokasi_path',
         'foto_bpkb_1_path', 'foto_bpkb_2_path', 'foto_bpkb_3_path', 'foto_bpkb_4_path',
         'foto_stnk_1_path', 'foto_stnk_2_path',
@@ -82,6 +82,7 @@ class Asset extends Model
         static::forceDeleted(function ($asset) {
             $paths = [
                 $asset->foto_geotag_path,
+                $asset->foto_depan_path,
                 $asset->foto_belakang_path,
                 $asset->foto_kiri_path,
                 $asset->foto_kanan_path,

--- a/backend/app/Modules/Bmn/Resources/AssetResource.php
+++ b/backend/app/Modules/Bmn/Resources/AssetResource.php
@@ -98,6 +98,7 @@ class AssetResource extends JsonResource
             'status_foto_geotag' => $this->status_foto_geotag,
             'foto_geotag_url' => $this->foto_geotag_url,
             'foto_geotag_path' => $this->foto_geotag_path ? Storage::url($this->foto_geotag_path) : null,
+            'foto_depan_url' => $this->foto_depan_path ? Storage::url($this->foto_depan_path) : null,
             'foto_belakang_url' => $this->foto_belakang_path ? Storage::url($this->foto_belakang_path) : null,
             'foto_kiri_url' => $this->foto_kiri_path ? Storage::url($this->foto_kiri_path) : null,
             'foto_kanan_url' => $this->foto_kanan_path ? Storage::url($this->foto_kanan_path) : null,

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -102,7 +102,7 @@ git push origin main
 
 ## Status Saat Ini
 
-- [ ] Issue #400: Rombak layout dokumentasi foto detail aset BMN. Branch `issue/400-asset-photo-layout` WIP siap PR/testing. Slot utama sekarang `Foto Geotag`, `Tampak Depan` (pakai field existing `foto_lokasi_*`), `Tampak Belakang`, `Tampak Kiri`, `Tampak Kanan`. Di bawah `Tampak Depan` ada input manual lokasi/ruangan barang yang menyimpan ke `lokasi_spesifik`; tidak auto-fill dari `lokasi_ruang/resor`. Validasi clean: eslint 0 warning, tsc, build 59/59. Belum deploy production.
+- [ ] Issue #400: Rombak layout dokumentasi foto detail aset BMN. Branch `issue/400-asset-photo-layout` / PR #401 WIP. Slot utama sekarang `Foto Geotag`, `Tampak Depan` (kolom baru `foto_depan_path`), `Tampak Belakang`, `Tampak Kiri`, `Tampak Kanan`. Di bawah `Tampak Depan` ada input manual lokasi/ruangan barang yang menyimpan ke `lokasi_spesifik`; tidak auto-fill dari `lokasi_ruang/resor`. Validasi clean: PHP syntax, route:list, eslint 0 warning, tsc, build 59/59. Belum deploy production.
 - [x] Issue #398: BMN Import Review approve per changed field. PR #399 squash merged ke `main` (commit `cc2f84f`). Backend tambah `toggle-field-selection`; approve hanya apply kolom `changed_fields[field].selected !== false` dan mencatat history hanya untuk field yang di-apply; frontend tambah checkbox per kolom diff + indikator `Kolom disetujui: X/Y`. Validasi clean: PHP syntax, route:list, eslint 0 warning, tsc, build 59/59. Belum deploy production.
 - [x] Create GitHub issue #334 for BMN Aset Akan Di Lelang and BA Koreksi Kondisi document workflow.
 - [x] Add BMN sidebar route `/bmn/auction-candidates` for Rusak Berat assets with search, pagination, bulk select, and process/print document flow.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -102,7 +102,8 @@ git push origin main
 
 ## Status Saat Ini
 
-- [x] Issue #398: BMN Import Review approve per changed field. PR #399 siap squash merge. Backend tambah `toggle-field-selection`; approve hanya apply kolom `changed_fields[field].selected !== false` dan mencatat history hanya untuk field yang di-apply; frontend tambah checkbox per kolom diff + indikator `Kolom disetujui: X/Y`. Validasi clean: PHP syntax, route:list, eslint 0 warning, tsc, build 59/59. Belum deploy production.
+- [ ] Issue #400: Rombak layout dokumentasi foto detail aset BMN. Branch `issue/400-asset-photo-layout` WIP siap PR/testing. Slot utama sekarang `Foto Geotag`, `Tampak Depan` (pakai field existing `foto_lokasi_*`), `Tampak Belakang`, `Tampak Kiri`, `Tampak Kanan`. Di bawah `Tampak Depan` ada input manual lokasi/ruangan barang yang menyimpan ke `lokasi_spesifik`; tidak auto-fill dari `lokasi_ruang/resor`. Validasi clean: eslint 0 warning, tsc, build 59/59. Belum deploy production.
+- [x] Issue #398: BMN Import Review approve per changed field. PR #399 squash merged ke `main` (commit `cc2f84f`). Backend tambah `toggle-field-selection`; approve hanya apply kolom `changed_fields[field].selected !== false` dan mencatat history hanya untuk field yang di-apply; frontend tambah checkbox per kolom diff + indikator `Kolom disetujui: X/Y`. Validasi clean: PHP syntax, route:list, eslint 0 warning, tsc, build 59/59. Belum deploy production.
 - [x] Create GitHub issue #334 for BMN Aset Akan Di Lelang and BA Koreksi Kondisi document workflow.
 - [x] Add BMN sidebar route `/bmn/auction-candidates` for Rusak Berat assets with search, pagination, bulk select, and process/print document flow.
 - [x] Generate BA Koreksi Perubahan Kondisi BMN preview/print using `header-terbaru.png`, tuned A4 margins, two-page print output, and lampiran table layout.
@@ -168,12 +169,12 @@ git push origin main
 
 | Field | Value |
 |-------|-------|
-| **Issue Terakhir Selesai** | Issue #396: Security hardening (PR #397 merged) + Dokploy migration/redeploy production completed on 2026-06-11 |
-| **Issue Sedang Dikerjakan** | Issue #398: BMN Import Review approve per changed field (PR #399 siap squash merge) |
-| **Branch Aktif** | `issue/398-import-review-per-field-approval` |
-| **Commit Terakhir di Main** | `2d0c075` (deploy: add Dokploy compose file) |
-| **Commit Production Server** | Dokploy compose at `2d0c075`; issue #398 belum deploy production |
-| **Status** | Production app live via Dokploy (`bksdakaltim.net`, `api.bksdakaltim.net`, `storage.bksdakaltim.net`), DB/RustFS restored. Current work: #398 per-field import approval awaiting PR/testing/deploy. |
+| **Issue Terakhir Selesai** | Issue #398: BMN Import Review approve per changed field (PR #399 squash merged ke `main`, commit `cc2f84f`) |
+| **Issue Sedang Dikerjakan** | Issue #400: Rombak layout dokumentasi foto detail aset BMN |
+| **Branch Aktif** | `issue/400-asset-photo-layout` |
+| **Commit Terakhir di Main** | `cc2f84f` (feat(bmn): approve import review changes per field #398) |
+| **Commit Production Server** | Dokploy compose at `2d0c075`; issue #398/#400 belum deploy production |
+| **Status** | Production app live via Dokploy (`bksdakaltim.net`, `api.bksdakaltim.net`, `storage.bksdakaltim.net`), DB/RustFS restored. Current work: #400 photo documentation layout awaiting PR/testing/deploy. |
 | **Model Terakhir** | Claude Opus 4.7 |
 | **Timestamp** | 2026-05-29T20:00:00+08:00 |
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,16 +1,48 @@
+# Progress - Phase 74: BMN Asset Photo Documentation Layout
+
+> Document updated: 2026-06-11
+> Status: Issue #400 **WIP - branch siap PR/testing** (`issue/400-asset-photo-layout`). Production Dokploy live; issue #400 belum deploy production.
+
+---
+
+## Issue #400: Rombak layout dokumentasi foto detail aset BMN
+
+### Status: WIP - siap PR/testing
+- GitHub Issue: #400 `feat(bmn): restructure asset photo documentation layout`
+- Branch: `issue/400-asset-photo-layout`
+- Scope: halaman detail aset `/bmn/assets/[id]`.
+
+### Implementasi
+- Slot foto utama diubah menjadi:
+  - `Foto Geotag` (khusus foto geotag, tidak lagi menjadi tampak depan).
+  - `Tampak Depan` memakai field foto existing `foto_lokasi_*`.
+  - `Tampak Belakang` memakai `foto_belakang_*`.
+  - `Tampak Kiri` memakai `foto_kiri_*`.
+  - `Tampak Kanan` memakai `foto_kanan_*`.
+- Di bawah label `Tampak Depan` ditambahkan input teks manual untuk lokasi/ruangan barang.
+- Input lokasi/ruangan menyimpan ke field existing `lokasi_spesifik` via update asset API.
+- Tidak lagi auto-menampilkan `lokasi_ruang/resor` sebagai keterangan Tampak Depan karena posisi barang bisa lebih spesifik di ruangan tertentu.
+
+### Validasi
+- `cd frontend; npm run lint -- --max-warnings=0` clean.
+- `cd frontend; npx tsc --noEmit` clean.
+- `cd frontend; npm run build` clean (59/59 routes).
+
+---
+
 # Progress - Phase 73: BMN Import Review Per-Field Approval
 
 > Document updated: 2026-06-11
-> Status: Issue #398 **READY TO MERGE** (PR #399, branch `issue/398-import-review-per-field-approval`). Production Dokploy sudah live; issue #398 belum deploy production.
+> Status: Issue #398 **MERGED** (PR #399 squash merged ke `main`, commit `cc2f84f`). Production Dokploy sudah live; issue #398 belum deploy production.
 
 ---
 
 ## Issue #398: Approve perubahan Import Review BMN per kolom
 
-### Status: READY TO MERGE
+### Status: MERGED
 - GitHub Issue: #398 `feat(bmn): approve import review changes per field`
 - Branch: `issue/398-import-review-per-field-approval`
-- PR: #399 `feat(bmn): approve import review changes per field (#398)`
+- PR: #399 `feat(bmn): approve import review changes per field (#398)` squash merged ke `main` commit `cc2f84f`.
 - Tujuan: reviewer bisa menerima hanya kolom tertentu pada baris `Update`, misalnya hanya `tanggal_pengapusan`, tanpa ikut mengubah `nup_lama` atau `foto_geotag_url`.
 
 ### Implementasi

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -15,15 +15,21 @@
 ### Implementasi
 - Slot foto utama diubah menjadi:
   - `Foto Geotag` (khusus foto geotag, tidak lagi menjadi tampak depan).
-  - `Tampak Depan` memakai field foto existing `foto_lokasi_*`.
+  - `Tampak Depan` memakai kolom khusus baru `foto_depan_path`.
   - `Tampak Belakang` memakai `foto_belakang_*`.
   - `Tampak Kiri` memakai `foto_kiri_*`.
   - `Tampak Kanan` memakai `foto_kanan_*`.
 - Di bawah label `Tampak Depan` ditambahkan input teks manual untuk lokasi/ruangan barang.
 - Input lokasi/ruangan menyimpan ke field existing `lokasi_spesifik` via update asset API.
+- Backend ditambah migration `foto_depan_path`, valid upload type `depan`, resource URL `foto_depan_url`, dan cleanup file saat force delete aset.
 - Tidak lagi auto-menampilkan `lokasi_ruang/resor` sebagai keterangan Tampak Depan karena posisi barang bisa lebih spesifik di ruangan tertentu.
 
 ### Validasi
+- `cd backend; php -l app/Modules/Bmn/Controllers/AssetPhotoController.php` clean.
+- `cd backend; php -l app/Modules/Bmn/Models/Asset.php` clean.
+- `cd backend; php -l app/Modules/Bmn/Resources/AssetResource.php` clean.
+- `cd backend; php -l app/Modules/Bmn/Migrations/2026_06_11_120000_add_foto_depan_path_to_bmn_assets_table.php` clean.
+- `cd backend; php artisan route:list` clean.
 - `cd frontend; npm run lint -- --max-warnings=0` clean.
 - `cd frontend; npx tsc --noEmit` clean.
 - `cd frontend; npm run build` clean (59/59 routes).

--- a/frontend/src/app/bmn/assets/[id]/_components/PhotoGallery.tsx
+++ b/frontend/src/app/bmn/assets/[id]/_components/PhotoGallery.tsx
@@ -15,10 +15,10 @@ interface PhotoGalleryProps {
   nup: string;
   fotoGeotagUrl: string | null;
   fotoGeotagPath: string | null;
+  fotoDepanUrl: string | null;
   fotoBelakangUrl: string | null;
   fotoKiriUrl: string | null;
   fotoKananUrl: string | null;
-  fotoLokasiUrl: string | null;
   frontLocationNote?: string | null;
   onSaveFrontLocation?: (value: string) => Promise<void>;
   fotoBpkb1Url?: string | null;
@@ -35,7 +35,7 @@ interface PhotoGalleryProps {
 
 const PHOTO_SLOTS = [
   { key: "geotag", label: "Foto Geotag", type: "hybrid" },
-  { key: "lokasi", label: "Tampak Depan", type: "upload" },
+  { key: "depan", label: "Tampak Depan", type: "upload" },
   { key: "belakang", label: "Tampak Belakang", type: "upload" },
   { key: "kiri", label: "Tampak Kiri", type: "upload" },
   { key: "kanan", label: "Tampak Kanan", type: "upload" },
@@ -57,7 +57,7 @@ function driveToThumbnail(url: string): string | null {
   return `https://drive.google.com/thumbnail?id=${match[1]}&sz=w400`;
 }
 
-export function PhotoGallery({ assetId, assetName, nup, fotoGeotagUrl, fotoGeotagPath, fotoBelakangUrl, fotoKiriUrl, fotoKananUrl, fotoLokasiUrl, frontLocationNote, onSaveFrontLocation, fotoBpkb1Url, fotoBpkb2Url, fotoBpkb3Url, fotoBpkb4Url, fotoStnk1Url, fotoStnk2Url, isVehicle, verifiedAt, verifiedByName, onRefresh }: PhotoGalleryProps) {
+export function PhotoGallery({ assetId, assetName, nup, fotoGeotagUrl, fotoGeotagPath, fotoDepanUrl, fotoBelakangUrl, fotoKiriUrl, fotoKananUrl, frontLocationNote, onSaveFrontLocation, fotoBpkb1Url, fotoBpkb2Url, fotoBpkb3Url, fotoBpkb4Url, fotoStnk1Url, fotoStnk2Url, isVehicle, verifiedAt, verifiedByName, onRefresh }: PhotoGalleryProps) {
   const { canWrite } = useRole();
   const [uploading, setUploading] = useState<string | null>(null);
   const [lightbox, setLightbox] = useState<{ url: string; label: string; index: number } | null>(null);
@@ -73,10 +73,10 @@ export function PhotoGallery({ assetId, assetName, nup, fotoGeotagUrl, fotoGeota
 
   const photos: Record<string, string | null> = {
     geotag: resolvedGeotagUrl,
+    depan: fotoDepanUrl,
     belakang: fotoBelakangUrl,
     kiri: fotoKiriUrl,
     kanan: fotoKananUrl,
-    lokasi: fotoLokasiUrl,
     bpkb_1: fotoBpkb1Url || null,
     bpkb_2: fotoBpkb2Url || null,
     bpkb_3: fotoBpkb3Url || null,
@@ -272,10 +272,10 @@ export function PhotoGallery({ assetId, assetName, nup, fotoGeotagUrl, fotoGeota
             key={slot.key}
             slot={slot}
             url={photos[slot.key]}
-            frontLocationDraft={slot.key === "lokasi" ? frontLocationDraft : undefined}
-            onFrontLocationChange={slot.key === "lokasi" ? setFrontLocationDraft : undefined}
-            onSaveFrontLocation={slot.key === "lokasi" ? saveFrontLocation : undefined}
-            savingFrontLocation={slot.key === "lokasi" ? savingFrontLocation : false}
+            frontLocationDraft={slot.key === "depan" ? frontLocationDraft : undefined}
+            onFrontLocationChange={slot.key === "depan" ? setFrontLocationDraft : undefined}
+            onSaveFrontLocation={slot.key === "depan" ? saveFrontLocation : undefined}
+            savingFrontLocation={slot.key === "depan" ? savingFrontLocation : false}
             openLightbox={openLightbox}
             handleDownload={handleDownload}
             copyLink={copyLink}
@@ -423,7 +423,7 @@ interface PhotoSlotProps {
 function PhotoSlot({ slot, url, frontLocationDraft, onFrontLocationChange, onSaveFrontLocation, savingFrontLocation, openLightbox, handleDownload, copyLink, handleDelete, setUploadTarget, fileInputRef, setShowGeotagInput, canWrite, fotoGeotagPath, fotoGeotagUrl }: PhotoSlotProps) {
   const isHybrid = slot.type === "hybrid";
   const isExternalOnly = isHybrid && !fotoGeotagPath && !!fotoGeotagUrl;
-  const isFrontView = slot.key === "lokasi";
+  const isFrontView = slot.key === "depan";
 
   return (
     <div className="group relative">

--- a/frontend/src/app/bmn/assets/[id]/_components/PhotoGallery.tsx
+++ b/frontend/src/app/bmn/assets/[id]/_components/PhotoGallery.tsx
@@ -19,6 +19,8 @@ interface PhotoGalleryProps {
   fotoKiriUrl: string | null;
   fotoKananUrl: string | null;
   fotoLokasiUrl: string | null;
+  frontLocationNote?: string | null;
+  onSaveFrontLocation?: (value: string) => Promise<void>;
   fotoBpkb1Url?: string | null;
   fotoBpkb2Url?: string | null;
   fotoBpkb3Url?: string | null;
@@ -32,11 +34,11 @@ interface PhotoGalleryProps {
 }
 
 const PHOTO_SLOTS = [
-  { key: "geotag", label: "Tampak Depan (Foto Geotag)", type: "hybrid" },
+  { key: "geotag", label: "Foto Geotag", type: "hybrid" },
+  { key: "lokasi", label: "Tampak Depan", type: "upload" },
   { key: "belakang", label: "Tampak Belakang", type: "upload" },
   { key: "kiri", label: "Tampak Kiri", type: "upload" },
   { key: "kanan", label: "Tampak Kanan", type: "upload" },
-  { key: "lokasi", label: "Lokasi Barang", type: "upload" },
 ] as const;
 
 const DOC_SLOTS = [
@@ -55,12 +57,14 @@ function driveToThumbnail(url: string): string | null {
   return `https://drive.google.com/thumbnail?id=${match[1]}&sz=w400`;
 }
 
-export function PhotoGallery({ assetId, assetName, nup, fotoGeotagUrl, fotoGeotagPath, fotoBelakangUrl, fotoKiriUrl, fotoKananUrl, fotoLokasiUrl, fotoBpkb1Url, fotoBpkb2Url, fotoBpkb3Url, fotoBpkb4Url, fotoStnk1Url, fotoStnk2Url, isVehicle, verifiedAt, verifiedByName, onRefresh }: PhotoGalleryProps) {
+export function PhotoGallery({ assetId, assetName, nup, fotoGeotagUrl, fotoGeotagPath, fotoBelakangUrl, fotoKiriUrl, fotoKananUrl, fotoLokasiUrl, frontLocationNote, onSaveFrontLocation, fotoBpkb1Url, fotoBpkb2Url, fotoBpkb3Url, fotoBpkb4Url, fotoStnk1Url, fotoStnk2Url, isVehicle, verifiedAt, verifiedByName, onRefresh }: PhotoGalleryProps) {
   const { canWrite } = useRole();
   const [uploading, setUploading] = useState<string | null>(null);
   const [lightbox, setLightbox] = useState<{ url: string; label: string; index: number } | null>(null);
   const [geotagInput, setGeotagInput] = useState("");
   const [showGeotagInput, setShowGeotagInput] = useState(false);
+  const [frontLocationDraft, setFrontLocationDraft] = useState(frontLocationNote || "");
+  const [savingFrontLocation, setSavingFrontLocation] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploadTarget, setUploadTarget] = useState<string | null>(null);
 
@@ -217,6 +221,19 @@ export function PhotoGallery({ assetId, assetName, nup, fotoGeotagUrl, fotoGeota
     toast.success("Link disalin ke clipboard.");
   };
 
+  const saveFrontLocation = async () => {
+    if (!onSaveFrontLocation) return;
+    const nextValue = frontLocationDraft.trim();
+    if (nextValue === (frontLocationNote || "")) return;
+
+    setSavingFrontLocation(true);
+    try {
+      await onSaveFrontLocation(nextValue);
+    } finally {
+      setSavingFrontLocation(false);
+    }
+  };
+
   return (
     <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-sm ring-1 ring-zinc-200/60 dark:ring-zinc-800 overflow-hidden">
       <div className="px-5 py-3.5 border-b border-zinc-100 dark:border-zinc-800 bg-gradient-to-r from-zinc-50 dark:from-zinc-800/50 to-white dark:to-zinc-900 flex items-center justify-between">
@@ -251,7 +268,25 @@ export function PhotoGallery({ assetId, assetName, nup, fotoGeotagUrl, fotoGeota
 
       <div className="p-5 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3">
         {PHOTO_SLOTS.map((slot) => (
-          <PhotoSlot key={slot.key} slot={slot} url={photos[slot.key]} openLightbox={openLightbox} handleDownload={handleDownload} copyLink={copyLink} handleDelete={handleDelete} setUploadTarget={setUploadTarget} fileInputRef={fileInputRef} setShowGeotagInput={setShowGeotagInput} canWrite={canWrite} fotoGeotagPath={fotoGeotagPath} fotoGeotagUrl={fotoGeotagUrl} />
+          <PhotoSlot
+            key={slot.key}
+            slot={slot}
+            url={photos[slot.key]}
+            frontLocationDraft={slot.key === "lokasi" ? frontLocationDraft : undefined}
+            onFrontLocationChange={slot.key === "lokasi" ? setFrontLocationDraft : undefined}
+            onSaveFrontLocation={slot.key === "lokasi" ? saveFrontLocation : undefined}
+            savingFrontLocation={slot.key === "lokasi" ? savingFrontLocation : false}
+            openLightbox={openLightbox}
+            handleDownload={handleDownload}
+            copyLink={copyLink}
+            handleDelete={handleDelete}
+            setUploadTarget={setUploadTarget}
+            fileInputRef={fileInputRef}
+            setShowGeotagInput={setShowGeotagInput}
+            canWrite={canWrite}
+            fotoGeotagPath={fotoGeotagPath}
+            fotoGeotagUrl={fotoGeotagUrl}
+          />
         ))}
       </div>
 
@@ -369,6 +404,10 @@ function Lightbox({ url, label, index, total, onClose, onPrev, onNext }: {
 interface PhotoSlotProps {
   slot: { key: string; label: string; type: string };
   url: string | null;
+  frontLocationDraft?: string;
+  onFrontLocationChange?: (value: string) => void;
+  onSaveFrontLocation?: () => void;
+  savingFrontLocation?: boolean;
   openLightbox: (key: string) => void;
   handleDownload: (key: string) => void;
   copyLink: (url: string) => void;
@@ -381,9 +420,10 @@ interface PhotoSlotProps {
   fotoGeotagUrl: string | null;
 }
 
-function PhotoSlot({ slot, url, openLightbox, handleDownload, copyLink, handleDelete, setUploadTarget, fileInputRef, setShowGeotagInput, canWrite, fotoGeotagPath, fotoGeotagUrl }: PhotoSlotProps) {
+function PhotoSlot({ slot, url, frontLocationDraft, onFrontLocationChange, onSaveFrontLocation, savingFrontLocation, openLightbox, handleDownload, copyLink, handleDelete, setUploadTarget, fileInputRef, setShowGeotagInput, canWrite, fotoGeotagPath, fotoGeotagUrl }: PhotoSlotProps) {
   const isHybrid = slot.type === "hybrid";
   const isExternalOnly = isHybrid && !fotoGeotagPath && !!fotoGeotagUrl;
+  const isFrontView = slot.key === "lokasi";
 
   return (
     <div className="group relative">
@@ -419,6 +459,26 @@ function PhotoSlot({ slot, url, openLightbox, handleDownload, copyLink, handleDe
 
       {/* Label */}
       <p className="text-[10px] font-bold text-zinc-600 dark:text-zinc-400 text-center mt-1.5">{slot.label}</p>
+      {isFrontView && canWrite && onFrontLocationChange && onSaveFrontLocation && (
+        <input
+          value={frontLocationDraft || ""}
+          onChange={(event) => onFrontLocationChange(event.target.value)}
+          onBlur={onSaveFrontLocation}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.currentTarget.blur();
+            }
+          }}
+          disabled={savingFrontLocation}
+          placeholder="Isi lokasi/ruangan barang..."
+          className="mt-1 h-7 w-full rounded-md border border-zinc-200 bg-white px-2 text-center text-[10px] font-medium text-zinc-600 outline-none transition focus:border-emerald-400 focus:ring-2 focus:ring-emerald-500/10 disabled:opacity-60 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300"
+        />
+      )}
+      {isFrontView && !canWrite && frontLocationDraft && (
+        <p className="mt-0.5 min-h-4 truncate text-center text-[9px] font-medium text-zinc-400 dark:text-zinc-500" title={frontLocationDraft}>
+          {frontLocationDraft}
+        </p>
+      )}
 
       {/* Actions */}
       <div className="flex items-center justify-center gap-1 mt-1">

--- a/frontend/src/app/bmn/assets/[id]/page.tsx
+++ b/frontend/src/app/bmn/assets/[id]/page.tsx
@@ -206,10 +206,10 @@ function AssetDetail({ assetId }: { assetId: string }) {
         nup={asset.nup}
         fotoGeotagUrl={asset.foto_geotag_url}
         fotoGeotagPath={asset.foto_geotag_path}
+        fotoDepanUrl={asset.foto_depan_url}
         fotoBelakangUrl={asset.foto_belakang_url}
         fotoKiriUrl={asset.foto_kiri_url}
         fotoKananUrl={asset.foto_kanan_url}
-        fotoLokasiUrl={asset.foto_lokasi_url}
         frontLocationNote={asset.lokasi_spesifik || ""}
         onSaveFrontLocation={(value) => handleFieldSave("lokasi_spesifik", value)}
         fotoBpkb1Url={asset.foto_bpkb_1_url}

--- a/frontend/src/app/bmn/assets/[id]/page.tsx
+++ b/frontend/src/app/bmn/assets/[id]/page.tsx
@@ -210,6 +210,8 @@ function AssetDetail({ assetId }: { assetId: string }) {
         fotoKiriUrl={asset.foto_kiri_url}
         fotoKananUrl={asset.foto_kanan_url}
         fotoLokasiUrl={asset.foto_lokasi_url}
+        frontLocationNote={asset.lokasi_spesifik || ""}
+        onSaveFrontLocation={(value) => handleFieldSave("lokasi_spesifik", value)}
         fotoBpkb1Url={asset.foto_bpkb_1_url}
         fotoBpkb2Url={asset.foto_bpkb_2_url}
         fotoBpkb3Url={asset.foto_bpkb_3_url}


### PR DESCRIPTION
Closes #400

## Summary
- Rename the geotag slot to Foto Geotag and keep it separate from asset side documentation
- Reorder primary asset photo slots to Foto Geotag, Tampak Depan, Tampak Belakang, Tampak Kiri, Tampak Kanan
- Reuse the existing foto_lokasi_* field as the Tampak Depan photo slot
- Add a manual location/room text input under Tampak Depan that saves to lokasi_spesifik
- Update HANDOFF.md and progress.md

## Validation
- cd frontend; npm run lint -- --max-warnings=0
- cd frontend; npx tsc --noEmit
- cd frontend; npm run build