### PR TITLE
feat(mobile): add Surat Tugas type definitions (#442)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -965,7 +965,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: forbidden user receives 403, not hidden data.
   - _Requirements: 11, 14, 19_
 
-- [ ] 59. Add Surat Tugas types
+- [x] 59. Add Surat Tugas types
   - Target area: `mobile/src/features/surat-tugas/types.ts`.
   - Define list item, detail, personel, status, file, and action types.
   - Acceptance check: assignment card does not use `any`.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,33 @@
+# Progress - Phase 102: Mobile Surat Tugas TypeScript Types
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-59`.
+> GitHub Issue: #442.
+
+---
+
+## Mobile Surat Tugas TypeScript Types
+
+### Status: SELESAI
+- Scope: Mobile App (Surat Tugas Module)
+- Tujuan: Menyediakan kontrak TypeScript untuk list item, detail, personel, status, file state, allowed actions, filter, dan mode list Surat Tugas agar hook dan komponen berikutnya tidak memakai `any`.
+
+### Implementasi
+- **Types**:
+  - Membuat [types.ts](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/types.ts) berisi `AssignmentListItem`, `AssignmentDetail`, `AssignmentPersonel`, `AssignmentFileState`, `AssignmentAllowedActions`, `AssignmentQueryFilters`, `AssignmentListMode`, dan payload aksi status.
+  - Menyesuaikan tipe dengan kontrak backend mobile yang sudah diperkuat pada Task 57-58 (`nomor`, `kegiatan`, `tujuan`, tanggal, status, personel, file state, dan `allowed_actions`).
+- **Checklist**:
+  - Mencentang Task 59 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 60: Add Surat Tugas list API hook.
+
+---
+
 # Progress - Phase 101: Mobile Surat Tugas Detail API Contract
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/surat-tugas/types.ts
+++ b/mobile/src/features/surat-tugas/types.ts
@@ -1,0 +1,75 @@
+export type AssignmentStatus =
+  | 'draft'
+  | 'pending'
+  | 'approved'
+  | 'rejected'
+  | 'completed'
+  | (string & {});
+
+export type AssignmentListMode = 'personal' | 'management';
+
+export interface AssignmentAllowedActions {
+  can_view: boolean;
+  can_download?: boolean;
+  can_update?: boolean;
+  can_approve?: boolean;
+  can_delete?: boolean;
+  can_reject?: boolean;
+  can_complete?: boolean;
+}
+
+export interface AssignmentFileState {
+  available: boolean;
+  download_url?: string | null;
+  filename?: string | null;
+  mime_type?: string | null;
+}
+
+export interface AssignmentPersonel {
+  id: string | number;
+  name: string;
+  nip?: string | null;
+  jabatan?: string | null;
+  unit_kerja?: string | null;
+  peran?: string | null;
+}
+
+export interface AssignmentListItem {
+  id: string | number;
+  nomor?: string | null;
+  kegiatan?: string | null;
+  tujuan?: string | null;
+  tanggal_mulai?: string | null;
+  tanggal_selesai?: string | null;
+  tanggal_surat?: string | null;
+  status?: AssignmentStatus | null;
+  personel_summary?: string | null;
+  personel_count?: number;
+  has_file?: boolean;
+  allowed_actions?: AssignmentAllowedActions;
+}
+
+export interface AssignmentDetail extends AssignmentListItem {
+  kode_surat?: string | null;
+  dasar_hukum?: string | null;
+  sumber_dana?: string | null;
+  template_type?: string | null;
+  personel: AssignmentPersonel[];
+  file: AssignmentFileState;
+  allowed_actions: AssignmentAllowedActions;
+}
+
+export interface AssignmentQueryFilters {
+  mode?: AssignmentListMode;
+  page?: number;
+  per_page?: number;
+  search?: string;
+  status?: AssignmentStatus;
+  employee_id?: string | number;
+}
+
+export interface AssignmentStatusActionPayload {
+  status: AssignmentStatus;
+  nomor_surat?: string | null;
+  reason?: string | null;
+}


### PR DESCRIPTION
Closes #442

## Summary
- Add typed mobile Surat Tugas contracts for list items, details, personel, file state, allowed actions, filters, status payloads, and list modes.
- Align mobile types with the API contracts hardened in Tasks 57-58.
- Mark Task 59 complete and update progress.md.

## Validation
- npm run typecheck
- npm run lint