### PR TITLE
feat(mobile): add Surat Tugas list hook (#444)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -971,7 +971,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: assignment card does not use `any`.
   - _Requirements: 11_
 
-- [ ] 60. Add Surat Tugas list API hook
+- [x] 60. Add Surat Tugas list API hook
   - Target area: `mobile/src/features/surat-tugas/useAssignments.ts`.
   - Support personal mode, management mode, page, search, and status filter.
   - Acceptance check: hook uses mobile params and pagination meta.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,37 @@
+# Progress - Phase 103: Mobile Surat Tugas List API Hook
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-60`.
+> GitHub Issue: #444.
+
+---
+
+## Mobile Surat Tugas List API Hook
+
+### Status: SELESAI
+- Scope: Mobile App (Surat Tugas Module)
+- Tujuan: Menyediakan hook list Surat Tugas yang mendukung mode personal/manajemen, pagination, search, status filter, pull-to-refresh, next-page loading, dan normalized error state.
+
+### Implementasi
+- **Hook**:
+  - Membuat [useAssignments.ts](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/useAssignments.ts) dengan bentuk return konsisten seperti hook list BMN: `items`, `isLoading`, `isRefreshing`, `isFetchingNextPage`, `error`, `refetch`, `fetchNextPage`, dan `hasNextPage`.
+  - Mode `personal` memakai endpoint `/surat-tugas/my`; mode `management` memakai endpoint `/surat-tugas`.
+  - Semua request memakai `withMobileParams` agar `mobile=true`, `page`, dan `per_page` selalu konsisten.
+- **Tests**:
+  - Menambahkan [useAssignments.test.tsx](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/__tests__/useAssignments.test.tsx) untuk menguji initial load personal, mode management dengan search/status, infinite pagination append, dan refresh state.
+- **Checklist**:
+  - Mencentang Task 60 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/surat-tugas/__tests__/useAssignments.test.tsx`: 4 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 61: Add AssignmentCard component.
+
+---
+
 # Progress - Phase 102: Mobile Surat Tugas TypeScript Types
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/surat-tugas/__tests__/useAssignments.test.tsx
+++ b/mobile/src/features/surat-tugas/__tests__/useAssignments.test.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { apiClient } from '@/lib/api/client';
+import { useAssignments } from '../useAssignments';
+import { AssignmentQueryFilters } from '../types';
+
+jest.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+  },
+}));
+
+describe('useAssignments', () => {
+  let capturedResult: ReturnType<typeof useAssignments> | null = null;
+
+  const TestComponent = ({ filters }: { filters?: AssignmentQueryFilters }) => {
+    capturedResult = useAssignments(filters);
+    return null;
+  };
+
+  const flushPromises = () => new Promise(jest.requireActual('timers').setImmediate);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedResult = null;
+  });
+
+  it('fetches personal assignments by default with mobile params', async () => {
+    const mockData = [
+      { id: 'st-1', nomor: 'ST.001/BKSDA/2026', kegiatan: 'Patroli' },
+    ];
+
+    let resolvePromise: (value: unknown) => void = () => undefined;
+    const apiPromise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    (apiClient.get as jest.Mock).mockReturnValue(apiPromise);
+
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<TestComponent />);
+    });
+
+    expect(capturedResult?.isLoading).toBe(true);
+
+    await act(async () => {
+      resolvePromise({
+        data: {
+          data: mockData,
+          meta: { current_page: 1, last_page: 1 },
+        },
+      });
+      await flushPromises();
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      '/surat-tugas/my',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          mobile: true,
+          page: 1,
+          per_page: 20,
+        }),
+      })
+    );
+    expect(capturedResult?.items).toEqual(mockData);
+    expect(capturedResult?.isLoading).toBe(false);
+    expect(capturedResult?.hasNextPage).toBe(false);
+
+    act(() => {
+      tree.unmount();
+    });
+  });
+
+  it('fetches management assignments with search and status filters', async () => {
+    const mockData = [{ id: 'st-2', nomor: 'ST.002/BKSDA/2026', status: 'pending' }];
+
+    (apiClient.get as jest.Mock).mockResolvedValue({
+      data: {
+        data: mockData,
+        meta: { current_page: 1, last_page: 1 },
+      },
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <TestComponent filters={{ mode: 'management', search: 'patroli', status: 'pending' }} />
+      );
+      await flushPromises();
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      '/surat-tugas',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          search: 'patroli',
+          status: 'pending',
+          page: 1,
+        }),
+      })
+    );
+    expect(capturedResult?.items).toEqual(mockData);
+
+    act(() => {
+      tree.unmount();
+    });
+  });
+
+  it('appends next page results when fetchNextPage is called', async () => {
+    const pageOne = [{ id: 'st-1', nomor: 'ST.001/BKSDA/2026' }];
+    const pageTwo = [{ id: 'st-2', nomor: 'ST.002/BKSDA/2026' }];
+
+    (apiClient.get as jest.Mock).mockResolvedValueOnce({
+      data: {
+        data: pageOne,
+        meta: { current_page: 1, last_page: 2 },
+      },
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<TestComponent filters={{ mode: 'management' }} />);
+      await flushPromises();
+    });
+
+    expect(capturedResult?.hasNextPage).toBe(true);
+
+    (apiClient.get as jest.Mock).mockResolvedValueOnce({
+      data: {
+        data: pageTwo,
+        meta: { current_page: 2, last_page: 2 },
+      },
+    });
+
+    await act(async () => {
+      capturedResult?.fetchNextPage();
+      await flushPromises();
+    });
+
+    expect(apiClient.get).toHaveBeenLastCalledWith(
+      '/surat-tugas',
+      expect.objectContaining({
+        params: expect.objectContaining({ page: 2 }),
+      })
+    );
+    expect(capturedResult?.items).toEqual([...pageOne, ...pageTwo]);
+    expect(capturedResult?.hasNextPage).toBe(false);
+
+    act(() => {
+      tree.unmount();
+    });
+  });
+
+  it('sets refreshing state during manual refetch', async () => {
+    const mockData = [{ id: 'st-1', nomor: 'ST.001/BKSDA/2026' }];
+
+    (apiClient.get as jest.Mock).mockResolvedValue({
+      data: {
+        data: mockData,
+        meta: { current_page: 1, last_page: 1 },
+      },
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<TestComponent />);
+      await flushPromises();
+    });
+
+    let resolveRefetch: (value: unknown) => void = () => undefined;
+    const refetchPromise = new Promise((resolve) => {
+      resolveRefetch = resolve;
+    });
+    (apiClient.get as jest.Mock).mockReturnValue(refetchPromise);
+
+    act(() => {
+      capturedResult?.refetch();
+    });
+
+    expect(capturedResult?.isRefreshing).toBe(true);
+
+    await act(async () => {
+      resolveRefetch({
+        data: {
+          data: mockData,
+          meta: { current_page: 1, last_page: 1 },
+        },
+      });
+      await flushPromises();
+    });
+
+    expect(capturedResult?.isRefreshing).toBe(false);
+
+    act(() => {
+      tree.unmount();
+    });
+  });
+});

--- a/mobile/src/features/surat-tugas/useAssignments.ts
+++ b/mobile/src/features/surat-tugas/useAssignments.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { apiClient } from '@/lib/api/client';
+import { withMobileParams } from '@/lib/api/mobileParams';
+import { ApiError, ApiSuccess } from '@/types/api';
+import { AssignmentListItem, AssignmentQueryFilters } from './types';
+
+type LoadMode = 'initial' | 'refresh' | 'next';
+
+export interface UseAssignmentsResult {
+  items: AssignmentListItem[];
+  isLoading: boolean;
+  isRefreshing: boolean;
+  isFetchingNextPage: boolean;
+  error?: ApiError;
+  refetch: () => void;
+  fetchNextPage: () => void;
+  hasNextPage: boolean;
+}
+
+export function useAssignments(filters?: AssignmentQueryFilters): UseAssignmentsResult {
+  const [items, setItems] = useState<AssignmentListItem[]>([]);
+  const [page, setPage] = useState<number>(1);
+  const [hasNextPage, setHasNextPage] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
+  const [isFetchingNextPage, setIsFetchingNextPage] = useState<boolean>(false);
+  const [error, setError] = useState<ApiError | undefined>(undefined);
+
+  const prevFilterKeyRef = useRef<string>('');
+  const mode = filters?.mode ?? 'personal';
+
+  const filterKey = JSON.stringify({
+    mode,
+    search: filters?.search,
+    status: filters?.status,
+    employee_id: filters?.employee_id,
+    per_page: filters?.per_page,
+  });
+
+  const loadData = useCallback(
+    async (targetPage: number, loadMode: LoadMode) => {
+      if (loadMode === 'initial') {
+        setIsLoading(true);
+      } else if (loadMode === 'refresh') {
+        setIsRefreshing(true);
+      } else {
+        setIsFetchingNextPage(true);
+      }
+      setError(undefined);
+
+      try {
+        const endpoint = mode === 'personal' ? '/surat-tugas/my' : '/surat-tugas';
+        const queryParams = withMobileParams({
+          page: targetPage,
+          per_page: filters?.per_page,
+          search: filters?.search || undefined,
+          status: filters?.status || undefined,
+          employee_id: filters?.employee_id || undefined,
+        });
+
+        const response = await apiClient.get<ApiSuccess<AssignmentListItem[]>>(endpoint, {
+          params: queryParams,
+        });
+
+        const newItems = response.data.data || [];
+        const meta = response.data.meta;
+
+        setItems((previousItems) => (targetPage === 1 ? newItems : [...previousItems, ...newItems]));
+        setPage(targetPage);
+
+        if (meta && typeof meta.current_page === 'number' && typeof meta.last_page === 'number') {
+          setHasNextPage(meta.current_page < meta.last_page);
+        } else {
+          setHasNextPage(newItems.length >= (queryParams.per_page || 20));
+        }
+      } catch (err: unknown) {
+        setError(err as ApiError);
+      } finally {
+        setIsLoading(false);
+        setIsRefreshing(false);
+        setIsFetchingNextPage(false);
+      }
+    },
+    [filters, mode]
+  );
+
+  useEffect(() => {
+    if (prevFilterKeyRef.current !== filterKey) {
+      prevFilterKeyRef.current = filterKey;
+      loadData(1, 'initial');
+    }
+  }, [filterKey, loadData]);
+
+  const refetch = useCallback(() => {
+    loadData(1, 'refresh');
+  }, [loadData]);
+
+  const fetchNextPage = useCallback(() => {
+    if (!isFetchingNextPage && hasNextPage && !isLoading) {
+      loadData(page + 1, 'next');
+    }
+  }, [hasNextPage, isFetchingNextPage, isLoading, loadData, page]);
+
+  return {
+    items,
+    isLoading,
+    isRefreshing,
+    isFetchingNextPage,
+    error,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+  };
+}


### PR DESCRIPTION
Closes #444

## Summary
- Add useAssignments hook for personal and management Surat Tugas lists.
- Support mobile params, pagination, search, status filter, refresh, next-page loading, and error state.
- Add hook tests for default personal mode, management filters, pagination append, and refresh state.
- Mark Task 60 complete and update progress.md.

## Validation
- npm test -- --runTestsByPath src/features/surat-tugas/__tests__/useAssignments.test.tsx
- npm run typecheck
- npm run lint