### PR TITLE
feat(mobile): verify Surat Tugas detail API contract (#440)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -959,7 +959,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: endpoint can return page 1 with mobile-friendly fields.
   - _Requirements: 11, 18_
 
-- [ ] 58. Verify Surat Tugas detail API
+- [x] 58. Verify Surat Tugas detail API
   - Target area: backend Surat Tugas detail endpoint.
   - Confirm response includes personel, status, dates, file state, and allowed actions where possible.
   - Acceptance check: forbidden user receives 403, not hidden data.

--- a/backend/app/Modules/SuratTugas/Controllers/AssignmentLetterController.php
+++ b/backend/app/Modules/SuratTugas/Controllers/AssignmentLetterController.php
@@ -56,14 +56,23 @@ class AssignmentLetterController extends Controller
             return response()->json(['message' => 'Data pegawai tidak ditemukan'], 404);
         }
 
-        $surat = AssignmentLetter::with(['creator:id,name', 'approver:id,name', 'employees'])
-            ->whereHas('employees', function ($q) use ($employee) {
-                $q->where('kpg_employees.id', $employee->id);
-            })
-            ->where('status', 'approved')
+        $surat = AssignmentLetter::with(['creator:id,name', 'approver:id,name', 'employees:id,nama_lengkap,nip,jabatan,satuan_kerja'])
             ->findOrFail($id);
 
-        return response()->json(['data' => $surat]);
+        $isAssignedEmployee = $surat->employees->contains(fn ($item) => (int) $item->id === (int) $employee->id);
+        $isPublished = in_array($surat->status, ['approved', 'completed'], true);
+
+        if (! $isAssignedEmployee || ! $isPublished) {
+            return response()->json([
+                'message' => 'Anda tidak memiliki akses ke Surat Tugas ini.',
+            ], 403);
+        }
+
+        return response()->json([
+            'data' => $this->isMobileRequest($request)
+                ? $this->toMobileDetailItem($surat, personal: true)
+                : $surat,
+        ]);
     }
 
     public function myDownload(Request $request, string $id)
@@ -163,6 +172,52 @@ class AssignmentLetterController extends Controller
                 'can_download' => $personal && (bool) $letter->file_surat_path,
             ],
         ];
+    }
+
+    private function toMobileDetailItem(AssignmentLetter $letter, bool $personal = false): array
+    {
+        $downloadUrl = $personal
+            ? "/api/surat-tugas/my/{$letter->id}/download"
+            : "/api/surat-tugas/{$letter->id}/download";
+
+        return [
+            'id' => $letter->id,
+            'nomor' => $letter->nomor_surat,
+            'kode_surat' => $letter->kode_surat,
+            'kegiatan' => $letter->maksud_tujuan,
+            'dasar_hukum' => $letter->dasar_hukum,
+            'tujuan' => $letter->tempat_tujuan,
+            'tanggal_mulai' => $letter->tanggal_mulai?->toDateString(),
+            'tanggal_selesai' => $letter->tanggal_selesai?->toDateString(),
+            'tanggal_surat' => $letter->tanggal_surat?->toDateString(),
+            'status' => $letter->status,
+            'sumber_dana' => $letter->sumber_dana,
+            'template_type' => $letter->template_type,
+            'personel' => $letter->employees->map(fn ($employee) => [
+                'id' => $employee->id,
+                'name' => $employee->nama_lengkap,
+                'nip' => $employee->nip,
+                'jabatan' => $employee->jabatan,
+                'unit_kerja' => $employee->satuan_kerja,
+                'peran' => $employee->pivot?->peran,
+            ])->values(),
+            'file' => [
+                'available' => (bool) $letter->file_surat_path,
+                'download_url' => $letter->file_surat_path ? $downloadUrl : null,
+            ],
+            'allowed_actions' => [
+                'can_view' => true,
+                'can_download' => (bool) $letter->file_surat_path,
+                'can_update' => ! $personal,
+                'can_approve' => ! $personal && $letter->status === 'pending',
+                'can_delete' => ! $personal,
+            ],
+        ];
+    }
+
+    private function isMobileRequest(Request $request): bool
+    {
+        return $request->boolean('mobile') || $request->header('X-Client') === 'mobile';
     }
 
     private function paginationMeta($paginator): array
@@ -268,11 +323,15 @@ class AssignmentLetterController extends Controller
         }
     }
 
-    public function show(string $id)
+    public function show(Request $request, string $id)
     {
-        $surat = AssignmentLetter::with(['creator:id,name', 'approver:id,name', 'employees'])->findOrFail($id);
+        $surat = AssignmentLetter::with(['creator:id,name', 'approver:id,name', 'employees:id,nama_lengkap,nip,jabatan,satuan_kerja'])->findOrFail($id);
 
-        return response()->json(['data' => $surat]);
+        return response()->json([
+            'data' => $this->isMobileRequest($request)
+                ? $this->toMobileDetailItem($surat)
+                : $surat,
+        ]);
     }
 
     public function update(AssignmentLetterRequest $request, string $id)

--- a/backend/tests/Feature/SuratTugasMobileListApiTest.php
+++ b/backend/tests/Feature/SuratTugasMobileListApiTest.php
@@ -58,6 +58,7 @@ class SuratTugasMobileListApiTest extends TestCase
             $table->string('tempat_tujuan')->nullable();
             $table->string('status')->default('draft');
             $table->string('file_surat_path')->nullable();
+            $table->string('sumber_dana')->nullable();
             $table->foreignId('created_by')->nullable();
             $table->foreignId('approved_by')->nullable();
             $table->timestamps();
@@ -167,5 +168,124 @@ class SuratTugasMobileListApiTest extends TestCase
             ->assertJsonPath('data.0.id', $myLetter->id)
             ->assertJsonPath('data.0.nomor', 'ST.002/BKSDA/2026')
             ->assertJsonPath('data.0.allowed_actions.can_download', true);
+    }
+
+    public function test_management_detail_returns_mobile_ready_payload(): void
+    {
+        $user = User::factory()->create([
+            'username' => '198001012005011001',
+            'role' => 'super_admin',
+            'access_modules' => ['surat_tugas'],
+        ]);
+        $employee = Employee::create([
+            'nip' => '199001012020011001',
+            'nama_lengkap' => 'Pegawai Satu',
+            'jabatan' => 'Analis',
+            'satuan_kerja' => 'Balai KSDA Kalimantan Timur',
+        ]);
+        $letter = AssignmentLetter::create([
+            'nomor_surat' => 'ST.004/BKSDA/2026',
+            'kode_surat' => 'ST',
+            'maksud_tujuan' => 'Pemeriksaan lapangan',
+            'dasar_hukum' => 'Surat permohonan pemeriksaan',
+            'tanggal_mulai' => '2026-06-25',
+            'tanggal_selesai' => '2026-06-26',
+            'tanggal_surat' => '2026-06-19',
+            'tempat_tujuan' => 'Kutai Kartanegara',
+            'status' => 'pending',
+            'file_surat_path' => 'surat-tugas/st-004.pdf',
+            'sumber_dana' => 'dipa',
+            'created_by' => $user->id,
+        ]);
+        $letter->employees()->sync([$employee->id => ['peran' => 'Ketua Tim']]);
+
+        Sanctum::actingAs($user);
+
+        $this->getJson("/api/surat-tugas/{$letter->id}?mobile=true")
+            ->assertOk()
+            ->assertJsonPath('data.id', $letter->id)
+            ->assertJsonPath('data.nomor', 'ST.004/BKSDA/2026')
+            ->assertJsonPath('data.kegiatan', 'Pemeriksaan lapangan')
+            ->assertJsonPath('data.dasar_hukum', 'Surat permohonan pemeriksaan')
+            ->assertJsonPath('data.tujuan', 'Kutai Kartanegara')
+            ->assertJsonPath('data.tanggal_mulai', '2026-06-25')
+            ->assertJsonPath('data.status', 'pending')
+            ->assertJsonPath('data.personel.0.name', 'Pegawai Satu')
+            ->assertJsonPath('data.personel.0.peran', 'Ketua Tim')
+            ->assertJsonPath('data.file.available', true)
+            ->assertJsonPath('data.file.download_url', "/api/surat-tugas/{$letter->id}/download")
+            ->assertJsonPath('data.allowed_actions.can_approve', true);
+    }
+
+    public function test_personal_detail_returns_assigned_published_letter(): void
+    {
+        $employee = Employee::create([
+            'nip' => '199001012020011001',
+            'nama_lengkap' => 'Pegawai Satu',
+            'jabatan' => 'Analis',
+        ]);
+        $user = User::factory()->create([
+            'username' => $employee->nip,
+            'role' => 'user',
+            'access_modules' => [],
+        ]);
+        $letter = AssignmentLetter::create([
+            'nomor_surat' => 'ST.005/BKSDA/2026',
+            'maksud_tujuan' => 'Pendampingan kegiatan',
+            'tanggal_mulai' => '2026-06-27',
+            'tanggal_selesai' => '2026-06-28',
+            'tanggal_surat' => '2026-06-19',
+            'tempat_tujuan' => 'Bontang',
+            'status' => 'approved',
+            'file_surat_path' => 'surat-tugas/st-005.pdf',
+            'created_by' => $user->id,
+        ]);
+        $letter->employees()->sync([$employee->id => ['peran' => 'Anggota']]);
+
+        Sanctum::actingAs($user);
+
+        $this->getJson("/api/surat-tugas/my/{$letter->id}", ['X-Client' => 'mobile'])
+            ->assertOk()
+            ->assertJsonPath('data.id', $letter->id)
+            ->assertJsonPath('data.personel.0.name', 'Pegawai Satu')
+            ->assertJsonPath('data.file.download_url', "/api/surat-tugas/my/{$letter->id}/download")
+            ->assertJsonPath('data.allowed_actions.can_update', false)
+            ->assertJsonPath('data.allowed_actions.can_download', true);
+    }
+
+    public function test_personal_detail_returns_forbidden_for_unassigned_existing_letter(): void
+    {
+        $employee = Employee::create([
+            'nip' => '199001012020011001',
+            'nama_lengkap' => 'Pegawai Satu',
+            'jabatan' => 'Analis',
+        ]);
+        $otherEmployee = Employee::create([
+            'nip' => '199001012020011002',
+            'nama_lengkap' => 'Pegawai Dua',
+            'jabatan' => 'Polhut',
+        ]);
+        $user = User::factory()->create([
+            'username' => $employee->nip,
+            'role' => 'user',
+            'access_modules' => [],
+        ]);
+        $letter = AssignmentLetter::create([
+            'nomor_surat' => 'ST.006/BKSDA/2026',
+            'maksud_tujuan' => 'Kegiatan terbatas',
+            'tanggal_mulai' => '2026-06-29',
+            'tanggal_selesai' => '2026-06-29',
+            'tanggal_surat' => '2026-06-19',
+            'tempat_tujuan' => 'Sangatta',
+            'status' => 'approved',
+            'created_by' => $user->id,
+        ]);
+        $letter->employees()->sync([$otherEmployee->id]);
+
+        Sanctum::actingAs($user);
+
+        $this->getJson("/api/surat-tugas/my/{$letter->id}", ['X-Client' => 'mobile'])
+            ->assertForbidden()
+            ->assertJsonPath('message', 'Anda tidak memiliki akses ke Surat Tugas ini.');
     }
 }

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,37 @@
+# Progress - Phase 101: Mobile Surat Tugas Detail API Contract
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-58`.
+> GitHub Issue: #440.
+
+---
+
+## Mobile Surat Tugas Detail API Contract
+
+### Status: SELESAI
+- Scope: Backend Mobile API (Surat Tugas Module)
+- Tujuan: Memverifikasi dan memperkuat endpoint detail Surat Tugas agar siap dipakai mobile app untuk mode personal dan manajemen, termasuk personel, status, tanggal, file state, allowed actions, dan perilaku forbidden yang eksplisit.
+
+### Implementasi
+- **Management Detail Endpoint**:
+  - Memperkuat `GET /api/surat-tugas/{id}?mobile=true` di [AssignmentLetterController.php](file:///e:/bksda-superapp/backend/app/Modules/SuratTugas/Controllers/AssignmentLetterController.php) agar request mobile mengembalikan payload detail terstruktur: identitas surat, kegiatan, dasar hukum, tujuan, tanggal, status, personel, status file, download URL, dan `allowed_actions`.
+- **Personal Detail Endpoint**:
+  - Memperkuat `GET /api/surat-tugas/my/{id}` agar user pegawai hanya dapat membuka surat yang memang melibatkan pegawai tersebut dan sudah berstatus `approved`/`completed`.
+  - Mengubah akses personal terhadap surat yang ada tetapi bukan hak user menjadi HTTP 403 dengan pesan aman, bukan menyembunyikan data sebagai 404.
+- **Verification Tests**:
+  - Memperluas [SuratTugasMobileListApiTest.php](file:///e:/bksda-superapp/backend/tests/Feature/SuratTugasMobileListApiTest.php) untuk membuktikan response detail manajemen, detail personal, dan forbidden personal access.
+- **Checklist**:
+  - Mencentang Task 58 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `php -l backend/app/Modules/SuratTugas/Controllers/AssignmentLetterController.php`: sukses tanpa syntax error.
+- `php artisan test --filter=SuratTugasMobileListApiTest`: 5 tests passed, 40 assertions.
+
+### Next Steps
+- [ ] Task 59: Add Surat Tugas types.
+
+---
+
 # Progress - Phase 100: Mobile Surat Tugas List API Contract
 
 > Document updated: 2026-06-19


### PR DESCRIPTION
Closes #440

## Summary
- Add mobile-friendly Surat Tugas detail serialization for management and personal endpoints.
- Return explicit 403 for existing personal Surat Tugas records the authenticated employee cannot access.
- Cover management detail, personal detail, and forbidden personal access with feature tests.
- Mark Task 58 complete and update progress.md.

## Validation
- php -l backend/app/Modules/SuratTugas/Controllers/AssignmentLetterController.php
- php artisan test --filter=SuratTugasMobileListApiTest