### PR TITLE
feat(mobile): build Surat Tugas list screen shell (#448)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -983,7 +983,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: status badge includes text.
   - _Requirements: 11, 20_
 
-- [ ] 62. Build Surat Tugas list screen shell
+- [x] 62. Build Surat Tugas list screen shell
   - Target area: `mobile/src/features/surat-tugas/AssignmentListScreen.tsx`.
   - Render header, search, status filter, and list.
   - Acceptance check: personal/management mode label is visible.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,38 @@
+# Progress - Phase 105: Mobile Surat Tugas List Screen Shell
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-62`.
+> GitHub Issue: #448.
+
+---
+
+## Mobile Surat Tugas List Screen Shell
+
+### Status: SELESAI
+- Scope: Mobile App (Surat Tugas Module)
+- Tujuan: Mengganti placeholder daftar Surat Tugas dengan screen shell yang menampilkan header, mode personal/manajemen, search, status filter, dan list card mobile.
+
+### Implementasi
+- **Screen Shell**:
+  - Memperbarui [SuratTugasListScreen.tsx](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/screens/SuratTugasListScreen.tsx) untuk memakai `useAssignments`, `AssignmentCard`, `SearchInput`, mode segmented controls, status chips, dan `FlatList`.
+  - Menampilkan label mode aktif ("Mode Personal" atau "Mode Manajemen") secara eksplisit.
+  - Mode manajemen hanya muncul bila user memiliki akses modul `surat_tugas` atau `kepegawaian`.
+  - Memakai `SafeAreaView` dari `react-native-safe-area-context` agar tidak menambah warning deprecation baru.
+- **Tests**:
+  - Menambahkan [SuratTugasListScreen.test.tsx](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx) untuk header, mode label, search, status filters, card rendering, mode switch, dan debounce search.
+- **Checklist**:
+  - Mencentang Task 62 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx`: 3 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 63: Add Surat Tugas list pagination and states.
+
+---
+
 # Progress - Phase 104: Mobile Surat Tugas AssignmentCard Component
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/surat-tugas/screens/SuratTugasListScreen.tsx
+++ b/mobile/src/features/surat-tugas/screens/SuratTugasListScreen.tsx
@@ -1,27 +1,242 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { SearchInput } from '@/components/SearchInput';
 import { useAppTheme } from '@/hooks/useAppTheme';
+import { usePermissions } from '@/lib/permissions';
+import AssignmentCard from '../components/AssignmentCard';
+import { useAssignments } from '../useAssignments';
+import { AssignmentListItem, AssignmentListMode, AssignmentStatus } from '../types';
+
+type StatusFilter = 'all' | Extract<AssignmentStatus, 'pending' | 'approved' | 'completed' | 'rejected'>;
+
+const statusFilters: { label: string; value: StatusFilter }[] = [
+  { label: 'Semua', value: 'all' },
+  { label: 'Menunggu', value: 'pending' },
+  { label: 'Disetujui', value: 'approved' },
+  { label: 'Selesai', value: 'completed' },
+  { label: 'Ditolak', value: 'rejected' },
+];
 
 export default function SuratTugasListScreen() {
-  const { colors, spacing } = useAppTheme();
+  const { colors, spacing, radius, typography } = useAppTheme();
+  const { hasModule } = usePermissions();
+  const canUseManagementMode = hasModule('surat_tugas') || hasModule('kepegawaian');
+  const [mode, setMode] = React.useState<AssignmentListMode>('personal');
+  const [search, setSearch] = React.useState('');
+  const [debouncedSearch, setDebouncedSearch] = React.useState('');
+  const [status, setStatus] = React.useState<StatusFilter>('all');
+  const activeMode: AssignmentListMode = canUseManagementMode ? mode : 'personal';
+
+  React.useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedSearch(search);
+    }, 400);
+
+    return () => clearTimeout(timeoutId);
+  }, [search]);
+
+  const { items } = useAssignments({
+    mode: activeMode,
+    search: debouncedSearch,
+    status: status === 'all' ? undefined : status,
+  });
+
+  const renderAssignment = ({ item }: { item: AssignmentListItem }) => (
+    <AssignmentCard assignment={item} onPress={() => undefined} />
+  );
+
+  const modeLabel = activeMode === 'personal' ? 'Mode Personal' : 'Mode Manajemen';
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background, padding: spacing.lg }]}>
-      <Text style={[styles.title, { color: colors.foreground }]}>Daftar Surat Tugas</Text>
-      <Text style={{ color: colors.mutedForeground }}>Kelola surat tugas Anda di sini.</Text>
-    </View>
+    <SafeAreaView style={[styles.safeArea, { backgroundColor: colors.background }]}>
+      <View style={[styles.container, { paddingHorizontal: spacing.lg, paddingTop: spacing.md }]}>
+        <View style={[styles.header, { marginBottom: spacing.lg }]}>
+          <Text
+            style={[
+              styles.title,
+              {
+                color: colors.foreground,
+                fontFamily: typography.fontFamilies.sans,
+                fontSize: typography.fontSizes.xl,
+                fontWeight: typography.fontWeights.bold,
+              },
+            ]}
+          >
+            Surat Tugas
+          </Text>
+          <Text
+            style={[
+              styles.subtitle,
+              {
+                color: colors.mutedForeground,
+                fontFamily: typography.fontFamilies.sans,
+                fontSize: typography.fontSizes.sm,
+                marginTop: spacing.xs,
+              },
+            ]}
+          >
+            {modeLabel}
+          </Text>
+        </View>
+
+        <View style={[styles.modeRow, { marginBottom: spacing.md }]}>
+          <TouchableOpacity
+            onPress={() => setMode('personal')}
+            accessibilityRole="button"
+            accessibilityLabel="Tampilkan surat tugas personal"
+            style={[
+              styles.modeButton,
+              {
+                backgroundColor: activeMode === 'personal' ? colors.primary : colors.card,
+                borderColor: activeMode === 'personal' ? colors.primary : colors.border,
+                borderRadius: radius.lg,
+              },
+            ]}
+          >
+            <Text
+              style={[
+                styles.modeText,
+                {
+                  color: activeMode === 'personal' ? colors.primaryForeground : colors.foreground,
+                  fontSize: typography.fontSizes.sm,
+                  fontWeight: typography.fontWeights.semibold,
+                },
+              ]}
+            >
+              Personal
+            </Text>
+          </TouchableOpacity>
+
+          {canUseManagementMode ? (
+            <TouchableOpacity
+              onPress={() => setMode('management')}
+              accessibilityRole="button"
+              accessibilityLabel="Tampilkan surat tugas manajemen"
+              style={[
+                styles.modeButton,
+                {
+                  backgroundColor: activeMode === 'management' ? colors.primary : colors.card,
+                  borderColor: activeMode === 'management' ? colors.primary : colors.border,
+                  borderRadius: radius.lg,
+                  marginLeft: spacing.sm,
+                },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.modeText,
+                  {
+                    color: activeMode === 'management' ? colors.primaryForeground : colors.foreground,
+                    fontSize: typography.fontSizes.sm,
+                    fontWeight: typography.fontWeights.semibold,
+                  },
+                ]}
+              >
+                Manajemen
+              </Text>
+            </TouchableOpacity>
+          ) : null}
+        </View>
+
+        <View style={{ marginBottom: spacing.md }}>
+          <SearchInput
+            value={search}
+            onChangeText={setSearch}
+            placeholder="Cari nomor, kegiatan, atau tujuan..."
+            accessibilityLabel="Cari surat tugas"
+            onClear={() => setSearch('')}
+          />
+        </View>
+
+        <View style={[styles.statusRow, { marginBottom: spacing.md }]}>
+          {statusFilters.map((option) => {
+            const isActive = option.value === status;
+            return (
+              <TouchableOpacity
+                key={option.value}
+                onPress={() => setStatus(option.value)}
+                accessibilityRole="button"
+                accessibilityLabel={`Filter status ${option.label}`}
+                style={[
+                  styles.statusChip,
+                  {
+                    backgroundColor: isActive ? colors.primary : colors.card,
+                    borderColor: isActive ? colors.primary : colors.border,
+                    borderRadius: radius.full,
+                    marginRight: spacing.sm,
+                  },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.statusText,
+                    {
+                      color: isActive ? colors.primaryForeground : colors.mutedForeground,
+                      fontSize: typography.fontSizes.sm,
+                      fontWeight: typography.fontWeights.medium,
+                    },
+                  ]}
+                >
+                  {option.label}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+
+        <FlatList
+          data={items}
+          renderItem={renderAssignment}
+          keyExtractor={(item) => String(item.id)}
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{ paddingBottom: spacing.xl * 2 }}
+        />
+      </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+  },
   container: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
   },
+  header: {},
   title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 8,
+    lineHeight: 28,
+  },
+  subtitle: {
+    lineHeight: 20,
+  },
+  modeRow: {
+    flexDirection: 'row',
+  },
+  modeButton: {
+    alignItems: 'center',
+    borderWidth: 1,
+    justifyContent: 'center',
+    minHeight: 48,
+    paddingHorizontal: 16,
+  },
+  modeText: {
+    lineHeight: 20,
+  },
+  statusRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    rowGap: 8,
+  },
+  statusChip: {
+    alignItems: 'center',
+    borderWidth: 1,
+    justifyContent: 'center',
+    minHeight: 40,
+    paddingHorizontal: 12,
+  },
+  statusText: {
+    lineHeight: 20,
   },
 });

--- a/mobile/src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx
+++ b/mobile/src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { Text, TouchableOpacity } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+import SuratTugasListScreen from '../SuratTugasListScreen';
+import { useAssignments } from '../../useAssignments';
+
+jest.mock('@/hooks/useAppTheme', () => ({
+  useAppTheme: () => ({
+    isDark: false,
+    colors: {
+      background: '#ffffff',
+      primary: '#16a34a',
+      primaryForeground: '#ffffff',
+      foreground: '#09090b',
+      card: '#ffffff',
+      border: '#e2e8f0',
+      mutedForeground: '#64748b',
+    },
+    spacing: {
+      xs: 4,
+      sm: 8,
+      md: 12,
+      lg: 16,
+      xl: 20,
+    },
+    radius: {
+      lg: 8,
+      full: 9999,
+    },
+    typography: {
+      fontFamilies: {
+        sans: 'System',
+      },
+      fontWeights: {
+        bold: '700',
+        semibold: '600',
+        medium: '500',
+      },
+      fontSizes: {
+        xs: 12,
+        sm: 14,
+        md: 16,
+        xl: 20,
+      },
+    },
+  }),
+}));
+
+jest.mock('@/lib/permissions', () => ({
+  usePermissions: jest.fn(() => ({
+    hasModule: (moduleName: string) => moduleName === 'surat_tugas',
+  })),
+}));
+
+jest.mock('../../useAssignments', () => ({
+  useAssignments: jest.fn(),
+}));
+
+describe('SuratTugasListScreen', () => {
+  const mockAssignments = [
+    {
+      id: 'st-1',
+      nomor: 'ST.001/BKSDA/2026',
+      kegiatan: 'Patroli kawasan',
+      tujuan: 'Samarinda',
+      tanggal_mulai: '2026-06-20',
+      tanggal_selesai: '2026-06-21',
+      status: 'approved',
+      personel_summary: 'Pegawai Satu',
+    },
+  ];
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    (useAssignments as jest.Mock).mockReturnValue({
+      items: mockAssignments,
+      isLoading: false,
+      isRefreshing: false,
+      isFetchingNextPage: false,
+      error: undefined,
+      refetch: jest.fn(),
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('renders header, personal mode label, search, status filters, and cards', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SuratTugasListScreen />);
+    });
+
+    const texts = tree!.root.findAllByType(Text).map((node) => node.props.children);
+
+    expect(texts).toContain('Surat Tugas');
+    expect(texts).toContain('Mode Personal');
+    expect(texts).toContain('Personal');
+    expect(texts).toContain('Manajemen');
+    expect(texts).toContain('Semua');
+    expect(texts).toContain('Menunggu');
+    expect(texts).toContain('ST.001/BKSDA/2026');
+    expect(texts).toContain('Patroli kawasan');
+
+    const searchInput = tree!.root.findByProps({ placeholder: 'Cari nomor, kegiatan, atau tujuan...' });
+    expect(searchInput).toBeTruthy();
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('switches to management mode when the management control is pressed', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SuratTugasListScreen />);
+    });
+
+    const managementButton = tree!.root
+      .findAllByType(TouchableOpacity)
+      .find((node) => node.props.accessibilityLabel === 'Tampilkan surat tugas manajemen');
+
+    act(() => {
+      managementButton?.props.onPress();
+    });
+
+    expect(useAssignments).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        mode: 'management',
+      })
+    );
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('debounces search before passing it to useAssignments', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SuratTugasListScreen />);
+    });
+
+    (useAssignments as jest.Mock).mockClear();
+
+    const searchInput = tree!.root.findByProps({ placeholder: 'Cari nomor, kegiatan, atau tujuan...' });
+    act(() => {
+      searchInput.props.onChangeText('patroli');
+    });
+
+    expect(useAssignments).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        search: '',
+      })
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+
+    expect(useAssignments).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        search: 'patroli',
+      })
+    );
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+});


### PR DESCRIPTION
Closes #448

## Summary
- Replace the Surat Tugas placeholder with a mobile list shell.
- Add header, explicit personal/management mode label, mode controls, search, status filters, and AssignmentCard FlatList rendering.
- Gate management mode by surat_tugas/kepegawaian module access.
- Use react-native-safe-area-context SafeAreaView to avoid adding RN SafeAreaView deprecation warnings.
- Mark Task 62 complete and update progress.md.

## Validation
- npm test -- --runTestsByPath src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx
- npm run typecheck
- npm run lint