### PR TITLE
feat(mobile): add AssignmentCard component (#446)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -977,7 +977,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: hook uses mobile params and pagination meta.
   - _Requirements: 11, 18_
 
-- [ ] 61. Add AssignmentCard component
+- [x] 61. Add AssignmentCard component
   - Target area: `mobile/src/features/surat-tugas/components/AssignmentCard.tsx`.
   - Show number, activity/destination, date range, status, and personel summary.
   - Acceptance check: status badge includes text.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,37 @@
+# Progress - Phase 104: Mobile Surat Tugas AssignmentCard Component
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-61`.
+> GitHub Issue: #446.
+
+---
+
+## Mobile Surat Tugas AssignmentCard Component
+
+### Status: SELESAI
+- Scope: Mobile App (Surat Tugas Module)
+- Tujuan: Menyediakan kartu presentational untuk daftar Surat Tugas mobile yang menampilkan nomor/fallback, kegiatan, tujuan, rentang tanggal, status, dan ringkasan personel dengan tap target aksesibel.
+
+### Implementasi
+- **Component**:
+  - Membuat [AssignmentCard.tsx](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/components/AssignmentCard.tsx) sebagai komponen presentational tanpa data fetching.
+  - Menampilkan `nomor` atau fallback "Belum bernomor", kegiatan/tujuan, tanggal mulai-selesai, `StatusBadge` tekstual, dan `personel_summary`.
+  - Menyediakan satu touch target utama dengan `accessibilityRole="button"` dan `accessibilityLabel` deskriptif.
+- **Tests**:
+  - Menambahkan [AssignmentCard.test.tsx](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/components/__tests__/AssignmentCard.test.tsx) untuk rendering summary, fallback label, status badge text, handler press, dan accessibility label.
+- **Checklist**:
+  - Mencentang Task 61 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/surat-tugas/components/__tests__/AssignmentCard.test.tsx`: 3 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 62: Build Surat Tugas list screen shell.
+
+---
+
 # Progress - Phase 103: Mobile Surat Tugas List API Hook
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/surat-tugas/components/AssignmentCard.tsx
+++ b/mobile/src/features/surat-tugas/components/AssignmentCard.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StatusBadge, StatusBadgeProps } from '@/components/StatusBadge';
+import { useAppTheme } from '@/hooks/useAppTheme';
+import { AssignmentListItem, AssignmentStatus } from '../types';
+
+interface AssignmentCardProps {
+  assignment: AssignmentListItem;
+  onPress: () => void;
+}
+
+function getStatusBadge(status?: AssignmentStatus | null): StatusBadgeProps {
+  switch (status) {
+    case 'approved':
+      return { text: 'Disetujui', status: 'success' };
+    case 'completed':
+      return { text: 'Selesai', status: 'success' };
+    case 'pending':
+      return { text: 'Menunggu', status: 'warning' };
+    case 'rejected':
+      return { text: 'Ditolak', status: 'danger' };
+    case 'draft':
+      return { text: 'Draft', status: 'neutral' };
+    default:
+      return { text: status || 'Belum Ada Status', status: 'neutral' };
+  }
+}
+
+function formatDateRange(start?: string | null, end?: string | null): string | null {
+  if (!start && !end) {
+    return null;
+  }
+
+  if (start && end && start !== end) {
+    return `${start} - ${end}`;
+  }
+
+  return start || end || null;
+}
+
+export default function AssignmentCard({ assignment, onPress }: AssignmentCardProps) {
+  const { colors, spacing, radius, typography } = useAppTheme();
+  const numberLabel = assignment.nomor || 'Belum bernomor';
+  const activityLabel = assignment.kegiatan || 'Kegiatan belum diisi';
+  const dateLabel = formatDateRange(assignment.tanggal_mulai, assignment.tanggal_selesai);
+  const statusBadge = getStatusBadge(assignment.status);
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      activeOpacity={0.72}
+      accessibilityRole="button"
+      accessibilityLabel={`Surat Tugas: ${numberLabel}. ${activityLabel}`}
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.card,
+          borderColor: colors.border,
+          borderRadius: radius.lg,
+          padding: spacing.lg,
+          marginBottom: spacing.md,
+        },
+      ]}
+    >
+      <View style={styles.header}>
+        <View style={styles.titleGroup}>
+          <Text
+            numberOfLines={1}
+            style={[
+              styles.number,
+              {
+                color: colors.mutedForeground,
+                fontFamily: typography.fontFamilies.sans,
+                fontSize: typography.fontSizes.sm,
+                fontWeight: typography.fontWeights.medium,
+              },
+            ]}
+          >
+            {numberLabel}
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={[
+              styles.activity,
+              {
+                color: colors.foreground,
+                fontFamily: typography.fontFamilies.sans,
+                fontSize: typography.fontSizes.md,
+                fontWeight: typography.fontWeights.bold,
+              },
+            ]}
+          >
+            {activityLabel}
+          </Text>
+        </View>
+        <StatusBadge text={statusBadge.text} status={statusBadge.status} />
+      </View>
+
+      {assignment.tujuan ? (
+        <Text
+          numberOfLines={2}
+          style={[
+            styles.metaText,
+            {
+              color: colors.mutedForeground,
+              fontFamily: typography.fontFamilies.sans,
+              fontSize: typography.fontSizes.sm,
+              marginTop: spacing.sm,
+            },
+          ]}
+        >
+          {`Tujuan: ${assignment.tujuan}`}
+        </Text>
+      ) : null}
+
+      {dateLabel ? (
+        <Text
+          style={[
+            styles.metaText,
+            {
+              color: colors.mutedForeground,
+              fontFamily: typography.fontFamilies.sans,
+              fontSize: typography.fontSizes.sm,
+              marginTop: spacing.xs,
+            },
+          ]}
+        >
+          {`Tanggal: ${dateLabel}`}
+        </Text>
+      ) : null}
+
+      {assignment.personel_summary ? (
+        <Text
+          numberOfLines={2}
+          style={[
+            styles.personelText,
+            {
+              color: colors.foreground,
+              fontFamily: typography.fontFamilies.sans,
+              fontSize: typography.fontSizes.sm,
+              marginTop: spacing.md,
+            },
+          ]}
+        >
+          {`Personel: ${assignment.personel_summary}`}
+        </Text>
+      ) : null}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 1,
+    minHeight: 96,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 1.5,
+    elevation: 1,
+  },
+  header: {
+    alignItems: 'flex-start',
+    flexDirection: 'row',
+    gap: 12,
+    justifyContent: 'space-between',
+  },
+  titleGroup: {
+    flex: 1,
+    minWidth: 0,
+  },
+  number: {
+    lineHeight: 18,
+  },
+  activity: {
+    lineHeight: 22,
+    marginTop: 2,
+  },
+  metaText: {
+    lineHeight: 20,
+  },
+  personelText: {
+    lineHeight: 20,
+  },
+});

--- a/mobile/src/features/surat-tugas/components/__tests__/AssignmentCard.test.tsx
+++ b/mobile/src/features/surat-tugas/components/__tests__/AssignmentCard.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { Text, TouchableOpacity } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+import AssignmentCard from '../AssignmentCard';
+
+jest.mock('@/hooks/useAppTheme', () => ({
+  useAppTheme: () => ({
+    isDark: false,
+    colors: {
+      card: '#ffffff',
+      border: '#e2e8f0',
+      foreground: '#09090b',
+      mutedForeground: '#64748b',
+    },
+    spacing: {
+      lg: 16,
+      md: 12,
+      sm: 8,
+      xs: 4,
+    },
+    radius: {
+      lg: 8,
+      full: 9999,
+    },
+    typography: {
+      fontFamilies: {
+        sans: 'System',
+      },
+      fontWeights: {
+        bold: '700',
+        medium: '500',
+      },
+      fontSizes: {
+        xs: 12,
+        sm: 14,
+        md: 16,
+      },
+    },
+  }),
+}));
+
+describe('AssignmentCard', () => {
+  const assignment = {
+    id: 'st-1',
+    nomor: 'ST.001/BKSDA/2026',
+    kegiatan: 'Patroli kawasan konservasi',
+    tujuan: 'Samarinda',
+    tanggal_mulai: '2026-06-20',
+    tanggal_selesai: '2026-06-21',
+    status: 'approved',
+    personel_summary: 'Pegawai Satu, Pegawai Dua',
+  };
+
+  it('renders assignment summary, date, status, and personel text', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<AssignmentCard assignment={assignment} onPress={jest.fn()} />);
+    });
+
+    const texts = tree!.root.findAllByType(Text).map((node) => node.props.children);
+
+    expect(texts).toContain('ST.001/BKSDA/2026');
+    expect(texts).toContain('Patroli kawasan konservasi');
+    expect(texts).toContain('Tujuan: Samarinda');
+    expect(texts).toContain('Tanggal: 2026-06-20 - 2026-06-21');
+    expect(texts).toContain('Disetujui');
+    expect(texts).toContain('Personel: Pegawai Satu, Pegawai Dua');
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('uses fallback labels when number and activity are missing', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <AssignmentCard
+          assignment={{
+            id: 'st-2',
+            status: 'draft',
+          }}
+          onPress={jest.fn()}
+        />
+      );
+    });
+
+    const texts = tree!.root.findAllByType(Text).map((node) => node.props.children);
+
+    expect(texts).toContain('Belum bernomor');
+    expect(texts).toContain('Kegiatan belum diisi');
+    expect(texts).toContain('Draft');
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('triggers onPress when card is pressed and exposes an accessible label', () => {
+    const handlePress = jest.fn();
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<AssignmentCard assignment={assignment} onPress={handlePress} />);
+    });
+
+    const touchable = tree!.root.findByType(TouchableOpacity);
+
+    expect(touchable.props.accessibilityRole).toBe('button');
+    expect(touchable.props.accessibilityLabel).toBe(
+      'Surat Tugas: ST.001/BKSDA/2026. Patroli kawasan konservasi'
+    );
+
+    act(() => {
+      touchable.props.onPress();
+    });
+
+    expect(handlePress).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+});


### PR DESCRIPTION
Closes #446

## Summary
- Add presentational AssignmentCard for mobile Surat Tugas lists.
- Render number/fallback, activity, destination, date range, textual status badge, and personel summary.
- Provide one accessible tap target with descriptive label.
- Add component tests for rendering, fallback, press behavior, and accessibility.
- Mark Task 61 complete and update progress.md.

## Validation
- npm test -- --runTestsByPath src/features/surat-tugas/components/__tests__/AssignmentCard.test.tsx
- npm run typecheck
- npm run lint