### PR TITLE
security: add CSP report-only and harden sanitizer

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,39 @@
+# Progress - Phase 84: CSP Report-Only dan Sanitizer Hardening
+
+> Document updated: 2026-06-18
+> Status: Selesai lokal, siap PR.
+
+---
+
+## XSS Blast Radius Reduction
+
+### Status: SELESAI DI LOKAL
+- Scope: frontend security header dan sanitizer HTML publik.
+- Tujuan: mengurangi dampak XSS tanpa langsung mematahkan halaman print, preview dokumen, dan konten CMS yang masih memakai inline style.
+
+### Implementasi
+- Menambahkan `Content-Security-Policy-Report-Only` di `next.config.ts`.
+  - mode report-only dipilih sebagai langkah aman sebelum enforce karena aplikasi masih punya print preview dan style inline.
+  - directive penting: `default-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `frame-ancestors 'self'`, dan pembatasan `frame-src` YouTube.
+- Memperketat `sanitizeHtml`:
+  - SSR fallback tidak lagi mengembalikan HTML mentah.
+  - URL dibatasi ke protokol aman.
+  - iframe hasil CMS hanya diizinkan untuk embed YouTube/YouTube-nocookie.
+  - link `target="_blank"` otomatis diberi `rel="noopener noreferrer"`.
+
+### Validasi
+- `npm run lint`: pass.
+- `npm run build`: pass.
+- Browser bawaan Codex:
+  - halaman publik `/` load normal.
+  - tidak ada console error setelah perubahan sanitizer.
+
+### Catatan
+- CSP masih report-only. Setelah observasi produksi aman, PR lanjutan bisa memindahkan policy ke enforce dan memperketat `script-src`/`style-src`.
+- File untracked lokal `frontend/public/header.png` tidak disentuh.
+
+---
+
 # Progress - Phase 83: File Upload Validation Hardening
 
 > Document updated: 2026-06-18

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,21 @@
 import type { NextConfig } from "next";
 
+const contentSecurityPolicyReportOnly = [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    "frame-ancestors 'self'",
+    "form-action 'self'",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: http: https:",
+    "font-src 'self' data: https:",
+    "connect-src 'self' http://localhost:8000 http://127.0.0.1:8000 https://bksdakaltim.net https://www.bksdakaltim.net https://api.bksdakaltim.net https://storage.bksdakaltim.net https://*.supabase.co",
+    "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
+    "media-src 'self' blob: https:",
+    "worker-src 'self' blob:",
+].join("; ");
+
 const nextConfig: NextConfig = {
 
     output: "standalone",
@@ -54,6 +70,10 @@ const nextConfig: NextConfig = {
                     {
                         key: "Permissions-Policy",
                         value: "camera=(), microphone=(), geolocation=()",
+                    },
+                    {
+                        key: "Content-Security-Policy-Report-Only",
+                        value: contentSecurityPolicyReportOnly,
                     },
                 ],
             },

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -16,21 +16,46 @@ export const formatDate = (date: string | null | undefined, format = "D MMM YYYY
 }
 
 export function sanitizeHtml(html: string): string {
-    if (!html) return '';
-    const processedHtml = html.replace(/&nbsp;/g, ' ');
+    if (!html) return "";
+    const processedHtml = html.replace(/&nbsp;/g, " ");
 
-    if (typeof window === 'undefined') return processedHtml; // SSR fallback
-    return DOMPurify.sanitize(processedHtml, {
+    if (typeof window === "undefined") return "";
+
+    const sanitizedHtml = DOMPurify.sanitize(processedHtml, {
         ALLOWED_TAGS: [
-            'p', 'br', 'b', 'i', 'em', 'strong', 'u', 's', 'a', 'ul', 'ol', 'li',
-            'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre', 'code',
-            'img', 'figure', 'figcaption', 'table', 'thead', 'tbody', 'tr', 'th', 'td',
-            'div', 'span', 'hr', 'sub', 'sup', 'iframe',
+            "p", "br", "b", "i", "em", "strong", "u", "s", "a", "ul", "ol", "li",
+            "h1", "h2", "h3", "h4", "h5", "h6", "blockquote", "pre", "code",
+            "img", "figure", "figcaption", "table", "thead", "tbody", "tr", "th", "td",
+            "div", "span", "hr", "sub", "sup", "iframe",
         ],
         ALLOWED_ATTR: [
-            'href', 'target', 'rel', 'src', 'alt', 'title', 'class', 'style',
-            'width', 'height', 'id', 'colspan', 'rowspan',
-            'allow', 'allowfullscreen', 'frameborder',
+            "href", "target", "rel", "src", "alt", "title", "class", "style",
+            "width", "height", "id", "colspan", "rowspan",
+            "allow", "allowfullscreen", "frameborder",
         ],
+        ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|tel):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+        ADD_ATTR: ["loading", "referrerpolicy"],
     });
+
+    const template = document.createElement("template");
+    template.innerHTML = sanitizedHtml;
+
+    template.content.querySelectorAll("iframe").forEach((iframe) => {
+        const src = iframe.getAttribute("src") || "";
+        const isAllowedVideo = /^https:\/\/(www\.)?(youtube\.com|youtube-nocookie\.com)\/embed\//i.test(src);
+
+        if (!isAllowedVideo) {
+            iframe.remove();
+            return;
+        }
+
+        iframe.setAttribute("loading", "lazy");
+        iframe.setAttribute("referrerpolicy", "strict-origin-when-cross-origin");
+    });
+
+    template.content.querySelectorAll("a[target=\"_blank\"]").forEach((link) => {
+        link.setAttribute("rel", "noopener noreferrer");
+    });
+
+    return template.innerHTML;
 }


### PR DESCRIPTION
## Summary
- add Content-Security-Policy-Report-Only header in Next config
- harden sanitizeHtml SSR fallback so raw HTML is not returned server-side
- restrict sanitized iframes to YouTube embeds and add safer link attributes
- update progress.md with Phase 84

## Validation
- npm run lint
- npm run build
- Codex browser smoke test: public homepage loads without console errors