### PR TITLE
security: sanitize audit log payloads

### DIFF
--- a/backend/app/Http/Middleware/AuditLogMiddleware.php
+++ b/backend/app/Http/Middleware/AuditLogMiddleware.php
@@ -5,10 +5,27 @@ namespace App\Http\Middleware;
 use App\Models\AuditLog;
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Symfony\Component\HttpFoundation\Response;
 
 class AuditLogMiddleware
 {
+    private const MAX_STRING_LENGTH = 1000;
+    private const MAX_ARRAY_ITEMS = 50;
+
+    private const SENSITIVE_KEYS = [
+        'password',
+        'password_confirmation',
+        'current_password',
+        'new_password',
+        'token',
+        'access_token',
+        'refresh_token',
+        'authorization',
+        'api_key',
+        'secret',
+    ];
+
     /**
      * Handle an incoming request.
      */
@@ -25,14 +42,8 @@ class AuditLogMiddleware
         }
 
         // 3. Sensor Data Sensitif (Best Practice Security)
-        // Kita tidak mau password user terekam secara plain-text di tabel logs
-        $payload = $request->except([
-            'password',
-            'password_confirmation',
-            'current_password',
-            'new_password',
-            'token',
-        ]);
+        // Kita tidak mau password, token, atau isi file terekam secara mentah di tabel logs.
+        $payload = $this->sanitizePayload($request->all());
 
         // 4. Catat aktivitas ke database menggunakan Eloquent
         AuditLog::create([
@@ -46,5 +57,65 @@ class AuditLogMiddleware
 
         // 5. Kembalikan response ke pengguna
         return $response;
+    }
+
+    /**
+     * Keep audit logs useful without storing secrets, raw files, or huge payloads.
+     */
+    private function sanitizePayload(mixed $value): mixed
+    {
+        if ($value instanceof UploadedFile) {
+            return [
+                '_type' => 'uploaded_file',
+                'name' => $value->getClientOriginalName(),
+                'mime' => $value->getClientMimeType(),
+                'extension' => $value->getClientOriginalExtension(),
+                'size' => $value->getSize(),
+            ];
+        }
+
+        if (is_array($value)) {
+            $sanitized = [];
+            $index = 0;
+
+            foreach ($value as $key => $item) {
+                if ($index >= self::MAX_ARRAY_ITEMS) {
+                    $sanitized['_truncated'] = true;
+                    break;
+                }
+
+                $normalizedKey = strtolower((string) $key);
+                if ($this->isSensitiveKey($normalizedKey)) {
+                    $sanitized[$key] = '[redacted]';
+                } else {
+                    $sanitized[$key] = $this->sanitizePayload($item);
+                }
+
+                $index++;
+            }
+
+            return $sanitized;
+        }
+
+        if (is_string($value) && strlen($value) > self::MAX_STRING_LENGTH) {
+            return substr($value, 0, self::MAX_STRING_LENGTH).'...[truncated]';
+        }
+
+        if (is_scalar($value) || $value === null) {
+            return $value;
+        }
+
+        return '['.get_debug_type($value).']';
+    }
+
+    private function isSensitiveKey(string $key): bool
+    {
+        foreach (self::SENSITIVE_KEYS as $sensitiveKey) {
+            if (str_contains($key, $sensitiveKey)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,46 @@
+# Progress - Phase 85: Audit Log Payload Sanitizer
+
+> Document updated: 2026-06-18
+> Status: Selesai lokal, siap PR.
+
+---
+
+## Security Observability Hardening
+
+### Status: SELESAI DI LOKAL
+- Scope: middleware audit log global API.
+- Tujuan: audit log tetap mencatat aksi write API, tetapi tidak menyimpan secret, token nested, raw upload file, atau payload besar secara mentah.
+
+### Implementasi
+- Menambahkan sanitizer payload di `AuditLogMiddleware`.
+- Secret key sensitif sekarang dimasking rekursif, termasuk:
+  - password/current password/new password.
+  - token/access token/refresh token.
+  - authorization/api key/secret.
+- File upload tidak disimpan sebagai object/raw payload, tetapi diringkas menjadi metadata:
+  - nama file.
+  - MIME.
+  - extension.
+  - ukuran file.
+- String panjang dipotong agar audit log tidak membengkak.
+- Array besar dibatasi jumlah itemnya dan diberi flag `_truncated`.
+
+### Validasi
+- `php -l backend/app/Http/Middleware/AuditLogMiddleware.php`: pass.
+- `php artisan route:list --path=api/login --json`: pass.
+- Script PHP ad hoc untuk sanitizer payload: pass (password/token nested ter-redact, file menjadi metadata, string panjang terpotong).
+- Browser bawaan Codex:
+  - `/bmn/import-review` load normal sebagai superadmin.
+  - upload import tampil.
+  - tidak ada console error.
+- `php artisan test`: masih gagal di test bawaan `Tests\Feature\ExampleTest::test_the_application_returns_a_successful_response` karena route `/` backend mengembalikan 404, tidak terkait perubahan audit middleware.
+
+### Catatan
+- Audit middleware sudah global untuk API write method, jadi perubahan ini langsung melindungi log dari banyak endpoint sekaligus.
+- File untracked lokal `frontend/public/header.png` tidak disentuh.
+
+---
+
 # Progress - Phase 84: CSP Report-Only dan Sanitizer Hardening
 
 > Document updated: 2026-06-18


### PR DESCRIPTION
## Summary
- recursively redact sensitive keys in audit payloads
- store upload files as metadata instead of raw objects
- truncate long strings and large arrays to keep audit logs bounded
- update progress.md with Phase 85

## Validation
- php -l backend/app/Http/Middleware/AuditLogMiddleware.php
- php artisan route:list --path=api/login --json
- ad hoc PHP sanitizer check: redaction/file metadata/truncation pass
- Codex browser smoke test: /bmn/import-review loads as superadmin, upload visible, no console errors

## Notes
- php artisan test still fails on the existing ExampleTest because backend / returns 404; this is unrelated to the audit middleware change.