### PR TITLE
feat(mobile): verify Surat Tugas list API contract (#438)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -873,79 +873,79 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: each section accepts typed asset detail props.
   - _Requirements: 6, 20_
 
-- [ ] 44. Build asset detail screen
+- [x] 44. Build asset detail screen
   - Target area: `mobile/src/features/bmn/AssetDetailScreen.tsx`.
   - Render sections, loading, not found, forbidden, and retry states.
   - Acceptance check: vehicle fields appear only when present.
   - _Requirements: 6, 17, 20_
 
-- [ ] 45. Add asset action bar
+- [x] 45. Add asset action bar
   - Target area: asset detail components.
   - Show edit, upload photo, verify, loan, and return actions based on permissions.
   - Acceptance check: action bar receives permission booleans from helper/backend state.
   - _Requirements: 6, 9, 10, 19_
 
-- [ ] 46. Add BMN asset form schema
+- [x] 46. Add BMN asset form schema
   - Target area: `mobile/src/features/bmn/assetFormSchema.ts`.
   - Define validation for required asset fields used on mobile.
   - Acceptance check: invalid required fields return readable Indonesian messages.
   - _Requirements: 7, 17_
 
-- [ ] 47. Build asset form screen shell
+- [x] 47. Build asset form screen shell
   - Target area: `mobile/src/features/bmn/AssetFormScreen.tsx`.
   - Build sectioned form layout with placeholders for fields.
   - Acceptance check: layout works on small Android screen without horizontal scroll.
   - _Requirements: 7, 20_
 
-- [ ] 48. Wire asset create/update submit
+- [x] 48. Wire asset create/update submit
   - Target area: BMN asset form API.
   - Submit create/update only when permission allows.
   - Acceptance check: backend 422 errors are mapped to fields.
   - _Requirements: 7, 17, 19_
 
-- [ ] 49. Add photo slot component
+- [x] 49. Add photo slot component
   - Target area: `mobile/src/features/bmn/components/PhotoSlot.tsx`.
   - Render image/placeholder, slot label, upload action, delete action if allowed.
   - Acceptance check: geotag slot is visually distinct from normal slots.
   - _Requirements: 8, 20_
 
-- [ ] 50. Add camera permission helper
+- [x] 50. Add camera permission helper
   - Target area: `mobile/src/features/bmn/photoPermissions.ts`.
   - Request camera permission before capture.
   - Acceptance check: denied permission shows user-friendly message.
   - _Requirements: 8, 17_
 
-- [ ] 51. Add location permission helper for geotag
+- [x] 51. Add location permission helper for geotag
   - Target area: photo/geotag helpers.
   - Request location only for geotag capture.
   - Acceptance check: normal photo slot does not request location.
   - _Requirements: 8, 16_
 
-- [ ] 52. Build photo capture screen
+- [x] 52. Build photo capture screen
   - Target area: `mobile/src/features/bmn/PhotoCaptureScreen.tsx`.
   - Capture photo, show preview, allow retake/cancel/submit.
   - Acceptance check: submit is disabled until a photo exists.
   - _Requirements: 8, 20_
 
-- [ ] 53. Wire photo upload API
+- [x] 53. Wire photo upload API
   - Target area: BMN photo API helper.
   - Upload `photo`, `type`, optional `latitude`, `longitude`, and `location_note`.
   - Acceptance check: upload progress is shown for uploads over 1 second.
   - _Requirements: 8, 17, 19_
 
-- [ ] 54. Build asset verification action
+- [x] 54. Build asset verification action
   - Target area: asset detail action components.
   - Add confirm dialog and call verification endpoint.
   - Acceptance check: success refreshes detail status.
   - _Requirements: 9, 17, 19_
 
-- [ ] 55. Build BMN loan form shell
+- [x] 55. Build BMN loan form shell
   - Target area: `mobile/src/features/bmn/LoanFormScreen.tsx`.
   - Include asset summary, employee selector placeholder, date, and notes.
   - Acceptance check: submit disabled until required fields exist.
   - _Requirements: 10, 15, 20_
 
-- [ ] 56. Wire BMN loan and return submit
+- [x] 56. Wire BMN loan and return submit
   - Target area: BMN loan API helper.
   - Submit loan and return actions with confirmation.
   - Acceptance check: success refreshes asset detail and loan history.
@@ -953,7 +953,7 @@ Use this matrix together with the numbered task. A lower-capability model should
 
 ### Milestone 3: Surat Tugas Alpha
 
-- [ ] 57. Verify Surat Tugas list API
+- [x] 57. Verify Surat Tugas list API
   - Target area: backend Surat Tugas endpoint.
   - Confirm personal and management list endpoints support pagination.
   - Acceptance check: endpoint can return page 1 with mobile-friendly fields.

--- a/backend/app/Modules/SuratTugas/Controllers/AssignmentLetterController.php
+++ b/backend/app/Modules/SuratTugas/Controllers/AssignmentLetterController.php
@@ -22,7 +22,10 @@ class AssignmentLetterController extends Controller
         $employee = \App\Modules\Kepegawaian\Models\Employee::where('nip', $user->username)->first();
 
         if (!$employee) {
-            return response()->json(['data' => [], 'meta' => ['total' => 0]]);
+            return response()->json([
+                'data' => [],
+                'meta' => $this->emptyPaginationMeta($request),
+            ]);
         }
 
         $query = AssignmentLetter::with(['employees:id,nama_lengkap,nip'])
@@ -37,13 +40,10 @@ class AssignmentLetterController extends Controller
         $letters = $query->latest()->paginate($perPage);
 
         return response()->json([
-            'data' => $letters->items(),
-            'meta' => [
-                'current_page' => $letters->currentPage(),
-                'last_page' => $letters->lastPage(),
-                'per_page' => $letters->perPage(),
-                'total' => $letters->total(),
-            ],
+            'data' => $isMobile
+                ? collect($letters->items())->map(fn (AssignmentLetter $letter) => $this->toMobileListItem($letter, personal: true))->values()
+                : $letters->items(),
+            'meta' => $this->paginationMeta($letters),
         ]);
     }
 
@@ -101,8 +101,11 @@ class AssignmentLetterController extends Controller
         $query = AssignmentLetter::with(['creator:id,name', 'approver:id,name', 'employees:id,nama_lengkap,nip,jabatan']);
 
         if ($search = $request->query('search')) {
-            $query->where('tempat_tujuan', 'ilike', "%{$search}%")
-                ->orWhere('maksud_tujuan', 'ilike', "%{$search}%");
+            $query->where(function ($q) use ($search) {
+                $q->where('tempat_tujuan', 'ilike', "%{$search}%")
+                    ->orWhere('maksud_tujuan', 'ilike', "%{$search}%")
+                    ->orWhere('nomor_surat', 'ilike', "%{$search}%");
+            });
         }
 
         if ($status = $request->query('status')) {
@@ -125,14 +128,61 @@ class AssignmentLetterController extends Controller
         $letters = $query->latest()->paginate($perPage);
 
         return response()->json([
-            'data' => $letters->items(),
-            'meta' => [
-                'current_page' => $letters->currentPage(),
-                'last_page' => $letters->lastPage(),
-                'per_page' => $letters->perPage(),
-                'total' => $letters->total(),
-            ],
+            'data' => $isMobile
+                ? collect($letters->items())->map(fn (AssignmentLetter $letter) => $this->toMobileListItem($letter))->values()
+                : $letters->items(),
+            'meta' => $this->paginationMeta($letters),
         ]);
+    }
+
+    private function toMobileListItem(AssignmentLetter $letter, bool $personal = false): array
+    {
+        $employees = $letter->employees;
+        $firstNames = $employees->pluck('nama_lengkap')->filter()->take(2)->values();
+        $remainingCount = max(0, $employees->count() - $firstNames->count());
+
+        $personelSummary = $firstNames->implode(', ');
+        if ($remainingCount > 0) {
+            $personelSummary .= " +{$remainingCount} lainnya";
+        }
+
+        return [
+            'id' => $letter->id,
+            'nomor' => $letter->nomor_surat,
+            'kegiatan' => $letter->maksud_tujuan,
+            'tujuan' => $letter->tempat_tujuan,
+            'tanggal_mulai' => $letter->tanggal_mulai?->toDateString(),
+            'tanggal_selesai' => $letter->tanggal_selesai?->toDateString(),
+            'tanggal_surat' => $letter->tanggal_surat?->toDateString(),
+            'status' => $letter->status,
+            'personel_summary' => $personelSummary ?: null,
+            'personel_count' => $employees->count(),
+            'has_file' => (bool) $letter->file_surat_path,
+            'allowed_actions' => [
+                'can_view' => true,
+                'can_download' => $personal && (bool) $letter->file_surat_path,
+            ],
+        ];
+    }
+
+    private function paginationMeta($paginator): array
+    {
+        return [
+            'current_page' => $paginator->currentPage(),
+            'last_page' => $paginator->lastPage(),
+            'per_page' => $paginator->perPage(),
+            'total' => $paginator->total(),
+        ];
+    }
+
+    private function emptyPaginationMeta(Request $request): array
+    {
+        return [
+            'current_page' => max(1, (int) $request->query('page', 1)),
+            'last_page' => 1,
+            'per_page' => max(1, (int) $request->query('per_page', 20)),
+            'total' => 0,
+        ];
     }
 
     public function store(AssignmentLetterRequest $request)

--- a/backend/tests/Feature/SuratTugasMobileListApiTest.php
+++ b/backend/tests/Feature/SuratTugasMobileListApiTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Modules\Kepegawaian\Models\Employee;
+use App\Modules\SuratTugas\Models\AssignmentLetter;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class SuratTugasMobileListApiTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('username')->unique();
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->string('role')->default('user');
+            $table->json('access_modules')->nullable();
+            $table->json('permissions')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->rememberToken();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('kpg_employees', function (Blueprint $table) {
+            $table->id();
+            $table->string('nip', 50)->unique();
+            $table->string('nama_lengkap');
+            $table->string('jabatan')->nullable();
+            $table->string('pangkat_golongan')->nullable();
+            $table->string('satuan_kerja')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->string('foto_profil')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('st_assignment_letters', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('nomor_surat')->nullable()->unique();
+            $table->string('kode_surat')->nullable();
+            $table->string('template_type')->nullable();
+            $table->text('dasar_hukum')->nullable();
+            $table->text('maksud_tujuan');
+            $table->date('tanggal_mulai');
+            $table->date('tanggal_selesai');
+            $table->date('tanggal_surat')->nullable();
+            $table->string('tempat_tujuan')->nullable();
+            $table->string('status')->default('draft');
+            $table->string('file_surat_path')->nullable();
+            $table->foreignId('created_by')->nullable();
+            $table->foreignId('approved_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('st_assignment_letter_employees', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('assignment_letter_id');
+            $table->foreignId('employee_id');
+            $table->string('peran')->nullable();
+            $table->timestamps();
+            $table->unique(['assignment_letter_id', 'employee_id'], 'st_al_employee_unique');
+        });
+    }
+
+    public function test_management_list_returns_mobile_friendly_paginated_items(): void
+    {
+        $user = User::factory()->create([
+            'username' => '198001012005011001',
+            'role' => 'super_admin',
+            'access_modules' => ['surat_tugas'],
+        ]);
+        $employee = Employee::create([
+            'nip' => '199001012020011001',
+            'nama_lengkap' => 'Pegawai Satu',
+            'jabatan' => 'Analis',
+        ]);
+        $letter = AssignmentLetter::create([
+            'nomor_surat' => 'ST.001/BKSDA/2026',
+            'maksud_tujuan' => 'Patroli kawasan konservasi',
+            'tanggal_mulai' => '2026-06-20',
+            'tanggal_selesai' => '2026-06-21',
+            'tanggal_surat' => '2026-06-19',
+            'tempat_tujuan' => 'Samarinda',
+            'status' => 'approved',
+            'file_surat_path' => 'surat-tugas/st-001.pdf',
+            'created_by' => $user->id,
+        ]);
+        $letter->employees()->sync([$employee->id]);
+
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/surat-tugas?mobile=true&page=1&per_page=20')
+            ->assertOk()
+            ->assertJsonPath('meta.current_page', 1)
+            ->assertJsonPath('meta.per_page', 20)
+            ->assertJsonPath('meta.total', 1)
+            ->assertJsonPath('data.0.id', $letter->id)
+            ->assertJsonPath('data.0.nomor', 'ST.001/BKSDA/2026')
+            ->assertJsonPath('data.0.kegiatan', 'Patroli kawasan konservasi')
+            ->assertJsonPath('data.0.tujuan', 'Samarinda')
+            ->assertJsonPath('data.0.tanggal_mulai', '2026-06-20')
+            ->assertJsonPath('data.0.tanggal_selesai', '2026-06-21')
+            ->assertJsonPath('data.0.status', 'approved')
+            ->assertJsonPath('data.0.personel_summary', 'Pegawai Satu')
+            ->assertJsonPath('data.0.has_file', true)
+            ->assertJsonPath('data.0.allowed_actions.can_view', true);
+    }
+
+    public function test_personal_list_returns_only_authenticated_employee_letters(): void
+    {
+        $employee = Employee::create([
+            'nip' => '199001012020011001',
+            'nama_lengkap' => 'Pegawai Satu',
+            'jabatan' => 'Analis',
+        ]);
+        $otherEmployee = Employee::create([
+            'nip' => '199001012020011002',
+            'nama_lengkap' => 'Pegawai Dua',
+            'jabatan' => 'Pengendali Ekosistem Hutan',
+        ]);
+        $user = User::factory()->create([
+            'username' => $employee->nip,
+            'role' => 'user',
+            'access_modules' => [],
+        ]);
+        $myLetter = AssignmentLetter::create([
+            'nomor_surat' => 'ST.002/BKSDA/2026',
+            'maksud_tujuan' => 'Monitoring satwa',
+            'tanggal_mulai' => '2026-06-22',
+            'tanggal_selesai' => '2026-06-23',
+            'tanggal_surat' => '2026-06-19',
+            'tempat_tujuan' => 'Balikpapan',
+            'status' => 'approved',
+            'file_surat_path' => 'surat-tugas/st-002.pdf',
+            'created_by' => $user->id,
+        ]);
+        $otherLetter = AssignmentLetter::create([
+            'nomor_surat' => 'ST.003/BKSDA/2026',
+            'maksud_tujuan' => 'Rapat koordinasi',
+            'tanggal_mulai' => '2026-06-24',
+            'tanggal_selesai' => '2026-06-24',
+            'tanggal_surat' => '2026-06-19',
+            'tempat_tujuan' => 'Berau',
+            'status' => 'approved',
+            'created_by' => $user->id,
+        ]);
+        $myLetter->employees()->sync([$employee->id]);
+        $otherLetter->employees()->sync([$otherEmployee->id]);
+
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/surat-tugas/my?page=1&per_page=20', ['X-Client' => 'mobile'])
+            ->assertOk()
+            ->assertJsonPath('meta.total', 1)
+            ->assertJsonPath('data.0.id', $myLetter->id)
+            ->assertJsonPath('data.0.nomor', 'ST.002/BKSDA/2026')
+            ->assertJsonPath('data.0.allowed_actions.can_download', true);
+    }
+}

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,39 @@
+# Progress - Phase 100: Mobile Surat Tugas List API Contract
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-57`.
+> GitHub Issue: #438.
+
+---
+
+## Mobile Surat Tugas List API Contract
+
+### Status: SELESAI
+- Scope: Backend Mobile API (Surat Tugas Module)
+- Tujuan: Memverifikasi dan memperkuat kontrak endpoint list Surat Tugas agar siap dipakai mobile app untuk mode personal dan manajemen, dengan pagination aman dan payload list yang ringan.
+
+### Implementasi
+- **Management List Endpoint**:
+  - Memperkuat `GET /api/surat-tugas?mobile=true&page=1&per_page=20` di [AssignmentLetterController.php](file:///e:/bksda-superapp/backend/app/Modules/SuratTugas/Controllers/AssignmentLetterController.php) agar request mobile mengembalikan item list ringkas (`nomor`, `kegiatan`, `tujuan`, tanggal, status, ringkasan personel, status file, dan `allowed_actions`) alih-alih model mentah.
+  - Memperbaiki grouping query search agar filter status/pegawai tidak tertembus oleh kondisi `orWhere` pencarian.
+- **Personal List Endpoint**:
+  - Memperkuat `GET /api/surat-tugas/my` agar tetap memakai pagination meta standar walaupun user belum punya data pegawai.
+  - Menyediakan payload mobile-friendly untuk surat tugas milik pegawai terautentikasi, termasuk `can_download` ketika berkas tersedia.
+- **Verification Tests**:
+  - Menambahkan [SuratTugasMobileListApiTest.php](file:///e:/bksda-superapp/backend/tests/Feature/SuratTugasMobileListApiTest.php) untuk membuktikan endpoint manajemen dan personal mengembalikan metadata pagination serta field card mobile yang dibutuhkan.
+- **Checklist**:
+  - Mencentang Task 57 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `php -l backend/app/Modules/SuratTugas/Controllers/AssignmentLetterController.php`: sukses tanpa syntax error.
+- `php artisan route:list --path=api/surat-tugas`: sukses, 17 route Surat Tugas terdaftar.
+- `php artisan test --filter=SuratTugasMobileListApiTest`: 2 tests passed, 19 assertions.
+
+### Next Steps
+- [ ] Task 58: Verify Surat Tugas detail API.
+
+---
+
 # Progress - Phase 99: Mobile BMN Photo Capture & Geotag Upload
 
 > Document updated: 2026-06-19


### PR DESCRIPTION
Closes #438

## Summary
- Add mobile-friendly list serialization for Surat Tugas management and personal endpoints.
- Keep non-mobile responses backward-compatible with existing raw model payloads.
- Fix grouped search conditions so status/employee filters remain scoped correctly.
- Mark mobile tasks 44-57 complete and update progress.md.

## Validation
- php -l backend/app/Modules/SuratTugas/Controllers/AssignmentLetterController.php
- php artisan route:list --path=api/surat-tugas
- php artisan test --filter=SuratTugasMobileListApiTest