### PR TITLE
security: hide admin-only bmn actions

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,13 +1,54 @@
+# Progress - Phase 82: BMN Admin-only UI Visibility
+
+> Document updated: 2026-06-18
+> Status: Implemented locally on branch `codex/bmn-admin-ui-visibility`; siap PR.
+
+---
+
+## Sinkronisasi UI dengan Authorization Backend BMN
+
+### Status: SELESAI DI LOKAL
+- Scope: frontend visibility guard untuk aksi sensitif BMN yang sudah diproteksi backend di Phase 81.
+- Tujuan: user non-admin tidak melihat tombol/aksi yang pasti ditolak backend, sementara admin/super admin tetap bisa bekerja normal.
+
+### Implementasi
+- Halaman `Aset Dihapus`:
+  - checkbox seleksi, bulk restore, dan hapus permanen hanya tampil untuk `admin` / `super_admin`.
+  - mode non-admin menjadi read-only.
+- Halaman `Import Review`:
+  - upload file import hanya tampil untuk `admin` / `super_admin`.
+  - user non-admin melihat notice read-only dan tetap bisa membuka riwayat.
+- Detail `Import Review`:
+  - approve/reject, bulk selection, checkbox row, dan checkbox perubahan per kolom hanya aktif untuk `admin` / `super_admin`.
+  - non-admin bisa melihat detail batch sebagai read-only.
+- Halaman `Laporan > Riwayat Dokumen`:
+  - tombol hapus arsip BA Pemakaian dan BA Serah Terima hanya tampil untuk `admin` / `super_admin`.
+
+### Validasi
+- `npm run lint`: pass.
+- `npm run build`: pass.
+- Browser bawaan Codex:
+  - login superadmin lokal berhasil.
+  - `/bmn/reports`: tab Riwayat Dokumen terbuka, tombol `Lihat`, `Cetak`, `Duplikasi`, dan `Hapus` tampil untuk superadmin.
+  - `/bmn/import-review`: upload file tampil untuk superadmin.
+  - `/bmn/disposal`: deskripsi dan mode aksi admin tampil untuk superadmin.
+
+### Catatan
+- Backend tetap menjadi sumber kebenaran authorization. UI guard ini untuk UX dan mengurangi peluang aksi tidak sah dari permukaan aplikasi.
+- File untracked lokal `frontend/public/header.png` tidak disentuh.
+
+---
+
 # Progress - Phase 81: BMN Authorization Hardening
 
 > Document updated: 2026-06-18
-> Status: Implemented locally on branch `codex/bmn-authorization-hardening`; siap PR.
+> Status: PR #411 squash merged ke `main` (commit `84d933d`). Branch remote `codex/bmn-authorization-hardening` sudah dihapus.
 
 ---
 
 ## Hardening Aksi Sensitif BMN
 
-### Status: SELESAI - siap PR
+### Status: SELESAI
 - Scope: backend route protection untuk modul BMN.
 - Tujuan: mencegah user yang hanya punya akses modul BMN menjalankan aksi destruktif/mutasi besar langsung lewat API.
 

--- a/frontend/src/app/bmn/disposal/page.tsx
+++ b/frontend/src/app/bmn/disposal/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { useRole } from "@/hooks/useRole";
 
 const formatRupiah = (angka: number) =>
   new Intl.NumberFormat("id-ID", { style: "currency", currency: "IDR", minimumFractionDigits: 0 }).format(angka);
@@ -28,6 +29,7 @@ interface IResponse { data: IDisposedAsset[]; last_page: number; total?: number 
 
 export default function BmnDisposalPage() {
   const queryClient = useQueryClient();
+  const { canWrite } = useRole();
   const [searchTerm, setSearchTerm] = useState("");
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
@@ -49,6 +51,7 @@ export default function BmnDisposalPage() {
   const assets = response?.data || [];
 
   const toggleSelect = (id: string) => {
+    if (!canWrite) return;
     setSelectedIds((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
@@ -58,6 +61,7 @@ export default function BmnDisposalPage() {
   };
 
   const toggleAll = () => {
+    if (!canWrite) return;
     if (selectedIds.size === assets.length) {
       setSelectedIds(new Set());
     } else {
@@ -66,7 +70,7 @@ export default function BmnDisposalPage() {
   };
 
   const handleRestore = async () => {
-    if (selectedIds.size === 0) return;
+    if (!canWrite || selectedIds.size === 0) return;
     setIsRestoring(true);
     try {
       await api.post("/bmn/assets/bulk-restore", { ids: Array.from(selectedIds) });
@@ -82,7 +86,7 @@ export default function BmnDisposalPage() {
   };
 
   const handleForceDelete = async () => {
-    if (selectedIds.size === 0) return;
+    if (!canWrite || selectedIds.size === 0) return;
     setIsDeleting(true);
     try {
       await api.post("/bmn/assets/bulk-force-delete", { ids: Array.from(selectedIds) });
@@ -104,7 +108,9 @@ export default function BmnDisposalPage() {
           <h1 className="text-2xl font-bold text-zinc-900 dark:text-white flex items-center gap-2">
             <Trash2 className="w-6 h-6 text-red-500" /> Aset Dihapus
           </h1>
-          <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-0.5">Daftar aset yang telah di-dispose. Bisa di-restore atau dihapus permanen.</p>
+          <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-0.5">
+            Daftar aset yang telah di-dispose{canWrite ? ". Bisa di-restore atau dihapus permanen." : "."}
+          </p>
         </div>
         <div className="relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-400" />
@@ -118,7 +124,7 @@ export default function BmnDisposalPage() {
       </div>
 
       {/* Bulk Actions */}
-      {selectedIds.size > 0 && (
+      {canWrite && selectedIds.size > 0 && (
         <div className="flex items-center gap-3 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl px-4 py-3">
           <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">{selectedIds.size} aset dipilih</span>
           <Button
@@ -171,12 +177,14 @@ export default function BmnDisposalPage() {
           <table className="w-full text-left">
             <thead>
               <tr className="border-b border-zinc-100 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50">
-                <th className="px-4 py-3 w-10">
-                  <Checkbox
-                    checked={assets.length > 0 && selectedIds.size === assets.length}
-                    onCheckedChange={toggleAll}
-                  />
-                </th>
+                {canWrite && (
+                  <th className="px-4 py-3 w-10">
+                    <Checkbox
+                      checked={assets.length > 0 && selectedIds.size === assets.length}
+                      onCheckedChange={toggleAll}
+                    />
+                  </th>
+                )}
                 <th className="px-4 py-3 text-[10px] font-bold text-zinc-500 dark:text-zinc-400 uppercase">Tgl Penghapusan</th>
                 <th className="px-4 py-3 text-[10px] font-bold text-zinc-500 dark:text-zinc-400 uppercase">Identitas BMN</th>
                 <th className="px-4 py-3 text-[10px] font-bold text-slate-500 uppercase text-right">Nilai</th>
@@ -184,9 +192,9 @@ export default function BmnDisposalPage() {
             </thead>
             <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800/50">
               {isLoading ? (
-                <tr><td colSpan={4} className="p-12 text-center"><Loader2 className="w-6 h-6 animate-spin text-red-500 mx-auto mb-2" /><p className="text-sm text-zinc-400">Memuat...</p></td></tr>
+                <tr><td colSpan={canWrite ? 4 : 3} className="p-12 text-center"><Loader2 className="w-6 h-6 animate-spin text-red-500 mx-auto mb-2" /><p className="text-sm text-zinc-400">Memuat...</p></td></tr>
               ) : assets.length === 0 ? (
-                <tr><td colSpan={4} className="p-12 text-center"><Package className="w-10 h-10 mx-auto mb-2 text-zinc-300 dark:text-zinc-700" /><p className="text-sm text-zinc-400">Tidak ada aset yang dihapus.</p></td></tr>
+                <tr><td colSpan={canWrite ? 4 : 3} className="p-12 text-center"><Package className="w-10 h-10 mx-auto mb-2 text-zinc-300 dark:text-zinc-700" /><p className="text-sm text-zinc-400">Tidak ada aset yang dihapus.</p></td></tr>
               ) : (
                 assets.map((asset) => (
                   <tr
@@ -196,12 +204,14 @@ export default function BmnDisposalPage() {
                       selectedIds.has(asset.id) && "bg-red-50/30 dark:bg-red-500/5"
                     )}
                   >
-                    <td className="px-4 py-3">
-                      <Checkbox
-                        checked={selectedIds.has(asset.id)}
-                        onCheckedChange={() => toggleSelect(asset.id)}
-                      />
-                    </td>
+                    {canWrite && (
+                      <td className="px-4 py-3">
+                        <Checkbox
+                          checked={selectedIds.has(asset.id)}
+                          onCheckedChange={() => toggleSelect(asset.id)}
+                        />
+                      </td>
+                    )}
                     <td className="px-4 py-3">
                       <p className="text-xs font-semibold text-zinc-800 dark:text-zinc-200">{asset.deleted_at ? new Date(asset.deleted_at).toLocaleDateString("id-ID", { day: "numeric", month: "short", year: "numeric" }) : "—"}</p>
                     </td>

--- a/frontend/src/app/bmn/import-review/[batchId]/page.tsx
+++ b/frontend/src/app/bmn/import-review/[batchId]/page.tsx
@@ -19,11 +19,13 @@ import {
   FileSpreadsheet,
   Search,
   X,
+  ShieldAlert,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import React from "react";
+import { useRole } from "@/hooks/useRole";
 
 interface ChangedField {
   old: string | number | null;
@@ -116,6 +118,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
   const { batchId } = React.use(params);
   const queryClient = useQueryClient();
   const router = useRouter();
+  const { canWrite } = useRole();
   const [filter, setFilter] = useState<"all" | "new" | "updated" | "unchanged">("all");
   const [page, setPage] = useState(1);
   const [identityFilters, setIdentityFilters] = useState({
@@ -164,6 +167,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
   };
 
   const handleToggleRow = async (rowId: string, selected: boolean) => {
+    if (!canWrite) return;
     try {
       await api.post("/bmn/import-review/toggle-selection", {
         ids: [rowId],
@@ -176,6 +180,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
   };
 
   const handleToggleField = async (rowId: string, field: string, selected: boolean) => {
+    if (!canWrite) return;
     const actionKey = `${rowId}:${field}`;
     setFieldAction(actionKey);
     try {
@@ -200,6 +205,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
     );
 
   const handleBulkSelection = async (action: "select_changed" | "clear_changed" | "select_new_only") => {
+    if (!canWrite) return;
     setBulkAction(action);
     try {
       const res = await api.post("/bmn/import-review/bulk-selection", {
@@ -217,6 +223,10 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
   };
 
   const handleApprove = async () => {
+    if (!canWrite) {
+      toast.error("Approve import hanya tersedia untuk admin.");
+      return;
+    }
     setIsApproving(true);
     try {
       const res = await api.post(`/bmn/import-review/${batchId}/approve`, {}, { timeout: 120000 });
@@ -234,6 +244,10 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
   };
 
   const handleReject = async () => {
+    if (!canWrite) {
+      toast.error("Tolak import hanya tersedia untuk admin.");
+      return;
+    }
     setIsRejecting(true);
     try {
       await api.post(`/bmn/import-review/${batchId}/reject`);
@@ -283,7 +297,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
           </div>
         </div>
 
-        {isPending && (
+        {canWrite && isPending && (
           <div className="flex items-center gap-2">
             <Button
               onClick={handleReject}
@@ -308,6 +322,17 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
           </div>
         )}
       </div>
+
+      {!canWrite && isPending && (
+        <div className="rounded-xl border border-amber-200 bg-amber-50/70 px-4 py-3 text-sm text-amber-800">
+          <div className="flex items-start gap-2">
+            <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>
+              Batch ini masih menunggu review. Kamu bisa melihat detail perubahan, tetapi approval dan pengaturan seleksi hanya tersedia untuk admin.
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Summary Cards */}
       <div className="grid grid-cols-4 gap-4">
@@ -406,7 +431,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
       </div>
 
       {/* Selection Toolbar */}
-      {isPending && (filteredNewTotal > 0 || selectionSummary.filtered_updated > 0) && (
+      {canWrite && isPending && (filteredNewTotal > 0 || selectionSummary.filtered_updated > 0) && (
         <div className="flex flex-col gap-3 bg-white border border-slate-200 rounded-xl px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
           <span className="text-sm text-slate-600">
             Dipilih: <strong>{selectionSummary.selected_new}</strong> baru, <strong>{selectionSummary.selected_updated}</strong> update
@@ -442,7 +467,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
           <table className="w-full text-sm">
             <thead className="bg-slate-50 border-b border-slate-200">
               <tr>
-                {isPending && (
+                {canWrite && isPending && (
                   <th className="px-4 py-3 w-10">
                     <Checkbox
                       checked={(() => {
@@ -470,7 +495,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
             <tbody className="divide-y divide-slate-100">
               {rows.length === 0 ? (
                 <tr>
-                  <td colSpan={isPending ? 6 : 5} className="px-4 py-12 text-center text-slate-400">
+                  <td colSpan={canWrite && isPending ? 6 : 5} className="px-4 py-12 text-center text-slate-400">
                     Tidak ada data untuk filter ini.
                   </td>
                 </tr>
@@ -489,7 +514,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
                         isSelectableRow && !isSelected && "opacity-60"
                       )}
                     >
-                    {isPending && (
+                    {canWrite && isPending && (
                       <td className="px-4 py-3">
                         {isSelectableRow && (
                           <Checkbox
@@ -522,7 +547,7 @@ export default function ImportReviewDetailPage({ params }: { params: Promise<{ b
                         <DiffFields
                           fields={row.changed_fields}
                           rowId={row.id}
-                          isPending={isPending}
+                          isPending={canWrite && isPending}
                           fieldAction={fieldAction}
                           onToggleField={handleToggleField}
                         />

--- a/frontend/src/app/bmn/import-review/page.tsx
+++ b/frontend/src/app/bmn/import-review/page.tsx
@@ -15,9 +15,11 @@ import {
   XCircle,
   Clock,
   Eye,
+  ShieldAlert,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
+import { useRole } from "@/hooks/useRole";
 
 interface ImportBatch {
   id: string;
@@ -33,6 +35,7 @@ interface ImportBatch {
 
 export default function ImportReviewPage() {
   const queryClient = useQueryClient();
+  const { canWrite } = useRole();
   const [file, setFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
 
@@ -47,6 +50,10 @@ export default function ImportReviewPage() {
   const batches: ImportBatch[] = data?.data || [];
 
   const handleUpload = async () => {
+    if (!canWrite) {
+      toast.error("Upload import hanya tersedia untuk admin.");
+      return;
+    }
     if (!file) return;
     setIsUploading(true);
     const formData = new FormData();
@@ -91,7 +98,7 @@ export default function ImportReviewPage() {
         </p>
       </div>
 
-      {/* Upload Section */}
+      {canWrite ? (
       <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6">
         <h2 className="text-base font-semibold text-zinc-800 dark:text-zinc-200 mb-4 flex items-center gap-2">
           <Upload className="w-4 h-4 text-emerald-600" />
@@ -122,6 +129,19 @@ export default function ImportReviewPage() {
           </Button>
         </div>
       </div>
+      ) : (
+        <div className="rounded-2xl border border-amber-200 bg-amber-50/70 p-5 text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+          <div className="flex items-start gap-3">
+            <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0" />
+            <div>
+              <h2 className="text-sm font-bold">Upload import hanya untuk admin</h2>
+              <p className="mt-1 text-xs leading-relaxed">
+                Kamu tetap bisa melihat riwayat import dan hasil review, tetapi perubahan data BMN hanya bisa diunggah dan disetujui oleh admin.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Batch History */}
       <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6">
@@ -180,7 +200,7 @@ export default function ImportReviewPage() {
                   {batch.status === "pending" && (
                     <Link href={`/bmn/import-review/${batch.id}`}>
                       <Button size="sm" className="bg-emerald-600 hover:bg-emerald-700 text-white">
-                        <Eye className="w-3.5 h-3.5 mr-1" /> Review
+                        <Eye className="w-3.5 h-3.5 mr-1" /> {canWrite ? "Review" : "Lihat"}
                       </Button>
                     </Link>
                   )}

--- a/frontend/src/app/bmn/reports/page.tsx
+++ b/frontend/src/app/bmn/reports/page.tsx
@@ -24,6 +24,7 @@ import {
   type HandoverVariant,
   type HandoverWitness,
 } from "./_components/HandoverAgreementDocument";
+import { useRole } from "@/hooks/useRole";
 
 interface EmployeeOption {
   id: number;
@@ -139,6 +140,7 @@ const DEFAULT_HANDOVER_FIRST_PARTY: HandoverParty = {
 
 export default function BmnReportsPage() {
   const confirm = useConfirm();
+  const { canWrite } = useRole();
   const [loadingAsset, setLoadingAsset] = useState(false);
   const [loadingLoan, setLoadingLoan] = useState(false);
   const [loadingMaintenance, setLoadingMaintenance] = useState(false);
@@ -900,16 +902,18 @@ export default function BmnReportsPage() {
                                     <FileText className="mr-1 h-3.5 w-3.5" />
                                     Duplikasi
                                   </Button>
-                                  <Button
-                                    type="button"
-                                    variant="outline"
-                                    size="sm"
-                                    className="h-8 rounded-lg border-rose-200 px-2 text-xs text-rose-600 hover:bg-rose-50"
-                                    onClick={() => deleteHistoryAgreement(item)}
-                                  >
-                                    <Trash2 className="mr-1 h-3.5 w-3.5" />
-                                    Hapus
-                                  </Button>
+                                  {canWrite && (
+                                    <Button
+                                      type="button"
+                                      variant="outline"
+                                      size="sm"
+                                      className="h-8 rounded-lg border-rose-200 px-2 text-xs text-rose-600 hover:bg-rose-50"
+                                      onClick={() => deleteHistoryAgreement(item)}
+                                    >
+                                      <Trash2 className="mr-1 h-3.5 w-3.5" />
+                                      Hapus
+                                    </Button>
+                                  )}
                                 </div>
                               </td>
                             </tr>
@@ -1547,16 +1551,18 @@ export default function BmnReportsPage() {
                             <FileText className="mr-1 h-3.5 w-3.5" />
                             Duplikasi
                           </Button>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            className="h-8 rounded-lg border-rose-200 px-2 text-xs text-rose-600 hover:bg-rose-50"
-                            onClick={() => isUsageHistoryItem(item) ? deleteHistoryAgreement(item) : deleteHandoverHistoryAgreement(item)}
-                          >
-                            <Trash2 className="mr-1 h-3.5 w-3.5" />
-                            Hapus
-                          </Button>
+                          {canWrite && (
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              className="h-8 rounded-lg border-rose-200 px-2 text-xs text-rose-600 hover:bg-rose-50"
+                              onClick={() => isUsageHistoryItem(item) ? deleteHistoryAgreement(item) : deleteHandoverHistoryAgreement(item)}
+                            >
+                              <Trash2 className="mr-1 h-3.5 w-3.5" />
+                              Hapus
+                            </Button>
+                          )}
                         </div>
                       </td>
                     </tr>


### PR DESCRIPTION
## Summary
- hide BMN destructive/admin-only actions from non-admin users in disposal, import review, and report history screens
- keep import review detail readable while reserving approval and selection controls for admin/super_admin
- update progress.md with Phase 82 validation notes

## Validation
- npm run lint
- npm run build
- browser validation with local superadmin on /bmn/reports, /bmn/import-review, and /bmn/disposal