### PR TITLE
security: mitigate frontend dependency advisories

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,40 @@
+# Progress - Phase 86: Frontend Dependency Mitigation
+
+> Document updated: 2026-06-18
+> Status: Selesai lokal, siap PR.
+
+---
+
+## PostCSS Override dan Quill Content Sanitization
+
+### Status: SELESAI DI LOKAL
+- Scope: frontend dependency audit dan CMS rich text editor.
+- Tujuan: menutup vulnerability moderate yang masih tersisa dan menurunkan risiko XSS dari output HTML editor.
+
+### Implementasi
+- Menambahkan `overrides.postcss` ke `package.json` agar PostCSS nested yang dipakai Next ikut naik ke versi aman.
+- Lockfile frontend diperbarui lewat `npm install`.
+- Konten Quill pada CMS berita sekarang disanitasi sebelum dikirim ke backend:
+  - create berita.
+  - edit berita.
+
+### Validasi
+- `npm audit --omit=dev --audit-level=moderate`: pass, tidak ada moderate/high/critical tersisa.
+- `npm audit --omit=dev --audit-level=low`: masih ada 2 low pada `quill/react-quill-new`; npm menawarkan `--force` yang men-downgrade `react-quill-new` ke `3.7.0` dan berisiko breaking, jadi mitigasi dilakukan dengan sanitasi konten sebelum submit.
+- `npm ls postcss`: semua PostCSS resolve ke `8.5.15`.
+- `npm run lint`: pass.
+- `npm run build`: pass.
+- Browser bawaan Codex:
+  - `/cms/informasi/create` load normal.
+  - editor Quill tampil.
+  - tidak ada console error.
+
+### Catatan
+- Dev server lokal sempat perlu distart ulang setelah proses validasi build membersihkan lock `.next`.
+- File untracked lokal `frontend/public/header.png` tidak disentuh.
+
+---
+
 # Progress - Phase 85: Audit Log Payload Sanitizer
 
 > Document updated: 2026-06-18

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9269,34 +9269,6 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -9816,9 +9788,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -9835,7 +9807,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,5 +52,8 @@
     "eslint-config-next": "latest",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "^8.5.15"
   }
 }

--- a/frontend/src/app/cms/informasi/[id]/page.tsx
+++ b/frontend/src/app/cms/informasi/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useState, FormEvent, useEffect, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter, useParams } from "next/navigation";
 import { api } from "@/lib/api";
+import { sanitizeHtml } from "@/lib/utils";
 import { Newspaper, Save, ArrowLeft, Loader2, ImagePlus } from "lucide-react";
 import { toast } from "sonner";
 import dynamic from "next/dynamic";
@@ -134,7 +135,7 @@ export default function EditInformasiPage() {
       const payload = new FormData();
       payload.append("_method", "PUT");
       payload.append("judul", judul);
-      payload.append("konten", konten);
+      payload.append("konten", sanitizeHtml(konten));
       if (categoryId) payload.append("category_id", categoryId);
       if (sumber) payload.append("sumber", sumber);
       payload.append("is_published", isPublished ? "1" : "0");

--- a/frontend/src/app/cms/informasi/create/page.tsx
+++ b/frontend/src/app/cms/informasi/create/page.tsx
@@ -4,6 +4,7 @@ import { useState, FormEvent, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { api } from "@/lib/api";
+import { sanitizeHtml } from "@/lib/utils";
 import { Newspaper, Save, ArrowLeft, Loader2, ImagePlus } from "lucide-react";
 import { toast } from "sonner";
 import dynamic from "next/dynamic";
@@ -96,7 +97,7 @@ export default function CreateInformasiPage() {
     try {
       const payload = new FormData();
       payload.append("judul", judul);
-      payload.append("konten", konten);
+      payload.append("konten", sanitizeHtml(konten));
       if (categoryId) payload.append("category_id", categoryId);
       if (sumber) payload.append("sumber", sumber);
       payload.append("is_published", isPublished ? "1" : "0");


### PR DESCRIPTION
## Summary
- force PostCSS resolution to 8.5.15 via npm overrides
- sanitize Quill CMS news content before create/update submit
- update progress.md with Phase 86

## Validation
- npm audit --omit=dev --audit-level=moderate
- npm audit --omit=dev --audit-level=low (only low quill advisory remains; npm fix is breaking downgrade, mitigated by sanitizing content before submit)
- npm ls postcss
- npm run lint
- npm run build
- Codex browser smoke test: /cms/informasi/create loads, Quill editor renders, no console errors