### PR TITLE
Show ownership document number in SK Kebenaran

### DIFF
--- a/frontend/src/app/bmn/auction-candidates/_components/SkKebenaranDokumenDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SkKebenaranDokumenDocument.tsx
@@ -17,6 +17,10 @@ function buildNomorText(number: string, kap: string, today: Date) {
   return `KT.${number.trim() || "____"}/K.18/TU/${kap.trim() || "KAP.06.01"}/B/${month}/${today.getFullYear()}`;
 }
 
+function getOwnershipDocumentNumber(asset: AuctionAsset) {
+  return asset.no_bpkp || asset.no_dokumen || asset.no_sertifikat || asset.no_identitas || "";
+}
+
 export function handlePrintSkKebenaran() {
   const printContent = document.getElementById("sk-kebenaran-print-root");
   if (!printContent) {
@@ -164,7 +168,7 @@ export function SkKebenaranDokumenDocument({ number, kap, assets, kepalaBalai }:
                 assets.map((asset, index) => (
                   <tr key={asset.id}>
                     <td>{index + 1}.</td>
-                    <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.no_identitas || ""}</td>
+                    <td contentEditable suppressContentEditableWarning className="doc-editable">{getOwnershipDocumentNumber(asset)}</td>
                     <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.merk_tipe || ""}</td>
                     <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.no_mesin || ""}</td>
                     <td contentEditable suppressContentEditableWarning className="doc-editable">{asset.no_rangka || ""}</td>

--- a/frontend/src/app/bmn/auction-candidates/_lib/auction-helpers.ts
+++ b/frontend/src/app/bmn/auction-candidates/_lib/auction-helpers.ts
@@ -14,6 +14,9 @@ export interface AuctionAsset {
   lokasi_spesifik?: string | null;
   tahun_perolehan?: number | null;
   no_polisi?: string | null;
+  no_dokumen?: string | null;
+  no_bpkp?: string | null;
+  no_sertifikat?: string | null;
   no_identitas?: string | null;
   no_mesin?: string | null;
   no_rangka?: string | null;


### PR DESCRIPTION
## Summary
- Display the vehicle ownership document number in SK Kebenaran Dokumen Kepemilikan
- Add ownership document fields to the auction asset type
- Use fallback order: no_bpkp, no_dokumen, no_sertifikat, then no_identitas

## Validation
- `cd frontend; npm run lint`
- `cd frontend; npx tsc --noEmit`