### PR TITLE
security: tighten auth cookie lifetime

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,36 @@
+# Progress - Phase 87: Auth Cookie Lifetime Hardening
+
+> Document updated: 2026-06-18
+> Status: Selesai lokal, siap PR.
+
+---
+
+## Browser Auth Storage Hardening Ringan
+
+### Status: SELESAI DI LOKAL
+- Scope: frontend auth store cookie helper.
+- Tujuan: mengurangi masa berlaku token di browser dan menambah atribut cookie yang lebih aman tanpa migrasi besar ke Sanctum SPA HttpOnly cookie.
+
+### Implementasi
+- Cookie auth (`bksda_token`, `bksda_user`) sekarang memakai helper terpusat.
+- `max-age` cookie diturunkan dari 7 hari menjadi 24 jam agar selaras dengan `SANCTUM_EXPIRATION=1440`.
+- Cookie otomatis diberi atribut `Secure` saat aplikasi berjalan di HTTPS.
+- Value cookie di-encode/decode lewat `encodeURIComponent` / `decodeURIComponent`.
+- Logout memakai helper delete cookie yang konsisten.
+
+### Validasi
+- `npm run lint`: pass.
+- `npm run build`: pass.
+- Browser bawaan Codex:
+  - `/login` dengan sesi aktif tetap redirect ke `/portal`.
+  - portal superadmin tetap load normal setelah perubahan auth store.
+
+### Catatan
+- Ini belum menyelesaikan target besar migrasi ke cookie HttpOnly. Itu tetap butuh PR terpisah karena menyentuh login backend, CSRF, CORS, RouteGuard, dan deployment env.
+- File untracked lokal `frontend/public/header.png` tidak disentuh.
+
+---
+
 # Progress - Phase 86: Frontend Dependency Mitigation
 
 > Document updated: 2026-06-18

--- a/frontend/src/lib/auth-store.ts
+++ b/frontend/src/lib/auth-store.ts
@@ -7,12 +7,35 @@ export interface StoredUser {
   access_modules: string[];
 }
 
+const AUTH_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24;
+
+function cookieSecurityAttributes() {
+  if (typeof window === "undefined") return "";
+
+  return window.location.protocol === "https:" ? "; Secure" : "";
+}
+
+function setAuthCookie(name: string, value: string) {
+  if (typeof document === "undefined") return;
+
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/; max-age=${AUTH_COOKIE_MAX_AGE_SECONDS}; SameSite=Lax${cookieSecurityAttributes()}`;
+}
+
+function deleteAuthCookie(name: string) {
+  if (typeof document === "undefined") return;
+
+  document.cookie = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax${cookieSecurityAttributes()}`;
+}
+
 function getCookie(name: string) {
   if (typeof document === "undefined") return null;
 
   const value = `; ${document.cookie}`;
   const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop()?.split(";").shift() ?? null;
+  if (parts.length === 2) {
+    const rawValue = parts.pop()?.split(";").shift() ?? null;
+    return rawValue ? decodeURIComponent(rawValue) : null;
+  }
 
   return null;
 }
@@ -24,7 +47,7 @@ function getUserString() {
   if (localUser) return localUser;
 
   const cookieUser = getCookie("bksda_user");
-  return cookieUser ? decodeURIComponent(cookieUser) : null;
+  return cookieUser;
 }
 
 export function getAuthSnapshot() {
@@ -81,8 +104,8 @@ export const authStore = {
     localStorage.setItem("bksda_token", token);
     localStorage.setItem("bksda_user", JSON.stringify(userData));
     
-    document.cookie = `bksda_token=${token}; path=/; max-age=604800; SameSite=Lax`;
-    document.cookie = `bksda_user=${encodeURIComponent(JSON.stringify(userData))}; path=/; max-age=604800; SameSite=Lax`;
+    setAuthCookie("bksda_token", token);
+    setAuthCookie("bksda_user", JSON.stringify(userData));
 
     window.dispatchEvent(new Event("auth-change"));
   },
@@ -92,7 +115,7 @@ export const authStore = {
     if (typeof window === "undefined") return;
 
     localStorage.setItem("bksda_user", JSON.stringify(userData));
-    document.cookie = `bksda_user=${encodeURIComponent(JSON.stringify(userData))}; path=/; max-age=604800; SameSite=Lax`;
+    setAuthCookie("bksda_user", JSON.stringify(userData));
 
     window.dispatchEvent(new Event("auth-change"));
   },
@@ -104,8 +127,8 @@ export const authStore = {
     localStorage.removeItem("bksda_token");
     localStorage.removeItem("bksda_user");
     
-    document.cookie = "bksda_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
-    document.cookie = "bksda_user=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+    deleteAuthCookie("bksda_token");
+    deleteAuthCookie("bksda_user");
 
     window.dispatchEvent(new Event("auth-change"));
   }


### PR DESCRIPTION
## Summary
- centralize auth cookie write/delete helpers
- reduce auth cookie max-age from 7 days to 24 hours to match Sanctum expiration
- add Secure attribute automatically on HTTPS
- encode/decode cookie values consistently
- update progress.md with Phase 87

## Validation
- npm run lint
- npm run build
- Codex browser smoke: active session redirects /login to /portal and portal loads normally

## Notes
- This is a low-risk auth storage hardening step. Full HttpOnly Sanctum SPA migration remains a separate larger PR.