### PR TITLE
feat(mobile): add Surat Tugas list states and pagination (#450)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -989,7 +989,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: personal/management mode label is visible.
   - _Requirements: 11, 20_
 
-- [ ] 63. Add Surat Tugas list pagination and states
+- [x] 63. Add Surat Tugas list pagination and states
   - Target area: assignment list screen.
   - Add pagination, loading skeleton, empty, error, retry, and pull-to-refresh.
   - Acceptance check: empty state is different from error state.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,39 @@
+# Progress - Phase 106: Mobile Surat Tugas List Pagination and States
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-63`.
+> GitHub Issue: #450.
+
+---
+
+## Mobile Surat Tugas List Pagination and States
+
+### Status: SELESAI
+- Scope: Mobile App (Surat Tugas Module)
+- Tujuan: Melengkapi screen daftar Surat Tugas dengan loading skeleton, empty state, error state + retry, pull-to-refresh, dan infinite pagination footer.
+
+### Implementasi
+- **Screen States**:
+  - Memperbarui [SuratTugasListScreen.tsx](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/screens/SuratTugasListScreen.tsx) agar memakai state lengkap dari `useAssignments`.
+  - Menambahkan `LoadingSkeleton` saat initial load, `ErrorState` khusus saat gagal memuat, dan `EmptyState` berbeda saat data kosong.
+- **Pagination & Refresh**:
+  - Menghubungkan `FlatList` ke `refreshing`, `onRefresh`, `onEndReached`, dan `ListFooterComponent`.
+  - Menampilkan `ActivityIndicator` footer saat `isFetchingNextPage` aktif.
+- **Tests**:
+  - Memperluas [SuratTugasListScreen.test.tsx](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx) untuk loading skeleton, empty state, error retry, pull-to-refresh, pagination trigger, dan footer spinner.
+- **Checklist**:
+  - Mencentang Task 63 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx`: 7 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 64: Add Surat Tugas detail API hook.
+
+---
+
 # Progress - Phase 105: Mobile Surat Tugas List Screen Shell
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/surat-tugas/screens/SuratTugasListScreen.tsx
+++ b/mobile/src/features/surat-tugas/screens/SuratTugasListScreen.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
-import { FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { EmptyState } from '@/components/EmptyState';
+import { ErrorState } from '@/components/ErrorState';
+import { LoadingSkeleton } from '@/components/LoadingSkeleton';
 import { SearchInput } from '@/components/SearchInput';
 import { useAppTheme } from '@/hooks/useAppTheme';
 import { usePermissions } from '@/lib/permissions';
@@ -36,7 +39,15 @@ export default function SuratTugasListScreen() {
     return () => clearTimeout(timeoutId);
   }, [search]);
 
-  const { items } = useAssignments({
+  const {
+    items,
+    isLoading,
+    isRefreshing,
+    isFetchingNextPage,
+    error,
+    refetch,
+    fetchNextPage,
+  } = useAssignments({
     mode: activeMode,
     search: debouncedSearch,
     status: status === 'all' ? undefined : status,
@@ -45,6 +56,66 @@ export default function SuratTugasListScreen() {
   const renderAssignment = ({ item }: { item: AssignmentListItem }) => (
     <AssignmentCard assignment={item} onPress={() => undefined} />
   );
+
+  const renderFooter = () => {
+    if (!isFetchingNextPage) {
+      return null;
+    }
+
+    return (
+      <View style={[styles.footer, { paddingVertical: spacing.md }]}>
+        <ActivityIndicator color={colors.primary} size="small" />
+      </View>
+    );
+  };
+
+  const renderContent = () => {
+    if (isLoading && items.length === 0) {
+      return (
+        <View style={[styles.stateContainer, { paddingTop: spacing.md }]}>
+          <LoadingSkeleton variant="card" count={3} />
+        </View>
+      );
+    }
+
+    if (error && items.length === 0) {
+      return (
+        <View style={styles.stateContainer}>
+          <ErrorState
+            title="Gagal Memuat Surat Tugas"
+            message={error.message || 'Terjadi kesalahan saat mengambil daftar surat tugas.'}
+            onRetry={refetch}
+          />
+        </View>
+      );
+    }
+
+    if (items.length === 0) {
+      return (
+        <View style={styles.stateContainer}>
+          <EmptyState
+            title="Tidak Ada Surat Tugas"
+            message="Surat tugas tidak ditemukan. Coba ubah mode, status, atau kata kunci pencarian."
+          />
+        </View>
+      );
+    }
+
+    return (
+      <FlatList
+        data={items}
+        renderItem={renderAssignment}
+        keyExtractor={(item) => String(item.id)}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: spacing.xl * 2 }}
+        refreshing={isRefreshing}
+        onRefresh={refetch}
+        onEndReached={fetchNextPage}
+        onEndReachedThreshold={0.5}
+        ListFooterComponent={renderFooter}
+      />
+    );
+  };
 
   const modeLabel = activeMode === 'personal' ? 'Mode Personal' : 'Mode Manajemen';
 
@@ -185,13 +256,7 @@ export default function SuratTugasListScreen() {
           })}
         </View>
 
-        <FlatList
-          data={items}
-          renderItem={renderAssignment}
-          keyExtractor={(item) => String(item.id)}
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={{ paddingBottom: spacing.xl * 2 }}
-        />
+        {renderContent()}
       </View>
     </SafeAreaView>
   );
@@ -238,5 +303,13 @@ const styles = StyleSheet.create({
   },
   statusText: {
     lineHeight: 20,
+  },
+  stateContainer: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  footer: {
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/mobile/src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx
+++ b/mobile/src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, TouchableOpacity } from 'react-native';
+import { ActivityIndicator, FlatList, Text, TouchableOpacity } from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 import SuratTugasListScreen from '../SuratTugasListScreen';
 import { useAssignments } from '../../useAssignments';
@@ -69,6 +69,8 @@ describe('SuratTugasListScreen', () => {
       personel_summary: 'Pegawai Satu',
     },
   ];
+  const mockRefetch = jest.fn();
+  const mockFetchNextPage = jest.fn();
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -79,8 +81,8 @@ describe('SuratTugasListScreen', () => {
       isRefreshing: false,
       isFetchingNextPage: false,
       error: undefined,
-      refetch: jest.fn(),
-      fetchNextPage: jest.fn(),
+      refetch: mockRefetch,
+      fetchNextPage: mockFetchNextPage,
       hasNextPage: false,
     });
   });
@@ -168,6 +170,121 @@ describe('SuratTugasListScreen', () => {
         search: 'patroli',
       })
     );
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('renders loading skeleton when initial list is loading', () => {
+    (useAssignments as jest.Mock).mockReturnValue({
+      items: [],
+      isLoading: true,
+      isRefreshing: false,
+      isFetchingNextPage: false,
+      error: undefined,
+      refetch: mockRefetch,
+      fetchNextPage: mockFetchNextPage,
+      hasNextPage: false,
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SuratTugasListScreen />);
+    });
+
+    const skeleton = tree!.root.findByProps({ variant: 'card' });
+    expect(skeleton.props.count).toBe(3);
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('renders error state separately from empty state and retries', () => {
+    (useAssignments as jest.Mock).mockReturnValue({
+      items: [],
+      isLoading: false,
+      isRefreshing: false,
+      isFetchingNextPage: false,
+      error: { message: 'Gagal dari server' },
+      refetch: mockRefetch,
+      fetchNextPage: mockFetchNextPage,
+      hasNextPage: false,
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SuratTugasListScreen />);
+    });
+
+    const errorState = tree!.root.findByProps({ title: 'Gagal Memuat Surat Tugas' });
+    expect(errorState.props.message).toBe('Gagal dari server');
+
+    act(() => {
+      errorState.props.onRetry();
+    });
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('renders empty state when there are no assignments', () => {
+    (useAssignments as jest.Mock).mockReturnValue({
+      items: [],
+      isLoading: false,
+      isRefreshing: false,
+      isFetchingNextPage: false,
+      error: undefined,
+      refetch: mockRefetch,
+      fetchNextPage: mockFetchNextPage,
+      hasNextPage: false,
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SuratTugasListScreen />);
+    });
+
+    const emptyState = tree!.root.findByProps({ title: 'Tidak Ada Surat Tugas' });
+    expect(emptyState.props.message).toContain('Surat tugas tidak ditemukan');
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('wires pull-to-refresh and next-page loading to FlatList', () => {
+    (useAssignments as jest.Mock).mockReturnValue({
+      items: mockAssignments,
+      isLoading: false,
+      isRefreshing: true,
+      isFetchingNextPage: true,
+      error: undefined,
+      refetch: mockRefetch,
+      fetchNextPage: mockFetchNextPage,
+      hasNextPage: true,
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SuratTugasListScreen />);
+    });
+
+    const list = tree!.root.findByType(FlatList);
+    expect(list.props.refreshing).toBe(true);
+
+    act(() => {
+      list.props.onRefresh();
+      list.props.onEndReached();
+    });
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+    expect(mockFetchNextPage).toHaveBeenCalledTimes(1);
+    expect(tree!.root.findByType(ActivityIndicator)).toBeTruthy();
 
     act(() => {
       tree!.unmount();


### PR DESCRIPTION
Closes #450

## Summary
- Add loading skeleton, empty state, and error state with retry to the Surat Tugas list screen.
- Wire FlatList pull-to-refresh, onEndReached pagination, and next-page footer spinner.
- Expand screen tests for loading, error, empty, refresh, pagination, and footer states.
- Mark Task 63 complete and update progress.md.

## Validation
- npm test -- --runTestsByPath src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx
- npm run typecheck
- npm run lint