### PR TITLE
feat(mobile): build Surat Tugas detail screen (#456)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1007,7 +1007,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: long content is readable without horizontal scroll.
   - _Requirements: 11, 14, 20_
 
-- [ ] 66. Build Surat Tugas detail screen
+- [x] 66. Build Surat Tugas detail screen
   - Target area: `mobile/src/features/surat-tugas/AssignmentDetailScreen.tsx`.
   - Render detail sections and permission-gated actions.
   - Acceptance check: file action appears only if backend says file is available/allowed.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,43 @@
+# Progress - Phase 109: Mobile Surat Tugas Detail Screen
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-66`.
+> GitHub Issue: #456.
+
+---
+
+## Mobile Surat Tugas Detail Screen
+
+### Status: SELESAI
+- Scope: Mobile App (Surat Tugas Module)
+- Tujuan: Menghubungkan daftar Surat Tugas ke layar detail yang merender section detail dan menampilkan action file hanya saat backend mengizinkan.
+
+### Implementasi
+- **Navigation**:
+  - Menambahkan `SuratTugasNavigator` sebagai stack khusus tab Surat Tugas.
+  - Mengubah tab Surat Tugas agar membuka navigator, bukan langsung list screen.
+  - Menambahkan navigasi dari `AssignmentCard` ke detail dengan parameter `id` dan mode aktif.
+- **Screen**:
+  - Membuat `AssignmentDetailScreen` dengan loading, forbidden/not-found/error state, empty fallback, dan content scroll.
+  - Merender section summary, tanggal/tujuan, personel, isi surat, berkas, serta status/aksi dari data detail.
+  - Menampilkan action `Unduh Berkas` hanya jika `file.available` dan `allowed_actions.can_download` dari backend bernilai true.
+- **Tests**:
+  - Menambahkan test detail screen untuk render section, gating action file, loading, forbidden state, dan placeholder download.
+  - Memperbarui test list screen untuk memastikan card membuka detail.
+  - Memperbarui test tab navigation untuk navigator Surat Tugas.
+- **Checklist**:
+  - Mencentang Task 66 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/surat-tugas/screens/__tests__/AssignmentDetailScreen.test.tsx src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx src/navigation/__tests__/AppTabs.test.tsx`: 18 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 67: Add Surat Tugas form schema.
+
+---
+
 # Progress - Phase 108: Mobile Surat Tugas Detail Sections
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/surat-tugas/navigation/SuratTugasNavigator.tsx
+++ b/mobile/src/features/surat-tugas/navigation/SuratTugasNavigator.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import SuratTugasListScreen from '../screens/SuratTugasListScreen';
+import AssignmentDetailScreen from '../screens/AssignmentDetailScreen';
+import { AssignmentListMode } from '../types';
+
+export type SuratTugasStackParamList = {
+  SuratTugasList: undefined;
+  AssignmentDetail: { id: string | number; mode?: AssignmentListMode };
+};
+
+const Stack = createNativeStackNavigator<SuratTugasStackParamList>();
+
+export default function SuratTugasNavigator() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="SuratTugasList" component={SuratTugasListScreen} />
+      <Stack.Screen name="AssignmentDetail" component={AssignmentDetailScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/mobile/src/features/surat-tugas/screens/AssignmentDetailScreen.tsx
+++ b/mobile/src/features/surat-tugas/screens/AssignmentDetailScreen.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { Alert, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { AppButton } from '@/components/AppButton';
+import { ErrorState } from '@/components/ErrorState';
+import { IconButton } from '@/components/IconButton';
+import { LoadingSkeleton } from '@/components/LoadingSkeleton';
+import { useAppTheme } from '@/hooks/useAppTheme';
+import {
+  AssignmentContentSection,
+  AssignmentDatesSection,
+  AssignmentFileSection,
+  AssignmentPersonelSection,
+  AssignmentStatusSection,
+  AssignmentSummarySection,
+} from '../components/detail';
+import { SuratTugasStackParamList } from '../navigation/SuratTugasNavigator';
+import { useAssignmentDetail } from '../useAssignmentDetail';
+
+export default function AssignmentDetailScreen() {
+  const { colors, spacing, typography } = useAppTheme();
+  const navigation = useNavigation();
+  const route = useRoute<RouteProp<SuratTugasStackParamList, 'AssignmentDetail'>>();
+  const { id, mode = 'personal' } = route.params;
+  const { data, isLoading, error, refetch, isForbidden, isNotFound } = useAssignmentDetail(id, mode);
+
+  const handleDownload = () => {
+    Alert.alert('Unduh Surat Tugas', 'Fitur unduh berkas akan disiapkan pada task file download berikutnya.');
+  };
+
+  const renderHeader = (title = 'Detail Surat Tugas') => (
+    <View style={[styles.headerRow, { paddingHorizontal: spacing.lg, paddingVertical: spacing.md }]}>
+      <IconButton
+        icon={<Text style={{ color: colors.foreground, fontSize: 20 }}>{'<'}</Text>}
+        onPress={() => navigation.goBack()}
+        accessibilityLabel="Kembali"
+      />
+      <Text
+        style={[
+          styles.headerTitle,
+          {
+            color: colors.foreground,
+            fontSize: typography.fontSizes.lg,
+            fontWeight: typography.fontWeights.bold,
+            marginLeft: spacing.sm,
+          },
+        ]}
+      >
+        {title}
+      </Text>
+    </View>
+  );
+
+  if (isLoading && !data) {
+    return (
+      <SafeAreaView style={[styles.safeArea, { backgroundColor: colors.background }]}>
+        {renderHeader()}
+        <View style={{ flex: 1, paddingHorizontal: spacing.lg }}>
+          <LoadingSkeleton variant="detail" count={1} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    const title = isForbidden
+      ? 'Akses Ditolak'
+      : isNotFound
+      ? 'Surat Tugas Tidak Ditemukan'
+      : 'Gagal Memuat Surat Tugas';
+    const message = isForbidden
+      ? 'Anda tidak memiliki akses untuk melihat detail Surat Tugas ini.'
+      : isNotFound
+      ? 'Surat Tugas yang Anda cari tidak ditemukan.'
+      : error.message || 'Terjadi kesalahan saat memuat detail Surat Tugas.';
+
+    return (
+      <SafeAreaView style={[styles.safeArea, { backgroundColor: colors.background }]}>
+        {renderHeader()}
+        <View style={{ flex: 1, justifyContent: 'center', padding: spacing.lg }}>
+          <ErrorState
+            title={title}
+            message={message}
+            onRetry={!isForbidden && !isNotFound ? refetch : undefined}
+          />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!data) {
+    return (
+      <SafeAreaView style={[styles.safeArea, { backgroundColor: colors.background }]}>
+        {renderHeader()}
+        <View style={{ flex: 1, justifyContent: 'center', padding: spacing.lg }}>
+          <ErrorState
+            title="Data Kosong"
+            message="Data detail Surat Tugas tidak tersedia."
+            onRetry={refetch}
+          />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const canDownload = data.file.available && data.allowed_actions.can_download;
+
+  return (
+    <SafeAreaView style={[styles.safeArea, { backgroundColor: colors.background }]}>
+      {renderHeader()}
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={[styles.scrollContent, { paddingHorizontal: spacing.lg, paddingBottom: spacing.xl * 2 }]}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={{ marginBottom: spacing.md }}>
+          <AssignmentSummarySection assignment={data} />
+        </View>
+        <AssignmentDatesSection assignment={data} />
+        <AssignmentPersonelSection assignment={data} />
+        <AssignmentContentSection assignment={data} />
+        <AssignmentFileSection assignment={data} />
+        <AssignmentStatusSection assignment={data} />
+
+        {canDownload ? (
+          <View style={{ marginTop: spacing.sm }}>
+            <AppButton
+              title="Unduh Berkas"
+              onPress={handleDownload}
+              accessibilityLabel="Unduh berkas Surat Tugas"
+            />
+          </View>
+        ) : null}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+  },
+  headerRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    width: '100%',
+  },
+  headerTitle: {
+    flexShrink: 1,
+    lineHeight: 24,
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    width: '100%',
+  },
+});

--- a/mobile/src/features/surat-tugas/screens/SuratTugasListScreen.tsx
+++ b/mobile/src/features/surat-tugas/screens/SuratTugasListScreen.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { ActivityIndicator, FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { EmptyState } from '@/components/EmptyState';
 import { ErrorState } from '@/components/ErrorState';
@@ -8,6 +10,7 @@ import { SearchInput } from '@/components/SearchInput';
 import { useAppTheme } from '@/hooks/useAppTheme';
 import { usePermissions } from '@/lib/permissions';
 import AssignmentCard from '../components/AssignmentCard';
+import { SuratTugasStackParamList } from '../navigation/SuratTugasNavigator';
 import { useAssignments } from '../useAssignments';
 import { AssignmentListItem, AssignmentListMode, AssignmentStatus } from '../types';
 
@@ -23,6 +26,7 @@ const statusFilters: { label: string; value: StatusFilter }[] = [
 
 export default function SuratTugasListScreen() {
   const { colors, spacing, radius, typography } = useAppTheme();
+  const navigation = useNavigation<NativeStackNavigationProp<SuratTugasStackParamList>>();
   const { hasModule } = usePermissions();
   const canUseManagementMode = hasModule('surat_tugas') || hasModule('kepegawaian');
   const [mode, setMode] = React.useState<AssignmentListMode>('personal');
@@ -54,7 +58,10 @@ export default function SuratTugasListScreen() {
   });
 
   const renderAssignment = ({ item }: { item: AssignmentListItem }) => (
-    <AssignmentCard assignment={item} onPress={() => undefined} />
+    <AssignmentCard
+      assignment={item}
+      onPress={() => navigation.navigate('AssignmentDetail', { id: item.id, mode: activeMode })}
+    />
   );
 
   const renderFooter = () => {

--- a/mobile/src/features/surat-tugas/screens/__tests__/AssignmentDetailScreen.test.tsx
+++ b/mobile/src/features/surat-tugas/screens/__tests__/AssignmentDetailScreen.test.tsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import { Alert, Text } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+import AssignmentDetailScreen from '../AssignmentDetailScreen';
+import { useAssignmentDetail } from '../../useAssignmentDetail';
+
+const mockGoBack = jest.fn();
+let mockRouteParams: { id: string | number; mode?: 'personal' | 'management' } = {
+  id: 'st-1',
+  mode: 'personal',
+};
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    goBack: mockGoBack,
+  }),
+  useRoute: () => ({
+    params: mockRouteParams,
+  }),
+}));
+
+jest.mock('@/hooks/useAppTheme', () => ({
+  useAppTheme: () => ({
+    isDark: false,
+    colors: {
+      background: '#ffffff',
+      primary: '#16a34a',
+      primaryForeground: '#ffffff',
+      secondary: '#f1f5f9',
+      secondaryForeground: '#0f172a',
+      danger: '#ef4444',
+      dangerForeground: '#ffffff',
+      foreground: '#09090b',
+      card: '#ffffff',
+      border: '#e2e8f0',
+      mutedForeground: '#64748b',
+    },
+    spacing: {
+      xs: 4,
+      sm: 8,
+      md: 12,
+      lg: 16,
+      xl: 20,
+    },
+    radius: {
+      lg: 8,
+      full: 9999,
+    },
+    shadows: {
+      sm: {},
+    },
+    typography: {
+      fontFamilies: {
+        sans: 'System',
+      },
+      fontWeights: {
+        bold: '700',
+        semibold: '600',
+        medium: '500',
+      },
+      fontSizes: {
+        xs: 12,
+        sm: 14,
+        md: 16,
+        lg: 18,
+      },
+    },
+  }),
+}));
+
+jest.mock('../../useAssignmentDetail', () => ({
+  useAssignmentDetail: jest.fn(),
+}));
+
+describe('AssignmentDetailScreen', () => {
+  const refetch = jest.fn();
+  const assignment = {
+    id: 'st-1',
+    nomor: 'ST.001/BKSDA/2026',
+    kode_surat: 'ST',
+    kegiatan: 'Patroli kawasan',
+    dasar_hukum: 'Dasar hukum perjalanan dinas',
+    tujuan: 'Samarinda',
+    tanggal_mulai: '2026-06-20',
+    tanggal_selesai: '2026-06-21',
+    tanggal_surat: '2026-06-19',
+    status: 'approved',
+    sumber_dana: 'DIPA',
+    template_type: 'default',
+    personel: [{ id: 1, name: 'Pegawai Satu', nip: '199001012020011001' }],
+    file: {
+      available: true,
+      download_url: '/api/surat-tugas/my/st-1/download',
+    },
+    allowed_actions: {
+      can_view: true,
+      can_download: true,
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRouteParams = { id: 'st-1', mode: 'personal' };
+    (useAssignmentDetail as jest.Mock).mockReturnValue({
+      data: assignment,
+      isLoading: false,
+      error: undefined,
+      refetch,
+      isForbidden: false,
+      isNotFound: false,
+    });
+  });
+
+  it('renders detail sections and gated file action when file is allowed', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<AssignmentDetailScreen />);
+    });
+
+    const texts = tree!.root.findAllByType(Text).map((node) => node.props.children);
+    expect(texts).toContain('Detail Surat Tugas');
+    expect(texts).toContain('ST.001/BKSDA/2026');
+    expect(texts).toContain('Tanggal & Tujuan');
+    expect(texts).toContain('Personel');
+    expect(texts).toContain('Isi Surat');
+    expect(texts).toContain('Berkas');
+    expect(texts).toContain('Status & Aksi');
+    expect(texts).toContain('Unduh Berkas');
+    expect(useAssignmentDetail).toHaveBeenCalledWith('st-1', 'personal');
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('hides file action when backend does not allow download', () => {
+    (useAssignmentDetail as jest.Mock).mockReturnValue({
+      data: {
+        ...assignment,
+        allowed_actions: { can_view: true, can_download: false },
+      },
+      isLoading: false,
+      error: undefined,
+      refetch,
+      isForbidden: false,
+      isNotFound: false,
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<AssignmentDetailScreen />);
+    });
+
+    expect(
+      tree!.root.findAllByProps({ accessibilityLabel: 'Unduh berkas Surat Tugas' })
+    ).toHaveLength(0);
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('renders loading skeleton while loading', () => {
+    (useAssignmentDetail as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: undefined,
+      refetch,
+      isForbidden: false,
+      isNotFound: false,
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<AssignmentDetailScreen />);
+    });
+
+    expect(tree!.root.findByProps({ variant: 'detail' })).toBeTruthy();
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('renders forbidden state without retry', () => {
+    (useAssignmentDetail as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: { message: 'Forbidden', kind: 'forbidden', status: 403 },
+      refetch,
+      isForbidden: true,
+      isNotFound: false,
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<AssignmentDetailScreen />);
+    });
+
+    const errorState = tree!.root.findByProps({ title: 'Akses Ditolak' });
+    expect(errorState.props.onRetry).toBeUndefined();
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('shows download placeholder alert when file action is pressed', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<AssignmentDetailScreen />);
+    });
+
+    const downloadButton = tree!.root.findByProps({ accessibilityLabel: 'Unduh berkas Surat Tugas' });
+    act(() => {
+      downloadButton.props.onPress();
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Unduh Surat Tugas',
+      'Fitur unduh berkas akan disiapkan pada task file download berikutnya.'
+    );
+
+    alertSpy.mockRestore();
+    act(() => {
+      tree!.unmount();
+    });
+  });
+});

--- a/mobile/src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx
+++ b/mobile/src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx
@@ -4,6 +4,14 @@ import renderer, { act } from 'react-test-renderer';
 import SuratTugasListScreen from '../SuratTugasListScreen';
 import { useAssignments } from '../../useAssignments';
 
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+}));
+
 jest.mock('@/hooks/useAppTheme', () => ({
   useAppTheme: () => ({
     isDark: false,
@@ -285,6 +293,30 @@ describe('SuratTugasListScreen', () => {
     expect(mockRefetch).toHaveBeenCalledTimes(1);
     expect(mockFetchNextPage).toHaveBeenCalledTimes(1);
     expect(tree!.root.findByType(ActivityIndicator)).toBeTruthy();
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('opens assignment detail when a card is pressed', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(<SuratTugasListScreen />);
+    });
+
+    const card = tree!.root.findByProps({
+      accessibilityLabel: 'Surat Tugas: ST.001/BKSDA/2026. Patroli kawasan',
+    });
+
+    act(() => {
+      card.props.onPress();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('AssignmentDetail', {
+      id: 'st-1',
+      mode: 'personal',
+    });
 
     act(() => {
       tree!.unmount();

--- a/mobile/src/navigation/AppTabs.tsx
+++ b/mobile/src/navigation/AppTabs.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import DashboardScreen from '@/features/dashboard/screens/DashboardScreen';
 import BmnNavigator from '@/features/bmn/navigation/BmnNavigator';
-import SuratTugasListScreen from '@/features/surat-tugas/screens/SuratTugasListScreen';
+import SuratTugasNavigator from '@/features/surat-tugas/navigation/SuratTugasNavigator';
 import ProfileScreen from '@/features/profile/screens/ProfileScreen';
 import { useAppTheme } from '@/hooks/useAppTheme';
 
@@ -62,9 +62,10 @@ export default function AppTabs() {
       {showSuratTugas && (
         <Tab.Screen
           name="SuratTugas"
-          component={SuratTugasListScreen}
+          component={SuratTugasNavigator}
           options={{
             title: 'Surat Tugas',
+            headerShown: false,
           }}
         />
       )}

--- a/mobile/src/navigation/__tests__/AppTabs.test.tsx
+++ b/mobile/src/navigation/__tests__/AppTabs.test.tsx
@@ -36,7 +36,7 @@ jest.mock('@react-navigation/bottom-tabs', () => {
 // Mock child screens
 jest.mock('@/features/dashboard/screens/DashboardScreen', () => () => null);
 jest.mock('@/features/bmn/navigation/BmnNavigator', () => () => null);
-jest.mock('@/features/surat-tugas/screens/SuratTugasListScreen', () => () => null);
+jest.mock('@/features/surat-tugas/navigation/SuratTugasNavigator', () => () => null);
 jest.mock('@/features/profile/screens/ProfileScreen', () => () => null);
 
 describe('AppTabs', () => {


### PR DESCRIPTION
## Summary
- add a Surat Tugas stack navigator and route list cards into assignment detail
- add AssignmentDetailScreen with loading/error/forbidden/empty states and existing detail sections
- gate the download action on backend file availability and allowed_actions.can_download
- update Task 66 checklist and progress notes

## Validation
- npm test -- --runTestsByPath src/features/surat-tugas/screens/__tests__/AssignmentDetailScreen.test.tsx src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx src/navigation/__tests__/AppTabs.test.tsx
- npm run typecheck
- npm run lint