### PR TITLE
feat(mobile): build Surat Tugas detail sections (#454)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1001,7 +1001,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: hook exposes loading, detail, forbidden, not found, and refetch.
   - _Requirements: 11, 17_
 
-- [ ] 65. Build Surat Tugas detail sections
+- [x] 65. Build Surat Tugas detail sections
   - Target area: `mobile/src/features/surat-tugas/components/detail`.
   - Create summary, dates, personel, content, file, and status sections.
   - Acceptance check: long content is readable without horizontal scroll.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,44 @@
+# Progress - Phase 108: Mobile Surat Tugas Detail Sections
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-65`.
+> GitHub Issue: #454.
+
+---
+
+## Mobile Surat Tugas Detail Sections
+
+### Status: SELESAI
+- Scope: Mobile App (Surat Tugas Module)
+- Tujuan: Menyediakan komponen presentational untuk detail Surat Tugas: summary, dates, personel, content, file, dan status sections.
+
+### Implementasi
+- **Components**:
+  - Membuat komponen detail di [mobile/src/features/surat-tugas/components/detail](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/components/detail):
+    - `AssignmentSummarySection`
+    - `AssignmentDatesSection`
+    - `AssignmentPersonelSection`
+    - `AssignmentContentSection`
+    - `AssignmentFileSection`
+    - `AssignmentStatusSection`
+    - `DetailRow` helper dan `index.ts` barrel export.
+  - Komponen bersifat presentational, menerima `AssignmentDetail`, dan tidak melakukan data fetching.
+  - Konten panjang seperti `dasar_hukum` dirender sebagai multiline text agar readable di layar kecil tanpa horizontal scroll.
+- **Tests**:
+  - Menambahkan [detailSections.test.tsx](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/components/detail/__tests__/detailSections.test.tsx) untuk seluruh section, fallback personel kosong, file state, allowed action badges, dan long content.
+- **Checklist**:
+  - Mencentang Task 65 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/surat-tugas/components/detail/__tests__/detailSections.test.tsx`: 7 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 66: Build Surat Tugas detail screen.
+
+---
+
 # Progress - Phase 107: Mobile Surat Tugas Detail API Hook
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/surat-tugas/components/detail/AssignmentContentSection.tsx
+++ b/mobile/src/features/surat-tugas/components/detail/AssignmentContentSection.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+import { SectionCard } from '@/components/SectionCard';
+import { useAppTheme } from '@/hooks/useAppTheme';
+import { AssignmentDetail } from '../../types';
+import { DetailRow } from './DetailRow';
+
+interface AssignmentContentSectionProps {
+  assignment: AssignmentDetail;
+}
+
+export function AssignmentContentSection({ assignment }: AssignmentContentSectionProps) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  return (
+    <SectionCard title="Isi Surat">
+      <DetailRow label="Kegiatan" value={assignment.kegiatan || '-'} />
+      <DetailRow label="Dasar Hukum" value={assignment.dasar_hukum || '-'} />
+      <Text
+        style={[
+          styles.longText,
+          {
+            color: colors.foreground,
+            fontSize: typography.fontSizes.sm,
+            marginTop: spacing.xs,
+          },
+        ]}
+      >
+        {assignment.dasar_hukum || 'Dasar hukum belum diisi.'}
+      </Text>
+      <DetailRow label="Sumber Dana" value={assignment.sumber_dana || '-'} />
+      <DetailRow label="Template" value={assignment.template_type || '-'} />
+    </SectionCard>
+  );
+}
+
+const styles = StyleSheet.create({
+  longText: {
+    flexShrink: 1,
+    lineHeight: 22,
+  },
+});

--- a/mobile/src/features/surat-tugas/components/detail/AssignmentDatesSection.tsx
+++ b/mobile/src/features/surat-tugas/components/detail/AssignmentDatesSection.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { SectionCard } from '@/components/SectionCard';
+import { AssignmentDetail } from '../../types';
+import { DetailRow } from './DetailRow';
+
+interface AssignmentDatesSectionProps {
+  assignment: AssignmentDetail;
+}
+
+export function AssignmentDatesSection({ assignment }: AssignmentDatesSectionProps) {
+  return (
+    <SectionCard title="Tanggal & Tujuan">
+      <DetailRow label="Tanggal Surat" value={assignment.tanggal_surat || '-'} />
+      <DetailRow label="Tanggal Mulai" value={assignment.tanggal_mulai || '-'} />
+      <DetailRow label="Tanggal Selesai" value={assignment.tanggal_selesai || '-'} />
+      <DetailRow label="Tujuan" value={assignment.tujuan || '-'} />
+    </SectionCard>
+  );
+}

--- a/mobile/src/features/surat-tugas/components/detail/AssignmentFileSection.tsx
+++ b/mobile/src/features/surat-tugas/components/detail/AssignmentFileSection.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { SectionCard } from '@/components/SectionCard';
+import { AssignmentDetail } from '../../types';
+import { DetailRow } from './DetailRow';
+
+interface AssignmentFileSectionProps {
+  assignment: AssignmentDetail;
+}
+
+export function AssignmentFileSection({ assignment }: AssignmentFileSectionProps) {
+  const fileLabel = assignment.file.available ? 'Tersedia' : 'Belum tersedia';
+
+  return (
+    <SectionCard title="Berkas">
+      <DetailRow label="Status Berkas" value={fileLabel} />
+      <DetailRow label="Nama File" value={assignment.file.filename || '-'} />
+      <DetailRow label="Tipe File" value={assignment.file.mime_type || '-'} />
+      <DetailRow label="Download URL" value={assignment.file.download_url || '-'} />
+    </SectionCard>
+  );
+}

--- a/mobile/src/features/surat-tugas/components/detail/AssignmentPersonelSection.tsx
+++ b/mobile/src/features/surat-tugas/components/detail/AssignmentPersonelSection.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { SectionCard } from '@/components/SectionCard';
+import { useAppTheme } from '@/hooks/useAppTheme';
+import { AssignmentDetail, AssignmentPersonel } from '../../types';
+
+interface AssignmentPersonelSectionProps {
+  assignment: AssignmentDetail;
+}
+
+function PersonelItem({ personel }: { personel: AssignmentPersonel }) {
+  const { colors, spacing, typography } = useAppTheme();
+  const meta = [personel.nip, personel.jabatan, personel.unit_kerja].filter(Boolean).join(' / ');
+
+  return (
+    <View style={[styles.personelItem, { borderColor: colors.border, paddingVertical: spacing.sm }]}>
+      <Text
+        style={[
+          styles.personelName,
+          {
+            color: colors.foreground,
+            fontSize: typography.fontSizes.sm,
+            fontWeight: typography.fontWeights.semibold,
+          },
+        ]}
+      >
+        {personel.name}
+      </Text>
+      {meta ? (
+        <Text
+          style={[
+            styles.personelMeta,
+            {
+              color: colors.mutedForeground,
+              fontSize: typography.fontSizes.xs,
+              marginTop: spacing.xs,
+            },
+          ]}
+        >
+          {meta}
+        </Text>
+      ) : null}
+      {personel.peran ? (
+        <Text
+          style={[
+            styles.personelRole,
+            {
+              color: colors.foreground,
+              fontSize: typography.fontSizes.xs,
+              marginTop: spacing.xs,
+            },
+          ]}
+        >
+          {`Peran: ${personel.peran}`}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+export function AssignmentPersonelSection({ assignment }: AssignmentPersonelSectionProps) {
+  const { colors, typography } = useAppTheme();
+
+  return (
+    <SectionCard title="Personel">
+      {assignment.personel.length > 0 ? (
+        assignment.personel.map((personel) => <PersonelItem key={String(personel.id)} personel={personel} />)
+      ) : (
+        <Text style={{ color: colors.mutedForeground, fontSize: typography.fontSizes.sm }}>
+          Belum ada personel.
+        </Text>
+      )}
+    </SectionCard>
+  );
+}
+
+const styles = StyleSheet.create({
+  personelItem: {
+    borderBottomWidth: 1,
+  },
+  personelName: {
+    lineHeight: 20,
+  },
+  personelMeta: {
+    lineHeight: 16,
+  },
+  personelRole: {
+    lineHeight: 16,
+  },
+});

--- a/mobile/src/features/surat-tugas/components/detail/AssignmentStatusSection.tsx
+++ b/mobile/src/features/surat-tugas/components/detail/AssignmentStatusSection.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { SectionCard } from '@/components/SectionCard';
+import { StatusBadge } from '@/components/StatusBadge';
+import { AssignmentDetail } from '../../types';
+import { DetailRow } from './DetailRow';
+
+interface AssignmentStatusSectionProps {
+  assignment: AssignmentDetail;
+}
+
+export function AssignmentStatusSection({ assignment }: AssignmentStatusSectionProps) {
+  const actions = assignment.allowed_actions;
+
+  return (
+    <SectionCard title="Status & Aksi">
+      <View style={styles.badgeRow}>
+        <StatusBadge text={assignment.status || 'Belum Ada Status'} status="neutral" />
+        {actions.can_download ? <StatusBadge text="Bisa Diunduh" status="success" /> : null}
+        {actions.can_approve ? <StatusBadge text="Butuh Persetujuan" status="warning" /> : null}
+        {actions.can_update ? <StatusBadge text="Bisa Diubah" status="info" /> : null}
+      </View>
+      <DetailRow label="Lihat Detail" value={actions.can_view ? 'Diizinkan' : 'Tidak diizinkan'} />
+      <DetailRow label="Unduh Berkas" value={actions.can_download ? 'Diizinkan' : 'Tidak tersedia'} />
+      <DetailRow label="Ubah Data" value={actions.can_update ? 'Diizinkan' : 'Tidak diizinkan'} />
+    </SectionCard>
+  );
+}
+
+const styles = StyleSheet.create({
+  badgeRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginBottom: 12,
+  },
+});

--- a/mobile/src/features/surat-tugas/components/detail/AssignmentSummarySection.tsx
+++ b/mobile/src/features/surat-tugas/components/detail/AssignmentSummarySection.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { StatusBadge, StatusBadgeProps } from '@/components/StatusBadge';
+import { useAppTheme } from '@/hooks/useAppTheme';
+import { AssignmentDetail, AssignmentStatus } from '../../types';
+
+interface AssignmentSummarySectionProps {
+  assignment: AssignmentDetail;
+}
+
+function getStatusBadge(status?: AssignmentStatus | null): StatusBadgeProps {
+  switch (status) {
+    case 'approved':
+      return { text: 'Disetujui', status: 'success' };
+    case 'completed':
+      return { text: 'Selesai', status: 'success' };
+    case 'pending':
+      return { text: 'Menunggu', status: 'warning' };
+    case 'rejected':
+      return { text: 'Ditolak', status: 'danger' };
+    case 'draft':
+      return { text: 'Draft', status: 'neutral' };
+    default:
+      return { text: status || 'Belum Ada Status', status: 'neutral' };
+  }
+}
+
+export function AssignmentSummarySection({ assignment }: AssignmentSummarySectionProps) {
+  const { colors, spacing, typography, radius } = useAppTheme();
+  const statusBadge = getStatusBadge(assignment.status);
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.card,
+          borderColor: colors.border,
+          borderRadius: radius.lg,
+          padding: spacing.lg,
+        },
+      ]}
+    >
+      <Text
+        style={[
+          styles.number,
+          {
+            color: colors.mutedForeground,
+            fontSize: typography.fontSizes.sm,
+            fontWeight: typography.fontWeights.medium,
+          },
+        ]}
+      >
+        {assignment.nomor || 'Belum bernomor'}
+      </Text>
+      <Text
+        style={[
+          styles.title,
+          {
+            color: colors.foreground,
+            fontSize: typography.fontSizes.lg,
+            fontWeight: typography.fontWeights.bold,
+            marginTop: spacing.xs,
+          },
+        ]}
+      >
+        {assignment.kegiatan || 'Kegiatan belum diisi'}
+      </Text>
+      <View style={[styles.badgeRow, { marginTop: spacing.md }]}>
+        <StatusBadge text={statusBadge.text} status={statusBadge.status} />
+        {assignment.kode_surat ? <StatusBadge text={assignment.kode_surat} status="info" /> : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 1,
+    width: '100%',
+  },
+  number: {
+    lineHeight: 20,
+  },
+  title: {
+    lineHeight: 24,
+  },
+  badgeRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+});

--- a/mobile/src/features/surat-tugas/components/detail/DetailRow.tsx
+++ b/mobile/src/features/surat-tugas/components/detail/DetailRow.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { useAppTheme } from '@/hooks/useAppTheme';
+
+interface DetailRowProps {
+  label: string;
+  value?: React.ReactNode;
+}
+
+export function DetailRow({ label, value }: DetailRowProps) {
+  const { colors, spacing, typography } = useAppTheme();
+
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+
+  return (
+    <View style={[styles.row, { marginBottom: spacing.sm }]}>
+      <Text
+        style={[
+          styles.label,
+          {
+            color: colors.mutedForeground,
+            fontSize: typography.fontSizes.xs,
+            fontWeight: typography.fontWeights.medium,
+          },
+        ]}
+      >
+        {label}
+      </Text>
+      {typeof value === 'string' || typeof value === 'number' ? (
+        <Text
+          style={[
+            styles.value,
+            {
+              color: colors.foreground,
+              fontSize: typography.fontSizes.sm,
+            },
+          ]}
+        >
+          {value}
+        </Text>
+      ) : (
+        value
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    width: '100%',
+  },
+  label: {
+    lineHeight: 16,
+    marginBottom: 2,
+  },
+  value: {
+    flexShrink: 1,
+    lineHeight: 20,
+  },
+});

--- a/mobile/src/features/surat-tugas/components/detail/__tests__/detailSections.test.tsx
+++ b/mobile/src/features/surat-tugas/components/detail/__tests__/detailSections.test.tsx
@@ -1,0 +1,227 @@
+import React from 'react';
+import { Text } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+import {
+  AssignmentContentSection,
+  AssignmentDatesSection,
+  AssignmentFileSection,
+  AssignmentPersonelSection,
+  AssignmentStatusSection,
+  AssignmentSummarySection,
+} from '..';
+import { AssignmentDetail } from '../../../types';
+
+jest.mock('@/hooks/useAppTheme', () => ({
+  useAppTheme: () => ({
+    isDark: false,
+    colors: {
+      background: '#ffffff',
+      primary: '#16a34a',
+      primaryForeground: '#ffffff',
+      foreground: '#09090b',
+      card: '#ffffff',
+      border: '#e2e8f0',
+      mutedForeground: '#64748b',
+    },
+    spacing: {
+      xs: 4,
+      sm: 8,
+      md: 12,
+      lg: 16,
+      xl: 20,
+    },
+    radius: {
+      lg: 8,
+      full: 9999,
+    },
+    shadows: {
+      sm: {},
+    },
+    typography: {
+      fontFamilies: {
+        sans: 'System',
+      },
+      fontWeights: {
+        bold: '700',
+        semibold: '600',
+        medium: '500',
+      },
+      fontSizes: {
+        xs: 12,
+        sm: 14,
+        md: 16,
+        lg: 18,
+      },
+    },
+  }),
+}));
+
+describe('Surat Tugas detail section components', () => {
+  const longDasar =
+    'Berdasarkan surat permohonan dan kebutuhan pengamanan kawasan konservasi yang membutuhkan koordinasi lintas resort tanpa memotong keterbacaan konten panjang pada layar kecil.';
+
+  const assignment: AssignmentDetail = {
+    id: 'st-1',
+    nomor: 'ST.001/BKSDA/2026',
+    kode_surat: 'ST',
+    kegiatan: 'Patroli kawasan konservasi',
+    dasar_hukum: longDasar,
+    tujuan: 'Samarinda',
+    tanggal_mulai: '2026-06-20',
+    tanggal_selesai: '2026-06-21',
+    tanggal_surat: '2026-06-19',
+    status: 'approved',
+    sumber_dana: 'DIPA',
+    template_type: 'default',
+    personel: [
+      {
+        id: 1,
+        name: 'Pegawai Satu',
+        nip: '199001012020011001',
+        jabatan: 'Analis',
+        unit_kerja: 'Balai KSDA',
+        peran: 'Ketua Tim',
+      },
+    ],
+    file: {
+      available: true,
+      download_url: '/api/surat-tugas/my/st-1/download',
+      filename: 'st-001.pdf',
+      mime_type: 'application/pdf',
+    },
+    allowed_actions: {
+      can_view: true,
+      can_download: true,
+      can_update: true,
+      can_approve: true,
+      can_delete: false,
+    },
+  };
+
+  function getTexts(tree: renderer.ReactTestRenderer) {
+    return tree.root.findAllByType(Text).map((node) => node.props.children);
+  }
+
+  it('renders AssignmentSummarySection', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<AssignmentSummarySection assignment={assignment} />);
+    });
+
+    const texts = getTexts(tree!);
+    expect(texts).toContain('ST.001/BKSDA/2026');
+    expect(texts).toContain('Patroli kawasan konservasi');
+    expect(texts).toContain('Disetujui');
+    expect(texts).toContain('ST');
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('renders AssignmentDatesSection', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<AssignmentDatesSection assignment={assignment} />);
+    });
+
+    const texts = getTexts(tree!);
+    expect(texts).toContain('Tanggal & Tujuan');
+    expect(texts).toContain('Tanggal Surat');
+    expect(texts).toContain('2026-06-19');
+    expect(texts).toContain('Tanggal Mulai');
+    expect(texts).toContain('2026-06-20');
+    expect(texts).toContain('Tujuan');
+    expect(texts).toContain('Samarinda');
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('renders AssignmentPersonelSection', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<AssignmentPersonelSection assignment={assignment} />);
+    });
+
+    const texts = getTexts(tree!);
+    expect(texts).toContain('Personel');
+    expect(texts).toContain('Pegawai Satu');
+    expect(texts).toContain('199001012020011001 / Analis / Balai KSDA');
+    expect(texts).toContain('Peran: Ketua Tim');
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('renders empty personel fallback', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<AssignmentPersonelSection assignment={{ ...assignment, personel: [] }} />);
+    });
+
+    expect(getTexts(tree!)).toContain('Belum ada personel.');
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('renders AssignmentContentSection with long readable content', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<AssignmentContentSection assignment={assignment} />);
+    });
+
+    const texts = getTexts(tree!);
+    expect(texts).toContain('Isi Surat');
+    expect(texts).toContain('Kegiatan');
+    expect(texts).toContain('Patroli kawasan konservasi');
+    expect(texts).toContain(longDasar);
+    expect(texts).toContain('Sumber Dana');
+    expect(texts).toContain('DIPA');
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('renders AssignmentFileSection', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<AssignmentFileSection assignment={assignment} />);
+    });
+
+    const texts = getTexts(tree!);
+    expect(texts).toContain('Berkas');
+    expect(texts).toContain('Status Berkas');
+    expect(texts).toContain('Tersedia');
+    expect(texts).toContain('st-001.pdf');
+    expect(texts).toContain('/api/surat-tugas/my/st-1/download');
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('renders AssignmentStatusSection', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<AssignmentStatusSection assignment={assignment} />);
+    });
+
+    const texts = getTexts(tree!);
+    expect(texts).toContain('Status & Aksi');
+    expect(texts).toContain('approved');
+    expect(texts).toContain('Bisa Diunduh');
+    expect(texts).toContain('Butuh Persetujuan');
+    expect(texts).toContain('Ubah Data');
+    expect(texts).toContain('Diizinkan');
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+});

--- a/mobile/src/features/surat-tugas/components/detail/index.ts
+++ b/mobile/src/features/surat-tugas/components/detail/index.ts
@@ -1,0 +1,6 @@
+export { AssignmentSummarySection } from './AssignmentSummarySection';
+export { AssignmentDatesSection } from './AssignmentDatesSection';
+export { AssignmentPersonelSection } from './AssignmentPersonelSection';
+export { AssignmentContentSection } from './AssignmentContentSection';
+export { AssignmentFileSection } from './AssignmentFileSection';
+export { AssignmentStatusSection } from './AssignmentStatusSection';


### PR DESCRIPTION
Closes #454

## Summary
- Add presentational detail sections for Surat Tugas summary, dates, personel, content, file, and status/action info.
- Add DetailRow helper and barrel export for upcoming detail screen composition.
- Render long content as wrapped multiline text for small mobile screens.
- Add section tests covering all components, empty personel fallback, file state, actions, and long content.
- Mark Task 65 complete and update progress.md.

## Validation
- npm test -- --runTestsByPath src/features/surat-tugas/components/detail/__tests__/detailSections.test.tsx
- npm run typecheck
- npm run lint