### PR TITLE
Polish auction document workflow

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,48 @@
+# Progress - Phase 78: UX Polish Aset Akan Dilelang
+
+> Document updated: 2026-06-17
+> Status: WIP lokal (`codex/auction-candidates-ux-polish`). Belum PR, belum deploy production.
+
+---
+
+## Halaman `/bmn/auction-candidates`
+
+### Status: WIP - siap dicek lokal
+- Scope: UI/UX halaman `Aset Akan Di Lelang`.
+- Tujuan: menaikkan kualitas pengalaman kerja menuju 9/10 dengan alur yang lebih jelas, warna lebih tenang, dan aksi dokumen lebih mudah dipahami.
+
+### Implementasi
+- Menambahkan stepper workflow 3 langkah:
+  - `Pilih aset`
+  - `Atur detail`
+  - `Generate dokumen`
+- Menyusun ulang halaman agar tabel aset menjadi fokus awal sebelum detail nomor surat dan generate dokumen.
+- Mengubah `Generate Dokumen Lelang` dari tombol warna-warni menjadi panel dokumen netral yang dikelompokkan:
+  - Berita acara
+  - Surat keputusan
+  - Surat pendukung
+- Memindahkan pengaturan nomor surat dari panel global ke masing-masing preview dokumen:
+  - kartu nomor muncul di panel kiri preview,
+  - untuk BA Pemeriksaan posisinya di atas form `Pemeriksa`,
+  - setiap kartu menampilkan preview nomor, input nomor, dan input KAP.
+- Menambahkan state disabled yang lebih konsisten untuk dokumen yang membutuhkan aset terpilih.
+- Mengubah banner aset terpilih menjadi sticky action bar bernuansa emerald:
+  - menampilkan jumlah aset terpilih,
+  - menampilkan jumlah dokumen siap cetak,
+  - menyediakan tombol cetak cepat untuk dokumen yang sudah digenerate.
+- Merapikan panel `Urutan Aset Terpilih`:
+  - teks instruksi lebih bersih,
+  - separator metadata tidak mojibake,
+  - ukuran tombol naik/turun lebih nyaman.
+- Merapikan picker `Penandatangan Kepala Balai` agar teks placeholder kosong tidak menampilkan karakter mojibake.
+- Menambahkan tombol `Jadikan ini sebagai default` pada picker global `Penandatangan Kepala Balai`; pilihan tersimpan lokal dan otomatis dipakai kembali saat halaman dibuka.
+
+### Validasi
+- `cd frontend; npm run lint` clean.
+- `cd frontend; npx tsc --noEmit` clean.
+
+---
+
 # Progress - Phase 77: Pagination Riwayat Dokumen BMN
 
 > Document updated: 2026-06-17

--- a/frontend/src/app/bmn/auction-candidates/_components/DocumentActions.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/DocumentActions.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { FileText, Sparkles } from "lucide-react";
+import { FileCheck2, FileText, FolderKanban, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 interface DocumentActionsProps {
   orderedIdsLength: number;
@@ -16,6 +17,45 @@ interface DocumentActionsProps {
   onProcessBaPemeriksaan: () => void;
   onProcessNotaDinas: () => void;
   onProcessPermohonanKpknl: () => void;
+}
+
+interface DocumentAction {
+  label: string;
+  description: string;
+  onClick: () => void;
+  needsSelection?: boolean;
+}
+
+interface DocumentGroup {
+  title: string;
+  description: string;
+  Icon: typeof FileText;
+  actions: DocumentAction[];
+}
+
+function ActionButton({ action, disabled }: { action: DocumentAction; disabled: boolean }) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      className={cn(
+        "h-auto min-h-12 justify-start rounded-xl border-zinc-200 bg-white px-3 py-2 text-left hover:border-emerald-200 hover:bg-emerald-50 dark:border-zinc-700 dark:bg-zinc-950 dark:hover:border-emerald-500/30 dark:hover:bg-emerald-500/10",
+        disabled && "cursor-not-allowed opacity-55",
+      )}
+      onClick={action.onClick}
+      disabled={disabled}
+    >
+      <FileText className="mr-2 h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+      <span className="min-w-0">
+        <span className="block truncate text-xs font-bold text-zinc-900 dark:text-zinc-100">
+          {action.label}
+        </span>
+        <span className="block truncate text-[10px] font-medium text-zinc-500 dark:text-zinc-400">
+          {action.description}
+        </span>
+      </span>
+    </Button>
+  );
 }
 
 export function DocumentActions({
@@ -33,117 +73,87 @@ export function DocumentActions({
   onProcessPermohonanKpknl,
 }: DocumentActionsProps) {
   const noSelection = orderedIdsLength === 0;
+  const groups: DocumentGroup[] = [
+    {
+      title: "Berita acara",
+      description: "Dokumen utama dengan lampiran aset terpilih.",
+      Icon: FileCheck2,
+      actions: [
+        { label: "BA Koreksi", description: "Koreksi kondisi aset", onClick: onProcess, needsSelection: true },
+        { label: "BA Pemeriksaan", description: "Pemeriksaan fisik aset", onClick: onProcessBaPemeriksaan, needsSelection: true },
+      ],
+    },
+    {
+      title: "Surat keputusan",
+      description: "SK pendukung proses pemindahtanganan.",
+      Icon: FolderKanban,
+      actions: [
+        { label: "SK Penghentian", description: "Penghentian penggunaan", onClick: onProcessSk, needsSelection: true },
+        { label: "SK Panitia", description: "Pembentukan panitia", onClick: onProcessSkPanitia, needsSelection: true },
+        { label: "SK Tim Penilai", description: "Pembentukan tim penilai", onClick: onProcessSkTimPenilai, needsSelection: true },
+        { label: "SK Kebenaran", description: "Pernyataan kebenaran dokumen", onClick: onProcessSkKebenaran, needsSelection: true },
+      ],
+    },
+    {
+      title: "Surat pendukung",
+      description: "Surat dan pengantar yang melengkapi berkas.",
+      Icon: FileText,
+      actions: [
+        { label: "SPTJ Limit", description: "Tanggung jawab limit", onClick: onProcessSptjLimit },
+        { label: "SPTJM", description: "Tanggung jawab mutlak", onClick: onProcessSptjm },
+        { label: "SP Tugas", description: "Surat penugasan", onClick: onProcessSpTugas },
+        { label: "Nota Dinas KSDAE", description: "Pengantar internal", onClick: onProcessNotaDinas, needsSelection: true },
+        { label: "Permohonan KPKNL", description: "Permohonan ke KPKNL", onClick: onProcessPermohonanKpknl, needsSelection: true },
+      ],
+    },
+  ];
+
   return (
     <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
-      <div className="mb-3 flex items-center gap-2">
-        <Sparkles className="h-4 w-4 text-zinc-400" />
-        <h2 className="text-[10px] font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
-          Generate Dokumen Lelang
-        </h2>
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+          <div>
+            <h2 className="text-sm font-bold text-zinc-900 dark:text-white">Generate Dokumen Lelang</h2>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              {orderedIdsLength > 0
+                ? `${orderedIdsLength} aset siap dipakai sebagai lampiran.`
+                : "Beberapa dokumen membutuhkan aset terpilih."}
+            </p>
+          </div>
+        </div>
+        <span className="w-fit rounded-full bg-zinc-100 px-3 py-1 text-[10px] font-bold uppercase tracking-wider text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+          Langkah 3
+        </span>
       </div>
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-        <Button
-          size="sm"
-          className="h-auto rounded-xl gap-2 bg-red-600 py-2.5 text-xs hover:bg-red-500"
-          onClick={onProcess}
-          disabled={noSelection}
-        >
-          <FileText className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">BA Koreksi</span>
-        </Button>
-        <Button
-          size="sm"
-          className="h-auto rounded-xl gap-2 bg-amber-600 py-2.5 text-xs hover:bg-amber-500"
-          onClick={onProcessSk}
-          disabled={noSelection}
-        >
-          <FileText className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">SK Penghentian</span>
-        </Button>
-        <Button
-          size="sm"
-          className="h-auto rounded-xl gap-2 bg-teal-600 py-2.5 text-xs hover:bg-teal-500"
-          onClick={onProcessSkPanitia}
-          disabled={noSelection}
-        >
-          <FileText className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">SK Panitia</span>
-        </Button>
-        <Button
-          size="sm"
-          className="h-auto rounded-xl gap-2 bg-emerald-600 py-2.5 text-xs hover:bg-emerald-500"
-          onClick={onProcessSkTimPenilai}
-          disabled={noSelection}
-        >
-          <FileText className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">SK Tim Penilai</span>
-        </Button>
-        <Button
-          size="sm"
-          className="h-auto rounded-xl gap-2 bg-orange-600 py-2.5 text-xs hover:bg-orange-500"
-          onClick={onProcessBaPemeriksaan}
-          disabled={noSelection}
-        >
-          <FileText className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">BA Pemeriksaan</span>
-        </Button>
-        <Button
-          size="sm"
-          className="h-auto rounded-xl gap-2 bg-cyan-600 py-2.5 text-xs hover:bg-cyan-500"
-          onClick={onProcessSkKebenaran}
-          disabled={noSelection}
-        >
-          <FileText className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">SK Kebenaran</span>
-        </Button>
-        <Button
-          size="sm"
-          className="h-auto rounded-xl gap-2 bg-blue-600 py-2.5 text-xs hover:bg-blue-500"
-          onClick={onProcessSptjLimit}
-        >
-          <FileText className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">SPTJ Limit</span>
-        </Button>
-        <Button
-          size="sm"
-          className="h-auto rounded-xl gap-2 bg-purple-600 py-2.5 text-xs hover:bg-purple-500"
-          onClick={onProcessSptjm}
-        >
-          <FileText className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">SPTJM</span>
-        </Button>
-        <Button
-          size="sm"
-          className="h-auto rounded-xl gap-2 bg-pink-600 py-2.5 text-xs hover:bg-pink-500"
-          onClick={onProcessSpTugas}
-        >
-          <FileText className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">SP Tugas</span>
-        </Button>
-        <Button
-          size="sm"
-          className="h-auto rounded-xl gap-2 bg-lime-600 py-2.5 text-xs hover:bg-lime-500"
-          onClick={onProcessNotaDinas}
-          disabled={noSelection}
-        >
-          <FileText className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">Nota Dinas KSDAE</span>
-        </Button>
-        <Button
-          size="sm"
-          className="h-auto rounded-xl gap-2 bg-violet-600 py-2.5 text-xs hover:bg-violet-500"
-          onClick={onProcessPermohonanKpknl}
-          disabled={noSelection}
-        >
-          <FileText className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">Permohonan KPKNL</span>
-        </Button>
+
+      <div className="grid gap-3 xl:grid-cols-3">
+        {groups.map(({ title, description, Icon, actions }) => (
+          <section
+            key={title}
+            className="rounded-xl border border-zinc-100 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-950"
+          >
+            <div className="mb-3 flex items-start gap-2">
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white text-emerald-600 ring-1 ring-zinc-200 dark:bg-zinc-900 dark:text-emerald-400 dark:ring-zinc-700">
+                <Icon className="h-4 w-4" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-xs font-bold text-zinc-900 dark:text-zinc-100">{title}</p>
+                <p className="text-[10px] leading-4 text-zinc-500 dark:text-zinc-400">{description}</p>
+              </div>
+            </div>
+            <div className="grid gap-2">
+              {actions.map((action) => (
+                <ActionButton
+                  key={action.label}
+                  action={action}
+                  disabled={Boolean(action.needsSelection && noSelection)}
+                />
+              ))}
+            </div>
+          </section>
+        ))}
       </div>
-      {noSelection && (
-        <p className="mt-2 text-[10px] text-zinc-400 dark:text-zinc-500">
-          Pilih aset di bawah untuk mengaktifkan dokumen yang memerlukan tabel lampiran.
-        </p>
-      )}
     </div>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/_components/DocumentNumberInputs.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/DocumentNumberInputs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDown, Settings2 } from "lucide-react";
+import { ChevronDown, FileText, Settings2 } from "lucide-react";
 import { formatDateLong } from "../_lib/auction-helpers";
 
 interface DocumentNumberInputsProps {
@@ -55,11 +55,154 @@ interface DocumentNumberInputsProps {
   setStTanggal: (value: string) => void;
 }
 
-const inputBoxClass =
-  "flex h-10 items-center rounded-lg border border-zinc-200 bg-white px-2.5 text-xs text-zinc-900 dark:border-zinc-700 dark:bg-zinc-950 dark:text-white";
+interface NumberRow {
+  id: string;
+  label: string;
+  prefix: string;
+  number: string;
+  setNumber: (value: string) => void;
+  kap: string;
+  setKap: (value: string) => void;
+}
 
-const labelClass =
-  "text-[9px] font-bold uppercase tracking-wider text-zinc-400";
+const fieldClass =
+  "h-10 w-full min-w-0 rounded-lg border border-zinc-200 bg-white px-3 text-sm font-semibold text-zinc-900 outline-none transition focus:border-emerald-400 focus:ring-2 focus:ring-emerald-500/15 dark:border-zinc-700 dark:bg-zinc-950 dark:text-white";
+
+interface DocumentNumberInlineCardProps {
+  title?: string;
+  label: string;
+  prefix: string;
+  number: string;
+  setNumber: (value: string) => void;
+  kap: string;
+  setKap: (value: string) => void;
+  stNumber?: string;
+  setStNumber?: (value: string) => void;
+  stTanggal?: string;
+  setStTanggal?: (value: string) => void;
+}
+
+export function DocumentNumberInlineCard({
+  title = "Nomor Surat",
+  label,
+  prefix,
+  number,
+  setNumber,
+  kap,
+  setKap,
+  stNumber,
+  setStNumber,
+  stTanggal,
+  setStTanggal,
+}: DocumentNumberInlineCardProps) {
+  const monthSuffix = `${String(new Date().getMonth() + 1).padStart(2, "0")}/${new Date().getFullYear()}`;
+  const preview = `${prefix}${number || "____"}/K.18/TU/${kap || "____"}/B/${monthSuffix}`;
+  const showStFields = setStNumber && setStTanggal;
+
+  return (
+    <div className="w-full min-w-0 overflow-hidden rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
+      <div className="mb-3 flex items-start gap-2">
+        <FileText className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+        <div className="min-w-0">
+          <p className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">{title}</p>
+          <h3 className="text-sm font-bold text-zinc-900 dark:text-white">{label}</h3>
+          <p className="truncate font-mono text-xs text-zinc-500 dark:text-zinc-400">{preview}</p>
+        </div>
+      </div>
+
+      <div className="grid min-w-0 gap-2 md:grid-cols-2">
+        <label className="grid min-w-0 gap-1">
+          <span className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">Nomor</span>
+          <input
+            type="text"
+            value={number}
+            onChange={(event) => setNumber(event.target.value)}
+            placeholder="____"
+            className={`${fieldClass} text-center`}
+          />
+        </label>
+        <label className="grid min-w-0 gap-1">
+          <span className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">KAP</span>
+          <input
+            type="text"
+            value={kap}
+            onChange={(event) => setKap(event.target.value)}
+            placeholder="KAP.00.00"
+            className={fieldClass}
+          />
+        </label>
+      </div>
+
+      {showStFields && (
+        <div className="mt-3 rounded-xl border border-dashed border-zinc-200 p-3 dark:border-zinc-800">
+          <p className="mb-2 text-[10px] font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+            Referensi Surat Tugas
+          </p>
+          <div className="grid gap-2">
+            <label className="grid gap-1">
+              <span className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">No. ST</span>
+              <input
+                type="text"
+                value={stNumber || ""}
+                onChange={(event) => setStNumber(event.target.value)}
+                placeholder="ST.xxx/K.18/TU/..."
+                className={fieldClass}
+              />
+            </label>
+            <label className="grid gap-1">
+              <span className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">Tanggal ST</span>
+              <input
+                type="text"
+                value={stTanggal || ""}
+                onChange={(event) => setStTanggal(event.target.value)}
+                placeholder={formatDateLong(new Date())}
+                className={fieldClass}
+              />
+            </label>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NumberSettingRow({ row, monthSuffix }: { row: NumberRow; monthSuffix: string }) {
+  const preview = `${row.prefix}${row.number || "____"}/K.18/TU/${row.kap || "____"}/B/${monthSuffix}`;
+
+  return (
+    <div className="grid gap-3 rounded-xl border border-zinc-100 bg-zinc-50 p-3 dark:border-zinc-800 dark:bg-zinc-950 lg:grid-cols-[minmax(0,1fr)_6.5rem_8rem] lg:items-center">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <FileText className="h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+          <p className="truncate text-sm font-bold text-zinc-900 dark:text-zinc-100">{row.label}</p>
+        </div>
+        <p className="mt-1 truncate font-mono text-xs text-zinc-500 dark:text-zinc-400">{preview}</p>
+      </div>
+      <label className="grid gap-1">
+        <span className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">Nomor</span>
+        <input
+          id={`${row.id}-number`}
+          type="text"
+          value={row.number}
+          onChange={(event) => row.setNumber(event.target.value)}
+          placeholder="____"
+          className={`${fieldClass} text-center`}
+        />
+      </label>
+      <label className="grid gap-1">
+        <span className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">KAP</span>
+        <input
+          id={`${row.id}-kap`}
+          type="text"
+          value={row.kap}
+          onChange={(event) => row.setKap(event.target.value)}
+          placeholder="KAP.00.00"
+          className={fieldClass}
+        />
+      </label>
+    </div>
+  );
+}
 
 export function DocumentNumberInputs({
   baNumber,
@@ -113,348 +256,77 @@ export function DocumentNumberInputs({
 }: DocumentNumberInputsProps) {
   const [open, setOpen] = useState(false);
   const monthSuffix = `${String(new Date().getMonth() + 1).padStart(2, "0")}/${new Date().getFullYear()}`;
+  const rows: NumberRow[] = [
+    { id: "ba", label: "BA Koreksi", prefix: "BA.", number: baNumber, setNumber: setBaNumber, kap: baKap, setKap: setBaKap },
+    { id: "sk", label: "SK Penghentian", prefix: "SK.", number: skNumber, setNumber: setSkNumber, kap: skKap, setKap: setSkKap },
+    { id: "sk-panitia", label: "SK Panitia", prefix: "SK.", number: skPanitiaNumber, setNumber: setSkPanitiaNumber, kap: skPanitiaKap, setKap: setSkPanitiaKap },
+    { id: "sk-tim-penilai", label: "SK Tim Penilai", prefix: "SK.", number: skTimPenilaiNumber, setNumber: setSkTimPenilaiNumber, kap: skTimPenilaiKap, setKap: setSkTimPenilaiKap },
+    { id: "sptj-limit", label: "SPTJ Nilai Limit", prefix: "SM.", number: sptjLimitNumber, setNumber: setSptjLimitNumber, kap: sptjLimitKap, setKap: setSptjLimitKap },
+    { id: "sptjm", label: "SPTJM", prefix: "SPTJM.", number: sptjmNumber, setNumber: setSptjmNumber, kap: sptjmKap, setKap: setSptjmKap },
+    { id: "sp-tugas", label: "SP Tidak Mengganggu Tugas", prefix: "SM.", number: spTugasNumber, setNumber: setSpTugasNumber, kap: spTugasKap, setKap: setSpTugasKap },
+    { id: "sk-kebenaran", label: "SK Kebenaran Dokumen", prefix: "KT.", number: skKebenaranNumber, setNumber: setSkKebenaranNumber, kap: skKebenaranKap, setKap: setSkKebenaranKap },
+    { id: "ba-pemeriksaan", label: "BA Pemeriksaan", prefix: "BA.", number: baPemeriksaanNumber, setNumber: setBaPemeriksaanNumber, kap: baPemeriksaanKap, setKap: setBaPemeriksaanKap },
+    { id: "nota-dinas", label: "Nota Dinas KSDAE", prefix: "ND.", number: notaDinasNumber, setNumber: setNotaDinasNumber, kap: notaDinasKap, setKap: setNotaDinasKap },
+    { id: "permohonan-kpknl", label: "Permohonan KPKNL", prefix: "S.", number: permohonanKpknlNumber, setNumber: setPermohonanKpknlNumber, kap: permohonanKpknlKap, setKap: setPermohonanKpknlKap },
+  ];
 
   return (
     <div className="rounded-2xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left transition hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
       >
-        <div className="flex items-center gap-2">
-          <Settings2 className="h-4 w-4 text-zinc-400" />
-          <span className="text-[10px] font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
-            Pengaturan Nomor Surat
-          </span>
-          <span className="rounded-md bg-zinc-100 px-1.5 py-0.5 text-[9px] font-semibold text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-300">
+            <Settings2 className="h-4 w-4" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-bold text-zinc-900 dark:text-white">Pengaturan Nomor Surat</p>
+            <p className="truncate text-xs text-zinc-500 dark:text-zinc-400">
+              Atur nomor dan KAP dokumen lelang dari satu tempat.
+            </p>
+          </div>
+          <span className="hidden rounded-md bg-zinc-100 px-2 py-1 text-[10px] font-bold text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400 sm:inline-flex">
             12 dokumen
           </span>
         </div>
-        <ChevronDown
-          className={`h-4 w-4 text-zinc-400 transition-transform ${open ? "rotate-180" : ""}`}
-        />
+        <ChevronDown className={`h-4 w-4 shrink-0 text-zinc-400 transition-transform ${open ? "rotate-180" : ""}`} />
       </button>
 
       {open && (
         <div className="space-y-3 border-t border-zinc-100 p-4 dark:border-zinc-800">
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {/* BA Koreksi */}
-            <div>
-              <label htmlFor="ba-number" className={labelClass}>
-                BA Koreksi
-              </label>
-              <div className={`${inputBoxClass} mt-1`}>
-                <span className="font-semibold">BA.</span>
-                <input
-                  id="ba-number"
-                  type="text"
-                  value={baNumber}
-                  onChange={(e) => setBaNumber(e.target.value)}
-                  placeholder="____"
-                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/K.18/TU/</span>
-                <input
-                  type="text"
-                  value={baKap}
-                  onChange={(e) => setBaKap(e.target.value)}
-                  className="w-20 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/B/{monthSuffix}</span>
-              </div>
-            </div>
-
-            {/* SK Penghentian */}
-            <div>
-              <label htmlFor="sk-number" className={labelClass}>
-                SK Penghentian
-              </label>
-              <div className={`${inputBoxClass} mt-1`}>
-                <span className="font-semibold">SK.</span>
-                <input
-                  id="sk-number"
-                  type="text"
-                  value={skNumber}
-                  onChange={(e) => setSkNumber(e.target.value)}
-                  placeholder="____"
-                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/K.18/TU/</span>
-                <input
-                  type="text"
-                  value={skKap}
-                  onChange={(e) => setSkKap(e.target.value)}
-                  className="w-20 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/B/{monthSuffix}</span>
-              </div>
-            </div>
-
-            {/* SK Panitia */}
-            <div>
-              <label htmlFor="sk-panitia-number" className={labelClass}>
-                SK Panitia
-              </label>
-              <div className={`${inputBoxClass} mt-1`}>
-                <span className="font-semibold">SK.</span>
-                <input
-                  id="sk-panitia-number"
-                  type="text"
-                  value={skPanitiaNumber}
-                  onChange={(e) => setSkPanitiaNumber(e.target.value)}
-                  placeholder="____"
-                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/K.18/TU/</span>
-                <input
-                  type="text"
-                  value={skPanitiaKap}
-                  onChange={(e) => setSkPanitiaKap(e.target.value)}
-                  className="w-20 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/B/{monthSuffix}</span>
-              </div>
-            </div>
-
-            {/* SK Tim Penilai */}
-            <div>
-              <label htmlFor="sk-tim-penilai-number" className={labelClass}>
-                SK Tim Penilai
-              </label>
-              <div className={`${inputBoxClass} mt-1`}>
-                <span className="font-semibold">SK.</span>
-                <input
-                  id="sk-tim-penilai-number"
-                  type="text"
-                  value={skTimPenilaiNumber}
-                  onChange={(e) => setSkTimPenilaiNumber(e.target.value)}
-                  placeholder="____"
-                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/K.18/TU/</span>
-                <input
-                  type="text"
-                  value={skTimPenilaiKap}
-                  onChange={(e) => setSkTimPenilaiKap(e.target.value)}
-                  className="w-20 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/B/{monthSuffix}</span>
-              </div>
-            </div>
-
-            {/* SPTJ Nilai Limit */}
-            <div>
-              <label htmlFor="sptj-limit-number" className={labelClass}>
-                SPTJ Nilai Limit
-              </label>
-              <div className={`${inputBoxClass} mt-1`}>
-                <span className="font-semibold">SM.</span>
-                <input
-                  id="sptj-limit-number"
-                  type="text"
-                  value={sptjLimitNumber}
-                  onChange={(e) => setSptjLimitNumber(e.target.value)}
-                  placeholder="____"
-                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/K.18/TU/</span>
-                <input
-                  type="text"
-                  value={sptjLimitKap}
-                  onChange={(e) => setSptjLimitKap(e.target.value)}
-                  className="w-20 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/B/{monthSuffix}</span>
-              </div>
-            </div>
-
-            {/* SPTJM */}
-            <div>
-              <label htmlFor="sptjm-number" className={labelClass}>
-                SPTJM
-              </label>
-              <div className={`${inputBoxClass} mt-1`}>
-                <span className="font-semibold">SPTJM.</span>
-                <input
-                  id="sptjm-number"
-                  type="text"
-                  value={sptjmNumber}
-                  onChange={(e) => setSptjmNumber(e.target.value)}
-                  placeholder="____"
-                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/K.18/TU/</span>
-                <input
-                  type="text"
-                  value={sptjmKap}
-                  onChange={(e) => setSptjmKap(e.target.value)}
-                  className="w-20 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/B/{monthSuffix}</span>
-              </div>
-            </div>
-
-            {/* SP Tidak Mengganggu Tugas */}
-            <div>
-              <label htmlFor="sp-tugas-number" className={labelClass}>
-                SP Tidak Mengganggu Tugas
-              </label>
-              <div className={`${inputBoxClass} mt-1`}>
-                <span className="font-semibold">SM.</span>
-                <input
-                  id="sp-tugas-number"
-                  type="text"
-                  value={spTugasNumber}
-                  onChange={(e) => setSpTugasNumber(e.target.value)}
-                  placeholder="____"
-                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/K.18/TU/</span>
-                <input
-                  type="text"
-                  value={spTugasKap}
-                  onChange={(e) => setSpTugasKap(e.target.value)}
-                  className="w-20 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/B/{monthSuffix}</span>
-              </div>
-            </div>
-
-            {/* SK Kebenaran Dokumen */}
-            <div>
-              <label htmlFor="sk-kebenaran-number" className={labelClass}>
-                SK Kebenaran Dokumen
-              </label>
-              <div className={`${inputBoxClass} mt-1`}>
-                <span className="font-semibold">KT.</span>
-                <input
-                  id="sk-kebenaran-number"
-                  type="text"
-                  value={skKebenaranNumber}
-                  onChange={(e) => setSkKebenaranNumber(e.target.value)}
-                  placeholder="____"
-                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/K.18/TU/</span>
-                <input
-                  type="text"
-                  value={skKebenaranKap}
-                  onChange={(e) => setSkKebenaranKap(e.target.value)}
-                  className="w-20 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/B/{monthSuffix}</span>
-              </div>
-            </div>
-
-            {/* BA Pemeriksaan */}
-            <div>
-              <label htmlFor="ba-pemeriksaan-number" className={labelClass}>
-                BA Pemeriksaan
-              </label>
-              <div className={`${inputBoxClass} mt-1`}>
-                <span className="font-semibold">BA.</span>
-                <input
-                  id="ba-pemeriksaan-number"
-                  type="text"
-                  value={baPemeriksaanNumber}
-                  onChange={(e) => setBaPemeriksaanNumber(e.target.value)}
-                  placeholder="____"
-                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/K.18/TU/</span>
-                <input
-                  type="text"
-                  value={baPemeriksaanKap}
-                  onChange={(e) => setBaPemeriksaanKap(e.target.value)}
-                  className="w-20 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/B/{monthSuffix}</span>
-              </div>
-            </div>
-
-            {/* Nota Dinas KSDAE */}
-            <div>
-              <label htmlFor="nota-dinas-number" className={labelClass}>
-                Nota Dinas KSDAE
-              </label>
-              <div className={`${inputBoxClass} mt-1`}>
-                <span className="font-semibold">ND.</span>
-                <input
-                  id="nota-dinas-number"
-                  type="text"
-                  value={notaDinasNumber}
-                  onChange={(e) => setNotaDinasNumber(e.target.value)}
-                  placeholder="____"
-                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/K.18/TU/</span>
-                <input
-                  type="text"
-                  value={notaDinasKap}
-                  onChange={(e) => setNotaDinasKap(e.target.value)}
-                  className="w-20 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/B/{monthSuffix}</span>
-              </div>
-            </div>
-
-            {/* Permohonan KPKNL */}
-            <div>
-              <label htmlFor="permohonan-kpknl-number" className={labelClass}>
-                Permohonan KPKNL
-              </label>
-              <div className={`${inputBoxClass} mt-1`}>
-                <span className="font-semibold">S.</span>
-                <input
-                  id="permohonan-kpknl-number"
-                  type="text"
-                  value={permohonanKpknlNumber}
-                  onChange={(e) => setPermohonanKpknlNumber(e.target.value)}
-                  placeholder="____"
-                  className="mx-1 w-14 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/K.18/TU/</span>
-                <input
-                  type="text"
-                  value={permohonanKpknlKap}
-                  onChange={(e) => setPermohonanKpknlKap(e.target.value)}
-                  className="w-20 bg-transparent text-center font-semibold outline-none"
-                />
-                <span>/B/{monthSuffix}</span>
-              </div>
-            </div>
+          <div className="grid gap-2">
+            {rows.map((row) => (
+              <NumberSettingRow key={row.id} row={row} monthSuffix={monthSuffix} />
+            ))}
           </div>
 
-          {/* Surat Tugas reference (hanya untuk BA Pemeriksaan) */}
           <div className="rounded-xl border border-dashed border-zinc-200 p-3 dark:border-zinc-800">
             <p className="mb-2 text-[10px] font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
               Referensi Surat Tugas (untuk BA Pemeriksaan)
             </p>
             <div className="grid gap-2 md:grid-cols-2">
-              <div className={inputBoxClass}>
-                <span className="mr-2 shrink-0 text-[9px] font-bold uppercase tracking-wider text-zinc-400">
-                  No. ST
-                </span>
+              <label className="grid gap-1">
+                <span className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">No. ST</span>
                 <input
                   type="text"
                   value={stNumber}
-                  onChange={(e) => setStNumber(e.target.value)}
+                  onChange={(event) => setStNumber(event.target.value)}
                   placeholder="ST.xxx/K.18/TU/..."
-                  className="w-full bg-transparent font-semibold outline-none"
+                  className={fieldClass}
                 />
-              </div>
-              <div className={inputBoxClass}>
-                <span className="mr-2 shrink-0 text-[9px] font-bold uppercase tracking-wider text-zinc-400">
-                  Tgl ST
-                </span>
+              </label>
+              <label className="grid gap-1">
+                <span className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">Tanggal ST</span>
                 <input
                   type="text"
                   value={stTanggal}
-                  onChange={(e) => setStTanggal(e.target.value)}
+                  onChange={(event) => setStTanggal(event.target.value)}
                   placeholder={formatDateLong(new Date())}
-                  className="w-full bg-transparent font-semibold outline-none"
+                  className={fieldClass}
                 />
-              </div>
+              </label>
             </div>
           </div>
         </div>

--- a/frontend/src/app/bmn/auction-candidates/_components/KepalaBalaiPicker.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/KepalaBalaiPicker.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { UserCheck } from "lucide-react";
+import { Check, Save, UserCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import api from "@/lib/api";
 import { formatNip, type SkKepalaBalai } from "../_lib/sk-defaults";
 
@@ -17,12 +19,34 @@ interface KepalaBalaiPickerProps {
   setKepalaBalai: (kb: SkKepalaBalai) => void;
 }
 
-/**
- * Global Kepala Balai picker. Pilihan pegawai dari API kepegawaian.
- * Saat dipilih: nama otomatis UPPERCASE, NIP terformat dengan spasi.
- * State ini di-share ke semua dokumen yang menampilkan TTD Kepala Balai.
- */
+export const KEPALA_BALAI_DEFAULT_STORAGE_KEY = "bmn.auction.defaultKepalaBalai";
+
+export function loadStoredKepalaBalaiDefault(): SkKepalaBalai | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const raw = window.localStorage.getItem(KEPALA_BALAI_DEFAULT_STORAGE_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as Partial<SkKepalaBalai>;
+    if (!parsed.nama || !parsed.nip) return null;
+
+    return {
+      nama: parsed.nama,
+      nip: parsed.nip,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function saveStoredKepalaBalaiDefault(value: SkKepalaBalai) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(KEPALA_BALAI_DEFAULT_STORAGE_KEY, JSON.stringify(value));
+}
+
 export function KepalaBalaiPicker({ kepalaBalai, setKepalaBalai }: KepalaBalaiPickerProps) {
+  const [saved, setSaved] = useState(false);
   const { data: employees = [], isLoading } = useQuery<EmployeeRecord[]>({
     queryKey: ["employees-select-kepala-balai"],
     queryFn: async () => {
@@ -40,13 +64,20 @@ export function KepalaBalaiPicker({ kepalaBalai, setKepalaBalai }: KepalaBalaiPi
 
   const handleSelect = (employeeId: string) => {
     if (!employeeId) return;
-    const emp = employees.find((e) => String(e.id) === employeeId);
+    const emp = employees.find((employee) => String(employee.id) === employeeId);
     if (!emp) return;
     const fullName = (emp.nama_lengkap || emp.name || "").toUpperCase();
+    setSaved(false);
     setKepalaBalai({
       nama: fullName,
       nip: formatNip(emp.nip || ""),
     });
+  };
+
+  const handleSaveDefault = () => {
+    saveStoredKepalaBalaiDefault(kepalaBalai);
+    setSaved(true);
+    window.setTimeout(() => setSaved(false), 1800);
   };
 
   return (
@@ -59,39 +90,48 @@ export function KepalaBalaiPicker({ kepalaBalai, setKepalaBalai }: KepalaBalaiPi
         Pilih pegawai untuk mengisi nama dan NIP penandatangan di semua dokumen yang digenerate.
       </p>
 
-      <div className="grid gap-3 md:grid-cols-[1fr_auto]">
-        <select
-          className="h-9 w-full rounded-lg border border-zinc-200 bg-white px-2 text-xs text-zinc-900 outline-none focus:ring-2 focus:ring-amber-500/20 dark:border-zinc-700 dark:bg-zinc-950 dark:text-white"
-          onChange={(e) => handleSelect(e.target.value)}
-          defaultValue=""
-          disabled={isLoading}
-        >
-          <option value="" disabled>
-            {isLoading ? "Memuat daftar pegawai..." : "Pilih pegawai untuk Kepala Balai..."}
+      <select
+        className="h-10 w-full rounded-lg border border-zinc-200 bg-white px-2 text-xs text-zinc-900 outline-none focus:ring-2 focus:ring-amber-500/20 dark:border-zinc-700 dark:bg-zinc-950 dark:text-white"
+        onChange={(event) => handleSelect(event.target.value)}
+        defaultValue=""
+        disabled={isLoading}
+      >
+        <option value="" disabled>
+          {isLoading ? "Memuat daftar pegawai..." : "Pilih pegawai untuk Kepala Balai..."}
+        </option>
+        {sortedEmployees.map((emp) => (
+          <option key={emp.id} value={String(emp.id)}>
+            {emp.nama_lengkap || emp.name || "Tanpa Nama"}
+            {emp.nip ? ` - NIP. ${formatNip(emp.nip)}` : ""}
           </option>
-          {sortedEmployees.map((emp) => (
-            <option key={emp.id} value={String(emp.id)}>
-              {emp.nama_lengkap || emp.name || "Tanpa Nama"}
-              {emp.nip ? ` — NIP. ${formatNip(emp.nip)}` : ""}
-            </option>
-          ))}
-        </select>
-      </div>
+        ))}
+      </select>
 
       <div className="mt-3 grid gap-2 rounded-lg bg-zinc-50 p-3 text-xs dark:bg-zinc-800/50 sm:grid-cols-2">
         <div>
           <p className="text-[10px] font-bold uppercase tracking-wide text-zinc-400">Nama (UPPERCASE)</p>
           <p className="mt-0.5 font-semibold text-zinc-900 dark:text-zinc-100">
-            {kepalaBalai.nama || "—"}
+            {kepalaBalai.nama || "-"}
           </p>
         </div>
         <div>
           <p className="text-[10px] font-bold uppercase tracking-wide text-zinc-400">NIP</p>
           <p className="mt-0.5 font-mono text-zinc-700 dark:text-zinc-300">
-            {kepalaBalai.nip ? `NIP. ${kepalaBalai.nip}` : "—"}
+            {kepalaBalai.nip ? `NIP. ${kepalaBalai.nip}` : "-"}
           </p>
         </div>
       </div>
+
+      <Button
+        type="button"
+        variant="outline"
+        className="mt-3 h-10 w-full justify-center gap-2 rounded-xl text-xs"
+        onClick={handleSaveDefault}
+        disabled={!kepalaBalai.nama || !kepalaBalai.nip}
+      >
+        {saved ? <Check className="h-3.5 w-3.5 text-emerald-600" /> : <Save className="h-3.5 w-3.5" />}
+        {saved ? "Default tersimpan" : "Jadikan ini sebagai default"}
+      </Button>
     </div>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/_components/ReorderPanel.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/ReorderPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowUp, ArrowDown, FileSpreadsheet, GripVertical } from "lucide-react";
+import { ArrowDown, ArrowUp, FileSpreadsheet, GripVertical } from "lucide-react";
 import type { AuctionAsset } from "../_lib/auction-helpers";
 
 interface ReorderPanelProps {
@@ -26,14 +26,14 @@ export function ReorderPanel({
 }: ReorderPanelProps) {
   return (
     <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 print:hidden">
-      <div className="mb-3 flex items-center justify-between">
+      <div className="mb-3 flex items-center justify-between gap-3">
         <div>
           <h2 className="text-sm font-bold text-zinc-900 dark:text-white">Urutan Aset Terpilih</h2>
           <p className="text-xs text-zinc-500 dark:text-zinc-400">
-            Drag atau gunakan tombol ↑↓ untuk mengatur nomor urut di dokumen.
+            Drag atau gunakan tombol naik/turun untuk mengatur nomor urut di dokumen.
           </p>
         </div>
-        <span className="rounded-lg bg-red-50 px-2.5 py-1 text-xs font-bold text-red-700 dark:bg-red-500/10 dark:text-red-400">
+        <span className="rounded-lg bg-emerald-50 px-2.5 py-1 text-xs font-bold text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-400">
           {orderedIds.length} aset
         </span>
       </div>
@@ -45,7 +45,7 @@ export function ReorderPanel({
             onDragStart={() => onDragStart(index)}
             onDragEnter={() => onDragEnter(index)}
             onDragEnd={onDragEnd}
-            onDragOver={(e) => e.preventDefault()}
+            onDragOver={(event) => event.preventDefault()}
             className="flex cursor-grab items-center gap-3 rounded-xl border border-zinc-100 bg-zinc-50 px-3 py-2 transition active:cursor-grabbing active:opacity-60 dark:border-zinc-800 dark:bg-zinc-800/50"
           >
             <GripVertical className="h-4 w-4 shrink-0 text-zinc-400" />
@@ -54,10 +54,10 @@ export function ReorderPanel({
             </span>
             <div className="min-w-0 flex-1">
               <p className="truncate text-xs font-semibold text-zinc-900 dark:text-zinc-100">{asset.nama_barang}</p>
-              <p className="font-mono text-[10px] text-zinc-400">
-                {asset.kode_barang} · NUP {asset.nup}
-                {asset.merk_tipe ? ` · ${asset.merk_tipe}` : ""}
-                {asset.no_polisi ? ` · ${asset.no_polisi}` : ""}
+              <p className="truncate font-mono text-[10px] text-zinc-400">
+                {asset.kode_barang} - NUP {asset.nup}
+                {asset.merk_tipe ? ` - ${asset.merk_tipe}` : ""}
+                {asset.no_polisi ? ` - ${asset.no_polisi}` : ""}
               </p>
             </div>
             <div className="flex shrink-0 gap-1">
@@ -66,7 +66,7 @@ export function ReorderPanel({
                   type="button"
                   onClick={() => onOpenWorksheet(asset.id)}
                   aria-label={`Buka kertas kerja aset nomor ${index + 1}`}
-                  className="flex h-7 items-center gap-1 rounded-lg border border-emerald-200 bg-white px-2 text-[10px] font-bold text-emerald-700 transition hover:bg-emerald-50 dark:border-emerald-500/30 dark:bg-zinc-900 dark:text-emerald-400 dark:hover:bg-emerald-500/10"
+                  className="flex h-8 items-center gap-1 rounded-lg border border-emerald-200 bg-white px-2 text-[10px] font-bold text-emerald-700 transition hover:bg-emerald-50 dark:border-emerald-500/30 dark:bg-zinc-900 dark:text-emerald-400 dark:hover:bg-emerald-500/10"
                 >
                   <FileSpreadsheet className="h-3.5 w-3.5" />
                   Kertas #{index + 1}
@@ -77,7 +77,7 @@ export function ReorderPanel({
                 onClick={() => onMoveUp(index)}
                 disabled={index === 0}
                 aria-label="Pindah ke atas"
-                className="flex h-7 w-7 items-center justify-center rounded-lg border border-zinc-200 bg-white text-zinc-500 transition hover:bg-zinc-100 disabled:opacity-30 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-700"
+                className="flex h-8 w-8 items-center justify-center rounded-lg border border-zinc-200 bg-white text-zinc-500 transition hover:bg-zinc-100 disabled:opacity-30 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-700"
               >
                 <ArrowUp className="h-3.5 w-3.5" />
               </button>
@@ -86,7 +86,7 @@ export function ReorderPanel({
                 onClick={() => onMoveDown(index)}
                 disabled={index === orderedIds.length - 1}
                 aria-label="Pindah ke bawah"
-                className="flex h-7 w-7 items-center justify-center rounded-lg border border-zinc-200 bg-white text-zinc-500 transition hover:bg-zinc-100 disabled:opacity-30 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-700"
+                className="flex h-8 w-8 items-center justify-center rounded-lg border border-zinc-200 bg-white text-zinc-500 transition hover:bg-zinc-100 disabled:opacity-30 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-700"
               >
                 <ArrowDown className="h-3.5 w-3.5" />
               </button>

--- a/frontend/src/app/bmn/auction-candidates/_components/SelectedAssetsBanner.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SelectedAssetsBanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Printer } from "lucide-react";
+import { CheckCircle2, Printer } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface SelectedAssetsBannerProps {
@@ -62,40 +62,46 @@ export function SelectedAssetsBanner({
   if (orderedIdsLength === 0) return null;
 
   const printActions: PrintAction[] = [];
-  if (showDocument) printActions.push({ label: "Cetak BA Koreksi", onClick: onPrint });
-  if (showSkDocument) printActions.push({ label: "Cetak SK Penghentian", onClick: onPrintSk });
-  if (showSkPanitia) printActions.push({ label: "Cetak SK Panitia", onClick: onPrintSkPanitia });
-  if (showSkTimPenilai) printActions.push({ label: "Cetak SK Tim Penilai", onClick: onPrintSkTimPenilai });
-  if (showSptjLimit) printActions.push({ label: "Cetak SPTJ Limit", onClick: onPrintSptjLimit });
-  if (showSptjm) printActions.push({ label: "Cetak SPTJM", onClick: onPrintSptjm });
-  if (showSpTugas) printActions.push({ label: "Cetak SP Tugas", onClick: onPrintSpTugas });
-  if (showSkKebenaran) printActions.push({ label: "Cetak SK Kebenaran", onClick: onPrintSkKebenaran });
-  if (showBaPemeriksaan) printActions.push({ label: "Cetak BA Pemeriksaan", onClick: onPrintBaPemeriksaan });
-  if (showNotaDinas) printActions.push({ label: "Cetak Nota Dinas KSDAE", onClick: onPrintNotaDinas });
-  if (showPermohonanKpknl) printActions.push({ label: "Cetak Permohonan KPKNL", onClick: onPrintPermohonanKpknl });
+  if (showDocument) printActions.push({ label: "BA Koreksi", onClick: onPrint });
+  if (showSkDocument) printActions.push({ label: "SK Penghentian", onClick: onPrintSk });
+  if (showSkPanitia) printActions.push({ label: "SK Panitia", onClick: onPrintSkPanitia });
+  if (showSkTimPenilai) printActions.push({ label: "SK Tim Penilai", onClick: onPrintSkTimPenilai });
+  if (showSptjLimit) printActions.push({ label: "SPTJ Limit", onClick: onPrintSptjLimit });
+  if (showSptjm) printActions.push({ label: "SPTJM", onClick: onPrintSptjm });
+  if (showSpTugas) printActions.push({ label: "SP Tugas", onClick: onPrintSpTugas });
+  if (showSkKebenaran) printActions.push({ label: "SK Kebenaran", onClick: onPrintSkKebenaran });
+  if (showBaPemeriksaan) printActions.push({ label: "BA Pemeriksaan", onClick: onPrintBaPemeriksaan });
+  if (showNotaDinas) printActions.push({ label: "Nota Dinas", onClick: onPrintNotaDinas });
+  if (showPermohonanKpknl) printActions.push({ label: "Permohonan KPKNL", onClick: onPrintPermohonanKpknl });
 
   return (
-    <div className="flex flex-col gap-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 dark:border-red-500/20 dark:bg-red-500/10 sm:flex-row sm:items-center sm:justify-between">
-      <div>
-        <p className="text-sm font-bold text-red-800 dark:text-red-300">{orderedIdsLength} aset dipilih</p>
-        <p className="text-xs text-red-700/80 dark:text-red-400">
-          {printActions.length > 0
-            ? "Klik tombol cetak untuk dokumen yang sudah ter-generate."
-            : "Klik salah satu tombol Generate Dokumen di atas untuk membuat dokumen lelang."}
-        </p>
+    <div className="sticky top-4 z-20 flex flex-col gap-3 rounded-2xl border border-emerald-200 bg-white/95 px-4 py-3 shadow-sm shadow-emerald-950/5 backdrop-blur dark:border-emerald-500/20 dark:bg-zinc-900/95 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-center gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-emerald-600 text-white">
+          <CheckCircle2 className="h-5 w-5" />
+        </div>
+        <div>
+          <p className="text-sm font-bold text-zinc-900 dark:text-zinc-100">{orderedIdsLength} aset dipilih</p>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+            {printActions.length > 0
+              ? `${printActions.length} dokumen siap dicetak.`
+              : "Lengkapi detail, lalu generate dokumen pada langkah 3."}
+          </p>
+        </div>
       </div>
+
       {printActions.length > 0 && (
-        <div className="flex flex-wrap gap-2">
+        <div className="flex max-w-full gap-2 overflow-x-auto pb-1 sm:justify-end sm:pb-0">
           {printActions.map((action) => (
             <Button
               key={action.label}
               size="sm"
               variant="outline"
-              className="rounded-lg border-red-300 bg-white text-xs text-red-700 hover:bg-red-100 dark:border-red-500/30 dark:bg-zinc-900 dark:text-red-300 dark:hover:bg-red-500/20"
+              className="h-9 shrink-0 rounded-lg border-emerald-200 bg-white text-xs font-bold text-emerald-700 hover:bg-emerald-50 dark:border-emerald-500/30 dark:bg-zinc-950 dark:text-emerald-300 dark:hover:bg-emerald-500/10"
               onClick={action.onClick}
             >
-              <Printer className="mr-1 h-3.5 w-3.5" />
-              {action.label}
+              <Printer className="mr-1.5 h-3.5 w-3.5" />
+              Cetak {action.label}
             </Button>
           ))}
         </div>

--- a/frontend/src/app/bmn/auction-candidates/_components/WorkflowSteps.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/WorkflowSteps.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { CheckCircle2, ClipboardList, FileText, SlidersHorizontal } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface WorkflowStepsProps {
+  selectedCount: number;
+  generatedDocumentCount: number;
+}
+
+const steps = [
+  {
+    key: "assets",
+    label: "Pilih aset",
+    Icon: ClipboardList,
+  },
+  {
+    key: "details",
+    label: "Atur detail",
+    Icon: SlidersHorizontal,
+  },
+  {
+    key: "documents",
+    label: "Generate dokumen",
+    Icon: FileText,
+  },
+];
+
+export function WorkflowSteps({ selectedCount, generatedDocumentCount }: WorkflowStepsProps) {
+  return (
+    <div className="grid gap-3 rounded-2xl border border-zinc-200 bg-white p-3 dark:border-zinc-800 dark:bg-zinc-900 md:grid-cols-3">
+      {steps.map(({ key, label, Icon }, index) => {
+        const isDone =
+          (key === "assets" && selectedCount > 0) ||
+          (key === "details" && selectedCount > 0) ||
+          (key === "documents" && generatedDocumentCount > 0);
+        const isActive =
+          (key === "assets" && selectedCount === 0) ||
+          (key === "details" && selectedCount > 0 && generatedDocumentCount === 0) ||
+          (key === "documents" && generatedDocumentCount > 0);
+
+        return (
+          <div
+            key={key}
+            className={cn(
+              "flex min-h-16 items-center gap-3 rounded-xl border px-3 py-2 transition",
+              isActive
+                ? "border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200"
+                : "border-zinc-100 bg-zinc-50 text-zinc-600 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-300",
+            )}
+          >
+            <div
+              className={cn(
+                "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
+                isDone
+                  ? "bg-emerald-600 text-white"
+                  : "bg-white text-zinc-500 ring-1 ring-zinc-200 dark:bg-zinc-900 dark:text-zinc-400 dark:ring-zinc-700",
+              )}
+            >
+              {isDone ? <CheckCircle2 className="h-4 w-4" /> : <Icon className="h-4 w-4" />}
+            </div>
+            <div>
+              <p className="text-[10px] font-bold uppercase tracking-wider text-zinc-400">
+                Langkah {index + 1}
+              </p>
+              <p className="text-sm font-bold">{label}</p>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/BaKoreksiSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/BaKoreksiSection.tsx
@@ -3,18 +3,29 @@
 import { Printer } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CorrectionDocument } from "../BaKoreksiDocument";
+import { DocumentNumberInlineCard } from "../DocumentNumberInputs";
 import type { AuctionAsset } from "../../_lib/auction-helpers";
 import type { SkKepalaBalai } from "../../_lib/sk-defaults";
 
 interface BaKoreksiSectionProps {
   assets: AuctionAsset[];
   baNumber: string;
+  setBaNumber: (value: string) => void;
   baKap: string;
+  setBaKap: (value: string) => void;
   kepalaBalai: SkKepalaBalai;
   onPrint: () => void;
 }
 
-export function BaKoreksiSection({ assets, baNumber, baKap, kepalaBalai, onPrint }: BaKoreksiSectionProps) {
+export function BaKoreksiSection({
+  assets,
+  baNumber,
+  setBaNumber,
+  baKap,
+  setBaKap,
+  kepalaBalai,
+  onPrint,
+}: BaKoreksiSectionProps) {
   return (
     <section id="ba-koreksi-preview" className="space-y-4">
       <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
@@ -27,7 +38,19 @@ export function BaKoreksiSection({ assets, baNumber, baKap, kepalaBalai, onPrint
           Cetak / Save PDF
         </Button>
       </div>
-      <CorrectionDocument assets={assets} baNumber={baNumber} baKap={baKap} kepalaBalai={kepalaBalai} />
+      <div className="grid gap-4 lg:grid-cols-[400px_1fr]">
+        <div className="space-y-4 print:hidden">
+          <DocumentNumberInlineCard
+            label="BA Koreksi"
+            prefix="BA."
+            number={baNumber}
+            setNumber={setBaNumber}
+            kap={baKap}
+            setKap={setBaKap}
+          />
+        </div>
+        <CorrectionDocument assets={assets} baNumber={baNumber} baKap={baKap} kepalaBalai={kepalaBalai} />
+      </div>
     </section>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/BaPemeriksaanSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/BaPemeriksaanSection.tsx
@@ -3,6 +3,7 @@
 import { Printer } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { BaPemeriksaanDocument } from "../BaPemeriksaanDocument";
+import { DocumentNumberInlineCard } from "../DocumentNumberInputs";
 import { PemeriksaEditor } from "../PemeriksaEditor";
 import type { AuctionAsset } from "../../_lib/auction-helpers";
 import type { SkKepalaBalai } from "../../_lib/sk-defaults";
@@ -12,9 +13,13 @@ import type { EmployeeOption } from "../../_hooks/useEmployeeOptions";
 interface BaPemeriksaanSectionProps {
   assets: AuctionAsset[];
   number: string;
+  setNumber: (value: string) => void;
   kap: string;
+  setKap: (value: string) => void;
   stNumber: string;
+  setStNumber: (value: string) => void;
   stTanggal: string;
+  setStTanggal: (value: string) => void;
   kepalaBalai: SkKepalaBalai;
   pemeriksaList: PemeriksaAnggota[];
   employees: EmployeeOption[];
@@ -28,9 +33,13 @@ interface BaPemeriksaanSectionProps {
 export function BaPemeriksaanSection({
   assets,
   number,
+  setNumber,
   kap,
+  setKap,
   stNumber,
+  setStNumber,
   stTanggal,
+  setStTanggal,
   kepalaBalai,
   pemeriksaList,
   employees,
@@ -53,7 +62,19 @@ export function BaPemeriksaanSection({
         </Button>
       </div>
       <div className="grid gap-4 lg:grid-cols-[400px_1fr]">
-        <div className="print:hidden">
+        <div className="space-y-4 print:hidden">
+          <DocumentNumberInlineCard
+            label="BA Pemeriksaan"
+            prefix="BA."
+            number={number}
+            setNumber={setNumber}
+            kap={kap}
+            setKap={setKap}
+            stNumber={stNumber}
+            setStNumber={setStNumber}
+            stTanggal={stTanggal}
+            setStTanggal={setStTanggal}
+          />
           <PemeriksaEditor
             pemeriksaList={pemeriksaList}
             employees={employees}

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/NotaDinasSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/NotaDinasSection.tsx
@@ -2,6 +2,7 @@
 
 import { Printer, X, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { DocumentNumberInlineCard } from "../DocumentNumberInputs";
 import { NotaDinasDocument } from "../NotaDinasDocument";
 import type { AuctionAsset } from "../../_lib/auction-helpers";
 import type { SkBuilderItem, SkKepalaBalai } from "../../_lib/sk-defaults";
@@ -10,7 +11,9 @@ import { newSkBuilderItem } from "../../_lib/sk-defaults";
 interface NotaDinasSectionProps {
   assets: AuctionAsset[];
   number: string;
+  setNumber: (v: string) => void;
   kap: string;
+  setKap: (v: string) => void;
   kepalaBalai: SkKepalaBalai;
   perihal: string;
   setPerihal: (v: string) => void;
@@ -33,7 +36,9 @@ const inputCls =
 export function NotaDinasSection({
   assets,
   number,
+  setNumber,
   kap,
+  setKap,
   kepalaBalai,
   perihal,
   setPerihal,
@@ -63,6 +68,14 @@ export function NotaDinasSection({
       </div>
       <div className="grid gap-4 lg:grid-cols-[400px_1fr]">
         <div className="space-y-4 print:hidden">
+          <DocumentNumberInlineCard
+            label="Nota Dinas KSDAE"
+            prefix="ND."
+            number={number}
+            setNumber={setNumber}
+            kap={kap}
+            setKap={setKap}
+          />
           <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
             <h3 className="mb-3 text-[10px] font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
               Pengaturan Nota Dinas

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/PermohonanKpknlSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/PermohonanKpknlSection.tsx
@@ -2,6 +2,7 @@
 
 import { Printer, X, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { DocumentNumberInlineCard } from "../DocumentNumberInputs";
 import { PermohonanKpknlDocument } from "../PermohonanKpknlDocument";
 import type { AuctionAsset } from "../../_lib/auction-helpers";
 import type { SkBuilderItem, SkKepalaBalai } from "../../_lib/sk-defaults";
@@ -10,7 +11,9 @@ import { newSkBuilderItem } from "../../_lib/sk-defaults";
 interface PermohonanKpknlSectionProps {
   assets: AuctionAsset[];
   number: string;
+  setNumber: (v: string) => void;
   kap: string;
+  setKap: (v: string) => void;
   kepalaBalai: SkKepalaBalai;
   perihal: string;
   setPerihal: (v: string) => void;
@@ -31,7 +34,9 @@ const inputCls =
 export function PermohonanKpknlSection({
   assets,
   number,
+  setNumber,
   kap,
+  setKap,
   kepalaBalai,
   perihal,
   setPerihal,
@@ -59,6 +64,14 @@ export function PermohonanKpknlSection({
       </div>
       <div className="grid gap-4 lg:grid-cols-[400px_1fr]">
         <div className="space-y-4 print:hidden">
+          <DocumentNumberInlineCard
+            label="Permohonan KPKNL"
+            prefix="S."
+            number={number}
+            setNumber={setNumber}
+            kap={kap}
+            setKap={setKap}
+          />
           <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900">
             <h3 className="mb-3 text-[10px] font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
               Pengaturan Permohonan KPKNL

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/SkKebenaranSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/SkKebenaranSection.tsx
@@ -2,6 +2,7 @@
 
 import { Printer } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { DocumentNumberInlineCard } from "../DocumentNumberInputs";
 import { SkKebenaranDokumenDocument } from "../SkKebenaranDokumenDocument";
 import type { AuctionAsset } from "../../_lib/auction-helpers";
 import type { SkKepalaBalai } from "../../_lib/sk-defaults";
@@ -9,12 +10,14 @@ import type { SkKepalaBalai } from "../../_lib/sk-defaults";
 interface SkKebenaranSectionProps {
   assets: AuctionAsset[];
   number: string;
+  setNumber: (value: string) => void;
   kap: string;
+  setKap: (value: string) => void;
   kepalaBalai: SkKepalaBalai;
   onPrint: () => void;
 }
 
-export function SkKebenaranSection({ assets, number, kap, kepalaBalai, onPrint }: SkKebenaranSectionProps) {
+export function SkKebenaranSection({ assets, number, setNumber, kap, setKap, kepalaBalai, onPrint }: SkKebenaranSectionProps) {
   return (
     <section id="sk-kebenaran-preview" className="space-y-4">
       <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
@@ -27,12 +30,24 @@ export function SkKebenaranSection({ assets, number, kap, kepalaBalai, onPrint }
           Cetak / Save PDF
         </Button>
       </div>
-      <SkKebenaranDokumenDocument
-        number={number}
-        kap={kap}
-        assets={assets}
-        kepalaBalai={kepalaBalai}
-      />
+      <div className="grid gap-4 lg:grid-cols-[400px_1fr]">
+        <div className="print:hidden">
+          <DocumentNumberInlineCard
+            label="SK Kebenaran Dokumen"
+            prefix="KT."
+            number={number}
+            setNumber={setNumber}
+            kap={kap}
+            setKap={setKap}
+          />
+        </div>
+        <SkKebenaranDokumenDocument
+          number={number}
+          kap={kap}
+          assets={assets}
+          kepalaBalai={kepalaBalai}
+        />
+      </div>
     </section>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/SkPanitiaSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/SkPanitiaSection.tsx
@@ -2,6 +2,7 @@
 
 import { Printer } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { DocumentNumberInlineCard } from "../DocumentNumberInputs";
 import { SkBuilder } from "../SkBuilder";
 import { SkPanitiaDocument } from "../SkPanitiaDocument";
 import { PanitiaEditor } from "../PanitiaEditor";
@@ -11,7 +12,9 @@ import type { EmployeeOption } from "../../_hooks/useEmployeeOptions";
 
 interface SkPanitiaSectionProps {
   skPanitiaNumber: string;
+  setSkPanitiaNumber: (value: string) => void;
   skPanitiaKap: string;
+  setSkPanitiaKap: (value: string) => void;
   panitiaMenimbang: SkBuilderItem[];
   setPanitiaMenimbang: (items: SkBuilderItem[]) => void;
   panitiaMengingat: SkBuilderItem[];
@@ -33,7 +36,9 @@ interface SkPanitiaSectionProps {
 
 export function SkPanitiaSection({
   skPanitiaNumber,
+  setSkPanitiaNumber,
   skPanitiaKap,
+  setSkPanitiaKap,
   panitiaMenimbang,
   setPanitiaMenimbang,
   panitiaMengingat,
@@ -65,7 +70,15 @@ export function SkPanitiaSection({
         </Button>
       </div>
       <div className="grid gap-4 lg:grid-cols-[400px_1fr]">
-        <div className="print:hidden">
+        <div className="space-y-4 print:hidden">
+          <DocumentNumberInlineCard
+            label="SK Panitia"
+            prefix="SK."
+            number={skPanitiaNumber}
+            setNumber={setSkPanitiaNumber}
+            kap={skPanitiaKap}
+            setKap={setSkPanitiaKap}
+          />
           <SkBuilder
             menimbang={panitiaMenimbang}
             setMenimbang={setPanitiaMenimbang}

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/SkPenghentianSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/SkPenghentianSection.tsx
@@ -2,6 +2,7 @@
 
 import { Printer } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { DocumentNumberInlineCard } from "../DocumentNumberInputs";
 import { SkBuilder } from "../SkBuilder";
 import { SkPenghentianDocument } from "../SkPenghentianDocument";
 import type { AuctionAsset } from "../../_lib/auction-helpers";
@@ -10,7 +11,9 @@ import type { SkBuilderItem, SkKepalaBalai, SkMemutuskan } from "../../_lib/sk-d
 interface SkPenghentianSectionProps {
   assets: AuctionAsset[];
   skNumber: string;
+  setSkNumber: (value: string) => void;
   skKap: string;
+  setSkKap: (value: string) => void;
   menimbang: SkBuilderItem[];
   setMenimbang: (items: SkBuilderItem[]) => void;
   mengingat: SkBuilderItem[];
@@ -27,7 +30,9 @@ interface SkPenghentianSectionProps {
 export function SkPenghentianSection({
   assets,
   skNumber,
+  setSkNumber,
   skKap,
+  setSkKap,
   menimbang,
   setMenimbang,
   mengingat,
@@ -53,7 +58,15 @@ export function SkPenghentianSection({
         </Button>
       </div>
       <div className="grid gap-4 lg:grid-cols-[400px_1fr]">
-        <div className="print:hidden">
+        <div className="space-y-4 print:hidden">
+          <DocumentNumberInlineCard
+            label="SK Penghentian"
+            prefix="SK."
+            number={skNumber}
+            setNumber={setSkNumber}
+            kap={skKap}
+            setKap={setSkKap}
+          />
           <SkBuilder
             menimbang={menimbang}
             setMenimbang={setMenimbang}

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/SkTimPenilaiSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/SkTimPenilaiSection.tsx
@@ -2,6 +2,7 @@
 
 import { Printer } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { DocumentNumberInlineCard } from "../DocumentNumberInputs";
 import { SkTimPenilaiBuilder } from "../SkTimPenilaiBuilder";
 import { SkTimPenilaiDocument } from "../SkTimPenilaiDocument";
 import { TimPenilaiEditor } from "../TimPenilaiEditor";
@@ -14,7 +15,9 @@ import type { EmployeeOption } from "../../_hooks/useEmployeeOptions";
 
 interface SkTimPenilaiSectionProps {
   skTimPenilaiNumber: string;
+  setSkTimPenilaiNumber: (value: string) => void;
   skTimPenilaiKap: string;
+  setSkTimPenilaiKap: (value: string) => void;
   timPenilaiMenimbang: SkBuilderItem[];
   setTimPenilaiMenimbang: (items: SkBuilderItem[]) => void;
   timPenilaiMengingat: SkBuilderItem[];
@@ -36,7 +39,9 @@ interface SkTimPenilaiSectionProps {
 
 export function SkTimPenilaiSection({
   skTimPenilaiNumber,
+  setSkTimPenilaiNumber,
   skTimPenilaiKap,
+  setSkTimPenilaiKap,
   timPenilaiMenimbang,
   setTimPenilaiMenimbang,
   timPenilaiMengingat,
@@ -68,7 +73,15 @@ export function SkTimPenilaiSection({
         </Button>
       </div>
       <div className="grid gap-4 lg:grid-cols-[400px_1fr]">
-        <div className="print:hidden">
+        <div className="space-y-4 print:hidden">
+          <DocumentNumberInlineCard
+            label="SK Tim Penilai"
+            prefix="SK."
+            number={skTimPenilaiNumber}
+            setNumber={setSkTimPenilaiNumber}
+            kap={skTimPenilaiKap}
+            setKap={setSkTimPenilaiKap}
+          />
           <SkTimPenilaiBuilder
             menimbang={timPenilaiMenimbang}
             setMenimbang={setTimPenilaiMenimbang}

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/SpTugasSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/SpTugasSection.tsx
@@ -2,17 +2,20 @@
 
 import { Printer } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { DocumentNumberInlineCard } from "../DocumentNumberInputs";
 import { SpTugasDocument } from "../SpTugasDocument";
 import type { SkKepalaBalai } from "../../_lib/sk-defaults";
 
 interface SpTugasSectionProps {
   number: string;
+  setNumber: (value: string) => void;
   kap: string;
+  setKap: (value: string) => void;
   kepalaBalai: SkKepalaBalai;
   onPrint: () => void;
 }
 
-export function SpTugasSection({ number, kap, kepalaBalai, onPrint }: SpTugasSectionProps) {
+export function SpTugasSection({ number, setNumber, kap, setKap, kepalaBalai, onPrint }: SpTugasSectionProps) {
   return (
     <section id="sp-tugas-preview" className="space-y-4">
       <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
@@ -25,7 +28,19 @@ export function SpTugasSection({ number, kap, kepalaBalai, onPrint }: SpTugasSec
           Cetak / Save PDF
         </Button>
       </div>
-      <SpTugasDocument number={number} kap={kap} kepalaBalai={kepalaBalai} />
+      <div className="grid gap-4 lg:grid-cols-[400px_1fr]">
+        <div className="print:hidden">
+          <DocumentNumberInlineCard
+            label="SP Tidak Mengganggu Tugas"
+            prefix="SM."
+            number={number}
+            setNumber={setNumber}
+            kap={kap}
+            setKap={setKap}
+          />
+        </div>
+        <SpTugasDocument number={number} kap={kap} kepalaBalai={kepalaBalai} />
+      </div>
     </section>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/SptjLimitSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/SptjLimitSection.tsx
@@ -2,17 +2,20 @@
 
 import { Printer } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { DocumentNumberInlineCard } from "../DocumentNumberInputs";
 import { SptjLimitDocument } from "../SptjLimitDocument";
 import type { SkKepalaBalai } from "../../_lib/sk-defaults";
 
 interface SptjLimitSectionProps {
   number: string;
+  setNumber: (value: string) => void;
   kap: string;
+  setKap: (value: string) => void;
   kepalaBalai: SkKepalaBalai;
   onPrint: () => void;
 }
 
-export function SptjLimitSection({ number, kap, kepalaBalai, onPrint }: SptjLimitSectionProps) {
+export function SptjLimitSection({ number, setNumber, kap, setKap, kepalaBalai, onPrint }: SptjLimitSectionProps) {
   return (
     <section id="sptj-limit-preview" className="space-y-4">
       <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
@@ -25,7 +28,19 @@ export function SptjLimitSection({ number, kap, kepalaBalai, onPrint }: SptjLimi
           Cetak / Save PDF
         </Button>
       </div>
-      <SptjLimitDocument number={number} kap={kap} kepalaBalai={kepalaBalai} />
+      <div className="grid gap-4 lg:grid-cols-[400px_1fr]">
+        <div className="space-y-4 print:hidden">
+          <DocumentNumberInlineCard
+            label="SPTJ Nilai Limit"
+            prefix="SM."
+            number={number}
+            setNumber={setNumber}
+            kap={kap}
+            setKap={setKap}
+          />
+        </div>
+        <SptjLimitDocument number={number} kap={kap} kepalaBalai={kepalaBalai} />
+      </div>
     </section>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/_components/sections/SptjmSection.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/sections/SptjmSection.tsx
@@ -2,17 +2,20 @@
 
 import { Printer } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { DocumentNumberInlineCard } from "../DocumentNumberInputs";
 import { SptjmDocument } from "../SptjmDocument";
 import type { SkKepalaBalai } from "../../_lib/sk-defaults";
 
 interface SptjmSectionProps {
   number: string;
+  setNumber: (value: string) => void;
   kap: string;
+  setKap: (value: string) => void;
   kepalaBalai: SkKepalaBalai;
   onPrint: () => void;
 }
 
-export function SptjmSection({ number, kap, kepalaBalai, onPrint }: SptjmSectionProps) {
+export function SptjmSection({ number, setNumber, kap, setKap, kepalaBalai, onPrint }: SptjmSectionProps) {
   return (
     <section id="sptjm-preview" className="space-y-4">
       <div className="flex flex-col gap-3 rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900 sm:flex-row sm:items-center sm:justify-between print:hidden">
@@ -25,7 +28,19 @@ export function SptjmSection({ number, kap, kepalaBalai, onPrint }: SptjmSection
           Cetak / Save PDF
         </Button>
       </div>
-      <SptjmDocument number={number} kap={kap} kepalaBalai={kepalaBalai} />
+      <div className="grid gap-4 lg:grid-cols-[400px_1fr]">
+        <div className="space-y-4 print:hidden">
+          <DocumentNumberInlineCard
+            label="SPTJM"
+            prefix="SPTJM."
+            number={number}
+            setNumber={setNumber}
+            kap={kap}
+            setKap={setKap}
+          />
+        </div>
+        <SptjmDocument number={number} kap={kap} kepalaBalai={kepalaBalai} />
+      </div>
     </section>
   );
 }

--- a/frontend/src/app/bmn/auction-candidates/_hooks/useSkBuilderState.ts
+++ b/frontend/src/app/bmn/auction-candidates/_hooks/useSkBuilderState.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { loadStoredKepalaBalaiDefault } from "../_components/KepalaBalaiPicker";
 import {
   DEFAULT_KEPALA_BALAI,
   DEFAULT_MEMUTUSKAN,
@@ -29,7 +30,9 @@ export function useSkBuilderState(): UseSkBuilderStateResult {
   const [menimbang, setMenimbang] = useState<SkBuilderItem[]>(DEFAULT_MENIMBANG);
   const [mengingat, setMengingat] = useState<SkBuilderItem[]>(DEFAULT_MENGINGAT);
   const [memutuskan, setMemutuskan] = useState<SkMemutuskan>(DEFAULT_MEMUTUSKAN);
-  const [kepalaBalai, setKepalaBalai] = useState<SkKepalaBalai>(DEFAULT_KEPALA_BALAI);
+  const [kepalaBalai, setKepalaBalai] = useState<SkKepalaBalai>(
+    () => loadStoredKepalaBalaiDefault() ?? DEFAULT_KEPALA_BALAI,
+  );
   const [tembusan, setTembusan] = useState<SkBuilderItem[]>(DEFAULT_TEMBUSAN);
 
   return {

--- a/frontend/src/app/bmn/auction-candidates/page.tsx
+++ b/frontend/src/app/bmn/auction-candidates/page.tsx
@@ -18,9 +18,9 @@ import { handlePrintPermohonanKpknl } from "./_components/PermohonanKpknlDocumen
 import { PageHeader } from "./_components/PageHeader";
 import { DocumentActions } from "./_components/DocumentActions";
 import { SearchBar } from "./_components/SearchBar";
-import { DocumentNumberInputs } from "./_components/DocumentNumberInputs";
-import { KepalaBalaiPicker } from "./_components/KepalaBalaiPicker";
 import { SelectedAssetsBanner } from "./_components/SelectedAssetsBanner";
+import { WorkflowSteps } from "./_components/WorkflowSteps";
+import { KepalaBalaiPicker } from "./_components/KepalaBalaiPicker";
 import { AssetTable } from "./_components/AssetTable";
 import { BaKoreksiSection } from "./_components/sections/BaKoreksiSection";
 import { SkPenghentianSection } from "./_components/sections/SkPenghentianSection";
@@ -102,6 +102,35 @@ export default function BmnAuctionCandidatesPage() {
   const activeWorksheetNumber = worksheetAssetId
     ? worksheetNumberByAssetId.get(worksheetAssetId) || 1
     : 1;
+  const generatedDocumentCount = useMemo(
+    () =>
+      [
+        docToggles.showDocument,
+        docToggles.showSkDocument,
+        docToggles.showSkPanitia,
+        docToggles.showSkTimPenilai,
+        docToggles.showSptjLimit,
+        docToggles.showSptjm,
+        docToggles.showSpTugas,
+        docToggles.showSkKebenaran,
+        docToggles.showBaPemeriksaan,
+        docToggles.showNotaDinas,
+        docToggles.showPermohonanKpknl,
+      ].filter(Boolean).length,
+    [
+      docToggles.showDocument,
+      docToggles.showSkDocument,
+      docToggles.showSkPanitia,
+      docToggles.showSkTimPenilai,
+      docToggles.showSptjLimit,
+      docToggles.showSptjm,
+      docToggles.showSpTugas,
+      docToggles.showSkKebenaran,
+      docToggles.showBaPemeriksaan,
+      docToggles.showNotaDinas,
+      docToggles.showPermohonanKpknl,
+    ],
+  );
 
   const handleOpenWorksheet = useCallback((assetId: string) => {
     setWorksheetAssetId(assetId);
@@ -187,19 +216,9 @@ export default function BmnAuctionCandidatesPage() {
         <SummaryTile label="Nilai Terpilih" value={formatRupiah(selectedTotal)} tone="zinc" />
       </div>
 
-      <DocumentActions
-        orderedIdsLength={orderedIds.length}
-        onProcess={docToggles.handleProcess}
-        onProcessSk={docToggles.handleProcessSk}
-        onProcessSkPanitia={docToggles.handleProcessSkPanitia}
-        onProcessSkTimPenilai={docToggles.handleProcessSkTimPenilai}
-        onProcessSptjLimit={docToggles.handleProcessSptjLimit}
-        onProcessSptjm={docToggles.handleProcessSptjm}
-        onProcessSpTugas={docToggles.handleProcessSpTugas}
-        onProcessSkKebenaran={docToggles.handleProcessSkKebenaran}
-        onProcessBaPemeriksaan={docToggles.handleProcessBaPemeriksaan}
-        onProcessNotaDinas={docToggles.handleProcessNotaDinas}
-        onProcessPermohonanKpknl={docToggles.handleProcessPermohonanKpknl}
+      <WorkflowSteps
+        selectedCount={orderedIds.length}
+        generatedDocumentCount={generatedDocumentCount}
       />
 
       <SearchBar
@@ -209,9 +228,21 @@ export default function BmnAuctionCandidatesPage() {
         isLoading={isLoading}
       />
 
-      <DocumentNumberInputs {...docNumbers} />
-
-      <KepalaBalaiPicker kepalaBalai={sk.kepalaBalai} setKepalaBalai={sk.setKepalaBalai} />
+      <AssetTable
+        assets={assets}
+        selectedIds={selectedIds}
+        allSelected={allSelected}
+        isLoading={isLoading}
+        response={response}
+        page={page}
+        perPage={perPage}
+        onToggleSelect={handleToggleSelect}
+        onToggleSelectAll={handleToggleSelectAll}
+        onPerPageChange={handlePerPageChange}
+        onPageChange={setPage}
+        worksheetNumberByAssetId={worksheetNumberByAssetId}
+        onOpenWorksheet={handleOpenWorksheet}
+      />
 
       <SelectedAssetsBanner
         orderedIdsLength={orderedIds.length}
@@ -239,21 +270,25 @@ export default function BmnAuctionCandidatesPage() {
         onPrintPermohonanKpknl={handlePrintPermohonanKpknlDoc}
       />
 
-      <AssetTable
-        assets={assets}
-        selectedIds={selectedIds}
-        allSelected={allSelected}
-        isLoading={isLoading}
-        response={response}
-        page={page}
-        perPage={perPage}
-        onToggleSelect={handleToggleSelect}
-        onToggleSelectAll={handleToggleSelectAll}
-        onPerPageChange={handlePerPageChange}
-        onPageChange={setPage}
-        worksheetNumberByAssetId={worksheetNumberByAssetId}
-        onOpenWorksheet={handleOpenWorksheet}
-      />
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+        <div className="space-y-5">
+          <KepalaBalaiPicker kepalaBalai={sk.kepalaBalai} setKepalaBalai={sk.setKepalaBalai} />
+        </div>
+        <DocumentActions
+          orderedIdsLength={orderedIds.length}
+          onProcess={docToggles.handleProcess}
+          onProcessSk={docToggles.handleProcessSk}
+          onProcessSkPanitia={docToggles.handleProcessSkPanitia}
+          onProcessSkTimPenilai={docToggles.handleProcessSkTimPenilai}
+          onProcessSptjLimit={docToggles.handleProcessSptjLimit}
+          onProcessSptjm={docToggles.handleProcessSptjm}
+          onProcessSpTugas={docToggles.handleProcessSpTugas}
+          onProcessSkKebenaran={docToggles.handleProcessSkKebenaran}
+          onProcessBaPemeriksaan={docToggles.handleProcessBaPemeriksaan}
+          onProcessNotaDinas={docToggles.handleProcessNotaDinas}
+          onProcessPermohonanKpknl={docToggles.handleProcessPermohonanKpknl}
+        />
+      </div>
 
       {orderedIds.length > 0 && (
         <ReorderPanel
@@ -282,7 +317,9 @@ export default function BmnAuctionCandidatesPage() {
         <BaKoreksiSection
           assets={orderedSelectedAssets}
           baNumber={docNumbers.baNumber}
+          setBaNumber={docNumbers.setBaNumber}
           baKap={docNumbers.baKap}
+          setBaKap={docNumbers.setBaKap}
           kepalaBalai={sk.kepalaBalai}
           onPrint={handlePrint}
         />
@@ -292,7 +329,9 @@ export default function BmnAuctionCandidatesPage() {
         <SkPenghentianSection
           assets={orderedSelectedAssets}
           skNumber={docNumbers.skNumber}
+          setSkNumber={docNumbers.setSkNumber}
           skKap={docNumbers.skKap}
+          setSkKap={docNumbers.setSkKap}
           menimbang={sk.menimbang}
           setMenimbang={sk.setMenimbang}
           mengingat={sk.mengingat}
@@ -310,7 +349,9 @@ export default function BmnAuctionCandidatesPage() {
       {docToggles.showSkPanitia && orderedIds.length > 0 && (
         <SkPanitiaSection
           skPanitiaNumber={docNumbers.skPanitiaNumber}
+          setSkPanitiaNumber={docNumbers.setSkPanitiaNumber}
           skPanitiaKap={docNumbers.skPanitiaKap}
+          setSkPanitiaKap={docNumbers.setSkPanitiaKap}
           panitiaMenimbang={skPanitia.panitiaMenimbang}
           setPanitiaMenimbang={skPanitia.setPanitiaMenimbang}
           panitiaMengingat={skPanitia.panitiaMengingat}
@@ -334,7 +375,9 @@ export default function BmnAuctionCandidatesPage() {
       {docToggles.showSkTimPenilai && orderedIds.length > 0 && (
         <SkTimPenilaiSection
           skTimPenilaiNumber={docNumbers.skTimPenilaiNumber}
+          setSkTimPenilaiNumber={docNumbers.setSkTimPenilaiNumber}
           skTimPenilaiKap={docNumbers.skTimPenilaiKap}
+          setSkTimPenilaiKap={docNumbers.setSkTimPenilaiKap}
           timPenilaiMenimbang={skTimPenilai.timPenilaiMenimbang}
           setTimPenilaiMenimbang={skTimPenilai.setTimPenilaiMenimbang}
           timPenilaiMengingat={skTimPenilai.timPenilaiMengingat}
@@ -358,7 +401,9 @@ export default function BmnAuctionCandidatesPage() {
       {docToggles.showSptjLimit && (
         <SptjLimitSection
           number={docNumbers.sptjLimitNumber}
+          setNumber={docNumbers.setSptjLimitNumber}
           kap={docNumbers.sptjLimitKap}
+          setKap={docNumbers.setSptjLimitKap}
           kepalaBalai={sk.kepalaBalai}
           onPrint={handlePrintSptjLimitDoc}
         />
@@ -367,7 +412,9 @@ export default function BmnAuctionCandidatesPage() {
       {docToggles.showSptjm && (
         <SptjmSection
           number={docNumbers.sptjmNumber}
+          setNumber={docNumbers.setSptjmNumber}
           kap={docNumbers.sptjmKap}
+          setKap={docNumbers.setSptjmKap}
           kepalaBalai={sk.kepalaBalai}
           onPrint={handlePrintSptjmDoc}
         />
@@ -376,7 +423,9 @@ export default function BmnAuctionCandidatesPage() {
       {docToggles.showSpTugas && (
         <SpTugasSection
           number={docNumbers.spTugasNumber}
+          setNumber={docNumbers.setSpTugasNumber}
           kap={docNumbers.spTugasKap}
+          setKap={docNumbers.setSpTugasKap}
           kepalaBalai={sk.kepalaBalai}
           onPrint={handlePrintSpTugasDoc}
         />
@@ -386,7 +435,9 @@ export default function BmnAuctionCandidatesPage() {
         <SkKebenaranSection
           assets={orderedSelectedAssets}
           number={docNumbers.skKebenaranNumber}
+          setNumber={docNumbers.setSkKebenaranNumber}
           kap={docNumbers.skKebenaranKap}
+          setKap={docNumbers.setSkKebenaranKap}
           kepalaBalai={sk.kepalaBalai}
           onPrint={handlePrintSkKebenaranDoc}
         />
@@ -396,9 +447,13 @@ export default function BmnAuctionCandidatesPage() {
         <BaPemeriksaanSection
           assets={orderedSelectedAssets}
           number={docNumbers.baPemeriksaanNumber}
+          setNumber={docNumbers.setBaPemeriksaanNumber}
           kap={docNumbers.baPemeriksaanKap}
+          setKap={docNumbers.setBaPemeriksaanKap}
           stNumber={docNumbers.stNumber}
+          setStNumber={docNumbers.setStNumber}
           stTanggal={docNumbers.stTanggal}
+          setStTanggal={docNumbers.setStTanggal}
           kepalaBalai={sk.kepalaBalai}
           pemeriksaList={pemeriksa.pemeriksaList}
           employees={sortedEmployeesForPanitia}
@@ -414,7 +469,9 @@ export default function BmnAuctionCandidatesPage() {
         <NotaDinasSection
           assets={orderedSelectedAssets}
           number={docNumbers.notaDinasNumber}
+          setNumber={docNumbers.setNotaDinasNumber}
           kap={docNumbers.notaDinasKap}
+          setKap={docNumbers.setNotaDinasKap}
           kepalaBalai={sk.kepalaBalai}
           perihal={notaKpknl.ndPerihal}
           setPerihal={notaKpknl.setNdPerihal}
@@ -436,7 +493,9 @@ export default function BmnAuctionCandidatesPage() {
         <PermohonanKpknlSection
           assets={orderedSelectedAssets}
           number={docNumbers.permohonanKpknlNumber}
+          setNumber={docNumbers.setPermohonanKpknlNumber}
           kap={docNumbers.permohonanKpknlKap}
+          setKap={docNumbers.setPermohonanKpknlKap}
           kepalaBalai={sk.kepalaBalai}
           perihal={notaKpknl.pkPerihal}
           setPerihal={notaKpknl.setPkPerihal}


### PR DESCRIPTION
## Summary
- Refine `/bmn/auction-candidates` workflow with clearer document generation steps and per-preview document number controls
- Improve selected asset ordering, sticky selected-assets actions, and document preview layout
- Restore global Kepala Balai signer picker with saved default support

## Validation
- `cd frontend; npm run lint`
- `cd frontend; npx tsc --noEmit`