### PR TITLE
feat(mobile): add Surat Tugas detail hook (#452)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -995,7 +995,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: empty state is different from error state.
   - _Requirements: 11, 17, 18, 20_
 
-- [ ] 64. Add Surat Tugas detail API hook
+- [x] 64. Add Surat Tugas detail API hook
   - Target area: `mobile/src/features/surat-tugas/useAssignmentDetail.ts`.
   - Fetch detail by id.
   - Acceptance check: hook exposes loading, detail, forbidden, not found, and refetch.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,38 @@
+# Progress - Phase 107: Mobile Surat Tugas Detail API Hook
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-64`.
+> GitHub Issue: #452.
+
+---
+
+## Mobile Surat Tugas Detail API Hook
+
+### Status: SELESAI
+- Scope: Mobile App (Surat Tugas Module)
+- Tujuan: Menyediakan hook detail Surat Tugas yang mengambil data berdasarkan ID, mendukung endpoint personal/manajemen, normalized forbidden/not-found states, dan refetch.
+
+### Implementasi
+- **Hook**:
+  - Membuat [useAssignmentDetail.ts](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/useAssignmentDetail.ts).
+  - Mode `personal` memakai endpoint `/surat-tugas/my/{id}`; mode `management` memakai `/surat-tugas/{id}`.
+  - Menambahkan `isForbidden` dan `isNotFound` berbasis normalized API error untuk memudahkan screen detail berikutnya.
+  - Menghindari request saat `id` belum tersedia.
+- **Tests**:
+  - Menambahkan [useAssignmentDetail.test.tsx](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/__tests__/useAssignmentDetail.test.tsx) untuk success personal, success management, 403 forbidden, 404 not found, refetch, dan missing ID.
+- **Checklist**:
+  - Mencentang Task 64 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/surat-tugas/__tests__/useAssignmentDetail.test.tsx`: 6 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 65: Build Surat Tugas detail sections.
+
+---
+
 # Progress - Phase 106: Mobile Surat Tugas List Pagination and States
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/surat-tugas/__tests__/useAssignmentDetail.test.tsx
+++ b/mobile/src/features/surat-tugas/__tests__/useAssignmentDetail.test.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { apiClient } from '@/lib/api/client';
+import { useAssignmentDetail } from '../useAssignmentDetail';
+
+jest.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+  },
+}));
+
+describe('useAssignmentDetail', () => {
+  let capturedResult: ReturnType<typeof useAssignmentDetail> | null = null;
+
+  const TestComponent = ({
+    id,
+    mode,
+  }: {
+    id?: string | number;
+    mode?: 'personal' | 'management';
+  }) => {
+    capturedResult = useAssignmentDetail(id, mode);
+    return null;
+  };
+
+  const flushPromises = () => new Promise(jest.requireActual('timers').setImmediate);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedResult = null;
+  });
+
+  it('fetches personal assignment detail by default', async () => {
+    const detail = {
+      id: 'st-1',
+      nomor: 'ST.001/BKSDA/2026',
+      kegiatan: 'Patroli kawasan',
+      personel: [],
+      file: { available: true, download_url: '/api/surat-tugas/my/st-1/download' },
+      allowed_actions: { can_view: true, can_download: true },
+    };
+
+    (apiClient.get as jest.Mock).mockResolvedValue({
+      data: { data: detail },
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<TestComponent id="st-1" />);
+      await flushPromises();
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith('/surat-tugas/my/st-1', {
+      params: { mobile: true },
+    });
+    expect(capturedResult?.data).toEqual(detail);
+    expect(capturedResult?.isLoading).toBe(false);
+    expect(capturedResult?.isForbidden).toBe(false);
+    expect(capturedResult?.isNotFound).toBe(false);
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('fetches management assignment detail when requested', async () => {
+    const detail = {
+      id: 'st-2',
+      nomor: 'ST.002/BKSDA/2026',
+      kegiatan: 'Monitoring',
+      personel: [],
+      file: { available: false },
+      allowed_actions: { can_view: true, can_update: true },
+    };
+
+    (apiClient.get as jest.Mock).mockResolvedValue({
+      data: { data: detail },
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<TestComponent id="st-2" mode="management" />);
+      await flushPromises();
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith('/surat-tugas/st-2', {
+      params: { mobile: true },
+    });
+    expect(capturedResult?.data).toEqual(detail);
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('exposes forbidden state on 403 error', async () => {
+    (apiClient.get as jest.Mock).mockRejectedValue({
+      response: {
+        status: 403,
+        data: { message: 'Anda tidak memiliki akses ke Surat Tugas ini.' },
+      },
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<TestComponent id="st-forbidden" />);
+      await flushPromises();
+    });
+
+    expect(capturedResult?.data).toBeUndefined();
+    expect(capturedResult?.isForbidden).toBe(true);
+    expect(capturedResult?.isNotFound).toBe(false);
+    expect(capturedResult?.error).toEqual(
+      expect.objectContaining({
+        status: 403,
+        kind: 'forbidden',
+      })
+    );
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('exposes not-found state on 404 error', async () => {
+    (apiClient.get as jest.Mock).mockRejectedValue({
+      response: {
+        status: 404,
+        data: { message: 'Data tidak ditemukan.' },
+      },
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<TestComponent id="missing" mode="management" />);
+      await flushPromises();
+    });
+
+    expect(capturedResult?.isForbidden).toBe(false);
+    expect(capturedResult?.isNotFound).toBe(true);
+    expect(capturedResult?.error).toEqual(
+      expect.objectContaining({
+        status: 404,
+        kind: 'not_found',
+      })
+    );
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('refetches detail on demand', async () => {
+    const detail = {
+      id: 'st-1',
+      nomor: 'ST.001/BKSDA/2026',
+      personel: [],
+      file: { available: false },
+      allowed_actions: { can_view: true },
+    };
+
+    (apiClient.get as jest.Mock).mockResolvedValue({
+      data: { data: detail },
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<TestComponent id="st-1" />);
+      await flushPromises();
+    });
+
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      capturedResult?.refetch();
+      await flushPromises();
+    });
+
+    expect(apiClient.get).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('does not fetch when id is missing', async () => {
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<TestComponent />);
+      await flushPromises();
+    });
+
+    expect(apiClient.get).not.toHaveBeenCalled();
+    expect(capturedResult?.isLoading).toBe(false);
+    expect(capturedResult?.data).toBeUndefined();
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+});

--- a/mobile/src/features/surat-tugas/useAssignmentDetail.ts
+++ b/mobile/src/features/surat-tugas/useAssignmentDetail.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useState } from 'react';
+import { apiClient } from '@/lib/api/client';
+import { normalizeError } from '@/lib/api/errors';
+import { ApiError, ApiSuccess } from '@/types/api';
+import { AssignmentDetail, AssignmentListMode } from './types';
+
+export interface UseAssignmentDetailResult {
+  data?: AssignmentDetail;
+  isLoading: boolean;
+  error?: ApiError;
+  refetch: () => void;
+  isForbidden: boolean;
+  isNotFound: boolean;
+}
+
+export function useAssignmentDetail(
+  id?: string | number,
+  mode: AssignmentListMode = 'personal'
+): UseAssignmentDetailResult {
+  const [data, setData] = useState<AssignmentDetail | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState<boolean>(!!id);
+  const [error, setError] = useState<ApiError | undefined>(undefined);
+
+  const loadData = useCallback(async () => {
+    if (!id) {
+      setData(undefined);
+      setError(undefined);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(undefined);
+
+    try {
+      const endpoint = mode === 'personal' ? `/surat-tugas/my/${id}` : `/surat-tugas/${id}`;
+      const response = await apiClient.get<ApiSuccess<AssignmentDetail>>(endpoint, {
+        params: { mobile: true },
+      });
+      setData(response.data.data);
+    } catch (err: unknown) {
+      setData(undefined);
+      setError(normalizeError(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [id, mode]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    loadData();
+  }, [loadData]);
+
+  return {
+    data,
+    isLoading,
+    error,
+    refetch: loadData,
+    isForbidden: error?.kind === 'forbidden' || error?.status === 403,
+    isNotFound: error?.kind === 'not_found' || error?.status === 404,
+  };
+}


### PR DESCRIPTION
Closes #452

## Summary
- Add useAssignmentDetail hook for personal and management Surat Tugas detail endpoints.
- Expose loading, detail data, normalized error, forbidden/not-found flags, and refetch.
- Avoid fetching when the id is not available.
- Add hook tests for success, 403, 404, refetch, and missing id.
- Mark Task 64 complete and update progress.md.

## Validation
- npm test -- --runTestsByPath src/features/surat-tugas/__tests__/useAssignmentDetail.test.tsx
- npm run typecheck
- npm run lint