### PR TITLE
security: harden file upload validation

### DIFF
--- a/backend/app/Http/Controllers/Api/AuthController.php
+++ b/backend/app/Http/Controllers/Api/AuthController.php
@@ -9,6 +9,7 @@ use App\Http\Resources\UserResource;
 use App\Models\User;
 use App\Modules\Bmn\Models\AssetLoan;
 use App\Modules\Kepegawaian\Models\Employee;
+use App\Support\Security\UploadValidationRules;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
@@ -169,7 +170,7 @@ class AuthController extends Controller
     public function updatePhoto(Request $request): JsonResponse
     {
         $request->validate([
-            'foto' => 'required|image|mimes:jpg,jpeg,png,webp|max:10240',
+            'foto' => UploadValidationRules::image(maxKilobytes: 10240),
         ]);
 
         $user = $request->user();

--- a/backend/app/Modules/Bmn/Controllers/AssetController.php
+++ b/backend/app/Modules/Bmn/Controllers/AssetController.php
@@ -12,9 +12,11 @@ use App\Modules\Bmn\Requests\StoreAssetRequest;
 use App\Modules\Bmn\Requests\UpdateAssetRequest;
 use App\Modules\Bmn\Resources\AssetResource;
 use App\Modules\Bmn\Services\AssetService;
+use App\Support\Security\UploadValidationRules;
 use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Maatwebsite\Excel\Facades\Excel;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
@@ -232,7 +234,7 @@ class AssetController extends Controller
     public function import(Request $request): JsonResponse
     {
         $request->validate([
-            'file' => 'required|mimes:xlsx,xls,csv|max:20480',
+            'file' => UploadValidationRules::spreadsheet(),
         ]);
 
         try {
@@ -244,7 +246,13 @@ class AssetController extends Controller
                 'count' => $import->getImportedCount(),
             ]);
         } catch (Exception $e) {
-            return response()->json(['error' => 'Gagal mengimpor data: '.$e->getMessage()], 422);
+            Log::warning('BMN direct asset import failed.', [
+                'user_id' => $request->user()?->id,
+                'filename' => $request->file('file')?->getClientOriginalName(),
+                'error' => $e->getMessage(),
+            ]);
+
+            return response()->json(['error' => 'Gagal mengimpor data. Pastikan format dan isi template sudah sesuai.'], 422);
         }
     }
 }

--- a/backend/app/Modules/Bmn/Controllers/AssetPhotoController.php
+++ b/backend/app/Modules/Bmn/Controllers/AssetPhotoController.php
@@ -5,6 +5,7 @@ namespace App\Modules\Bmn\Controllers;
 use App\Http\Controllers\Controller;
 use App\Modules\Bmn\Models\Asset;
 use App\Modules\Bmn\Models\AssetUpdate;
+use App\Support\Security\UploadValidationRules;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
@@ -27,7 +28,7 @@ class AssetPhotoController extends Controller
     public function upload(Request $request, string $assetId): JsonResponse
     {
         $request->validate([
-            'photo' => 'required|image|mimes:jpg,jpeg,png,webp|max:5120',
+            'photo' => UploadValidationRules::image(),
             'type' => 'required|in:' . implode(',', self::VALID_TYPES),
         ]);
 
@@ -71,7 +72,7 @@ class AssetPhotoController extends Controller
     public function updateGeotag(Request $request, string $assetId): JsonResponse
     {
         $request->validate([
-            'photo' => 'nullable|image|mimes:jpg,jpeg,png,webp|max:5120',
+            'photo' => UploadValidationRules::image(required: false),
             'url' => 'nullable|url',
         ]);
 

--- a/backend/app/Modules/Bmn/Controllers/ImportReviewController.php
+++ b/backend/app/Modules/Bmn/Controllers/ImportReviewController.php
@@ -8,10 +8,12 @@ use App\Modules\Bmn\Models\Asset;
 use App\Modules\Bmn\Models\AssetUpdate;
 use App\Modules\Bmn\Models\ImportBatch;
 use App\Modules\Bmn\Models\ImportStaging;
+use App\Support\Security\UploadValidationRules;
 use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Maatwebsite\Excel\Facades\Excel;
 
@@ -23,7 +25,7 @@ class ImportReviewController extends Controller
     public function upload(Request $request): JsonResponse
     {
         $request->validate([
-            'file' => 'required|mimes:xlsx,xls,csv|max:20480',
+            'file' => UploadValidationRules::spreadsheet(),
         ]);
 
         try {
@@ -60,7 +62,13 @@ class ImportReviewController extends Controller
                 ],
             ]);
         } catch (Exception $e) {
-            return response()->json(['error' => 'Gagal memproses file: ' . $e->getMessage()], 422);
+            Log::warning('BMN import review upload failed.', [
+                'user_id' => $request->user()?->id,
+                'filename' => $request->file('file')?->getClientOriginalName(),
+                'error' => $e->getMessage(),
+            ]);
+
+            return response()->json(['error' => 'Gagal memproses file. Pastikan format dan isi template sudah sesuai.'], 422);
         }
     }
 
@@ -92,7 +100,7 @@ class ImportReviewController extends Controller
         ];
 
         // Paginate
-        $perPage = $request->integer('per_page', 50);
+        $perPage = max(1, min($request->integer('per_page', 50), 200));
         $rows = $query->orderByRaw("CASE diff_status WHEN 'new' THEN 1 WHEN 'updated' THEN 2 WHEN 'unchanged' THEN 3 END")
             ->paginate($perPage);
 

--- a/backend/app/Modules/CMS/Controllers/Admin/InformasiController.php
+++ b/backend/app/Modules/CMS/Controllers/Admin/InformasiController.php
@@ -5,6 +5,7 @@ namespace App\Modules\CMS\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Modules\CMS\Models\Informasi;
 use App\Modules\CMS\Traits\AdminCrudTrait;
+use App\Support\Security\UploadValidationRules;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 
@@ -39,7 +40,7 @@ class InformasiController extends Controller
         $request->validate([
             'judul' => 'required|string|max:500',
             'konten' => 'required|string',
-            'thumbnail' => 'nullable|file|max:5120|mimes:jpg,jpeg,png,webp',
+            'thumbnail' => UploadValidationRules::image(required: false),
         ]);
 
         $data = $request->only((new Informasi)->getFillable());

--- a/backend/app/Modules/CMS/Traits/AdminCrudTrait.php
+++ b/backend/app/Modules/CMS/Traits/AdminCrudTrait.php
@@ -114,6 +114,8 @@ trait AdminCrudTrait
      */
     protected function handleFileUpload(Request $request, array $data): array
     {
+        $this->validateCmsUploads($request);
+
         $fileFields = [
             'thumbnail' => 'thumbnail_path',
             'file' => 'file_path',
@@ -133,5 +135,28 @@ trait AdminCrudTrait
         }
 
         return $data;
+    }
+
+    protected function validateCmsUploads(Request $request): void
+    {
+        $rules = [
+            'thumbnail' => 'nullable|image|mimes:jpg,jpeg,png,webp|extensions:jpg,jpeg,png,webp|max:5120',
+            'foto' => 'nullable|image|mimes:jpg,jpeg,png,webp|extensions:jpg,jpeg,png,webp|max:5120',
+            'cover' => 'nullable|image|mimes:jpg,jpeg,png,webp|extensions:jpg,jpeg,png,webp|max:5120',
+            'logo' => 'nullable|file|mimes:jpg,jpeg,png,webp,svg|extensions:jpg,jpeg,png,webp,svg|max:5120',
+            'favicon' => 'nullable|file|mimes:jpg,jpeg,png,webp,svg,ico|extensions:jpg,jpeg,png,webp,svg,ico|max:1024',
+            'file' => 'nullable|file|mimes:pdf,doc,docx,xls,xlsx,ppt,pptx,jpg,jpeg,png,webp|extensions:pdf,doc,docx,xls,xlsx,ppt,pptx,jpg,jpeg,png,webp|max:10240',
+        ];
+
+        $activeRules = [];
+        foreach (array_keys($rules) as $field) {
+            if ($request->hasFile($field)) {
+                $activeRules[$field] = $rules[$field];
+            }
+        }
+
+        if ($activeRules !== []) {
+            $request->validate($activeRules);
+        }
     }
 }

--- a/backend/app/Modules/DeReporting/Requests/StoreEksternalRequest.php
+++ b/backend/app/Modules/DeReporting/Requests/StoreEksternalRequest.php
@@ -23,7 +23,7 @@ class StoreEksternalRequest extends FormRequest
             'deskripsi' => ['nullable', 'string'],
 
             // Masyarakat boleh mengirimkan bukti Foto (jpg, png, jpeg)
-            'file' => ['required', 'file', 'max:10240', 'mimes:pdf,doc,docx,xls,xlsx,zip,rar,jpg,png,jpeg'],
+            'file' => ['required', 'file', 'max:10240', 'mimes:pdf,doc,docx,xls,xlsx,zip,rar,jpg,png,jpeg', 'extensions:pdf,doc,docx,xls,xlsx,zip,rar,jpg,png,jpeg'],
         ];
     }
 

--- a/backend/app/Modules/DeReporting/Requests/StoreInternalRequest.php
+++ b/backend/app/Modules/DeReporting/Requests/StoreInternalRequest.php
@@ -36,7 +36,7 @@ class StoreInternalRequest extends FormRequest
 
             // Proteksi Inti Berkas (Project Rule 4.1 & 4.2)
             // Maksimal 10240 KB = 10 MB
-            'file' => ['required', 'file', 'max:10240', 'mimes:pdf,doc,docx,xls,xlsx,zip,rar'],
+            'file' => ['required', 'file', 'max:10240', 'mimes:pdf,doc,docx,xls,xlsx,zip,rar', 'extensions:pdf,doc,docx,xls,xlsx,zip,rar'],
         ];
     }
 

--- a/backend/app/Modules/Inventory/Controllers/ItemController.php
+++ b/backend/app/Modules/Inventory/Controllers/ItemController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Modules\Inventory\Imports\ItemImport;
 use App\Modules\Inventory\Models\Item;
 use App\Modules\Inventory\Requests\StoreItemRequest;
+use App\Support\Security\UploadValidationRules;
 use Illuminate\Http\Request;
 use Maatwebsite\Excel\Facades\Excel;
 
@@ -33,7 +34,7 @@ class ItemController extends Controller
     public function import(Request $request): \Illuminate\Http\JsonResponse
     {
         $request->validate([
-            'file' => 'required|mimes:xlsx,xls,csv',
+            'file' => UploadValidationRules::spreadsheet(),
         ]);
 
         Excel::import(new ItemImport, $request->file('file'));

--- a/backend/app/Modules/Kepegawaian/Controllers/EmployeeController.php
+++ b/backend/app/Modules/Kepegawaian/Controllers/EmployeeController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Modules\Kepegawaian\Models\Employee;
 use App\Modules\Kepegawaian\Requests\EmployeeRequest;
+use App\Support\Security\UploadValidationRules;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
@@ -156,7 +157,7 @@ class EmployeeController extends Controller
     public function updatePhoto(Request $request, $id): JsonResponse
     {
         $request->validate([
-            'foto' => 'required|image|mimes:jpg,jpeg,png,webp|max:10240',
+            'foto' => UploadValidationRules::image(maxKilobytes: 10240),
         ]);
 
         $employee = Employee::findOrFail($id);

--- a/backend/app/Modules/Kepegawaian/Requests/EmployeeRequest.php
+++ b/backend/app/Modules/Kepegawaian/Requests/EmployeeRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Modules\Kepegawaian\Requests;
 
+use App\Support\Security\UploadValidationRules;
 use Illuminate\Foundation\Http\FormRequest;
 
 class EmployeeRequest extends FormRequest
@@ -32,8 +33,8 @@ class EmployeeRequest extends FormRequest
             'satuan_kerja' => 'nullable|string|max:255',
             'is_active' => 'boolean',
 
-            // Aturan File (MIME types strict) - Hanya gambar
-            'foto' => 'nullable|file|mimes:jpg,jpeg,png,webp|max:10240',
+            // Aturan File (MIME + ekstensi strict) - Hanya gambar
+            'foto' => UploadValidationRules::image(required: false, maxKilobytes: 10240),
         ];
     }
 

--- a/backend/app/Modules/SuratTugas/Requests/AssignmentLetterRequest.php
+++ b/backend/app/Modules/SuratTugas/Requests/AssignmentLetterRequest.php
@@ -43,7 +43,7 @@ class AssignmentLetterRequest extends FormRequest
         ];
 
         if ($this->isMethod('post') || $this->hasFile('file_surat')) {
-            $rules['file_surat'] = 'nullable|file|mimes:pdf,jpg,jpeg,png,webp|max:10240';
+            $rules['file_surat'] = 'nullable|file|mimes:pdf,jpg,jpeg,png,webp|extensions:pdf,jpg,jpeg,png,webp|max:10240';
         }
 
         return $rules;

--- a/backend/app/Modules/SuratTugas/Requests/PublicSuratTugasRequest.php
+++ b/backend/app/Modules/SuratTugas/Requests/PublicSuratTugasRequest.php
@@ -21,7 +21,7 @@ class PublicSuratTugasRequest extends FormRequest
             'employee_ids' => 'required|array|min:1',
             'employee_ids.*' => 'required|uuid|exists:kpg_employees,id',
             'sumber_dana' => 'required|string|max:100',
-            'dasar_surat' => 'nullable|file|mimes:pdf,jpg,jpeg,png|max:10240',
+            'dasar_surat' => 'nullable|file|mimes:pdf,jpg,jpeg,png|extensions:pdf,jpg,jpeg,png|max:10240',
         ];
     }
 

--- a/backend/app/Support/Security/UploadValidationRules.php
+++ b/backend/app/Support/Security/UploadValidationRules.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Support\Security;
+
+final class UploadValidationRules
+{
+    /**
+     * Validation rules for spreadsheet imports.
+     *
+     * Laravel's mimes rule validates detected MIME type. The extensions rule
+     * adds a visible filename extension whitelist so disguised uploads fail
+     * before being parsed by PhpSpreadsheet.
+     */
+    public static function spreadsheet(int $maxKilobytes = 20480): array
+    {
+        return [
+            'required',
+            'file',
+            'mimes:xlsx,xls,csv',
+            'extensions:xlsx,xls,csv',
+            "max:{$maxKilobytes}",
+        ];
+    }
+
+    public static function image(bool $required = true, int $maxKilobytes = 5120): array
+    {
+        return [
+            $required ? 'required' : 'nullable',
+            'image',
+            'mimes:jpg,jpeg,png,webp',
+            'extensions:jpg,jpeg,png,webp',
+            "max:{$maxKilobytes}",
+        ];
+    }
+}

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,13 +1,60 @@
+# Progress - Phase 83: File Upload Validation Hardening
+
+> Document updated: 2026-06-18
+> Status: Selesai lokal, siap PR.
+
+---
+
+## Hardening Upload File dan Import
+
+### Status: SELESAI DI LOKAL
+- Scope: backend upload/import validation untuk BMN, Inventory, Kepegawaian, Surat Tugas, DE Reporting, CMS, dan profile photo.
+- Tujuan: mengurangi risiko file spoofing, upload tipe berbahaya, dan error detail dari parser import yang bocor ke user.
+
+### Implementasi
+- Menambahkan helper `UploadValidationRules` untuk rule upload yang konsisten:
+  - spreadsheet import: `xlsx`, `xls`, `csv`, MIME check, extension check, dan batas ukuran.
+  - image upload: `jpg`, `jpeg`, `png`, `webp`, MIME check, extension check, dan batas ukuran.
+- Memperketat upload/import:
+  - BMN import review.
+  - BMN direct asset import.
+  - foto aset BMN dan update geotag.
+  - Inventory item import.
+  - foto profile portal.
+  - foto pegawai.
+  - Surat Tugas attachment.
+  - DE Reporting attachment internal/eksternal.
+  - CMS thumbnail/file upload.
+- Error import spreadsheet sekarang dibuat generic untuk user, sementara detail teknis dicatat ke log backend.
+- Pagination import review dibatasi maksimal 200 item per request agar endpoint tidak mudah dipakai untuk query besar.
+
+### Validasi
+- `php -l` seluruh file backend yang diubah: pass.
+- `composer audit --no-dev`: clean.
+- `php artisan route:list --path=bmn --json`: pass.
+- `php artisan route:list --path=cms --json`: pass.
+- Browser bawaan Codex:
+  - login superadmin lokal masih aktif.
+  - `/bmn/import-review` load normal.
+  - upload import tampil untuk superadmin.
+  - tidak ada console error.
+
+### Catatan
+- Hardening ini belum mengganti storage publik ke private/signed URL. Itu tetap menjadi PR lanjutan karena butuh review dampak akses file lama.
+- File untracked lokal `frontend/public/header.png` tidak disentuh.
+
+---
+
 # Progress - Phase 82: BMN Admin-only UI Visibility
 
 > Document updated: 2026-06-18
-> Status: Implemented locally on branch `codex/bmn-admin-ui-visibility`; siap PR.
+> Status: PR #412 squash merged ke `main` (commit `e1c00e4`). Branch remote `codex/bmn-admin-ui-visibility` sudah dihapus.
 
 ---
 
 ## Sinkronisasi UI dengan Authorization Backend BMN
 
-### Status: SELESAI DI LOKAL
+### Status: SELESAI
 - Scope: frontend visibility guard untuk aksi sensitif BMN yang sudah diproteksi backend di Phase 81.
 - Tujuan: user non-admin tidak melihat tombol/aksi yang pasti ditolak backend, sementara admin/super admin tetap bisa bekerja normal.
 


### PR DESCRIPTION
## Summary
- add shared upload validation rules for spreadsheet and image uploads
- enforce filename extension allowlists alongside MIME checks across import/photo/report/CMS upload paths
- log parser failures server-side while returning generic import errors to users
- cap BMN import review pagination size
- update progress.md with Phase 83 status

## Validation
- php -l on changed backend files
- composer audit --no-dev
- php artisan route:list --path=bmn --json
- php artisan route:list --path=cms --json
- Codex browser smoke test: /bmn/import-review loads as superadmin, upload section visible, no console errors