### PR TITLE
feat(mobile): add Surat Tugas form schema (#458)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1013,7 +1013,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: file action appears only if backend says file is available/allowed.
   - _Requirements: 11, 14, 19_
 
-- [ ] 67. Add Surat Tugas form schema
+- [x] 67. Add Surat Tugas form schema
   - Target area: `mobile/src/features/surat-tugas/assignmentFormSchema.ts`.
   - Validate core fields, dates, location, personel, and transport where required.
   - Acceptance check: validation messages are in Indonesian.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,40 @@
+# Progress - Phase 110: Mobile Surat Tugas Form Schema
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-67`.
+> GitHub Issue: #458.
+
+---
+
+## Mobile Surat Tugas Form Schema
+
+### Status: SELESAI
+- Scope: Mobile App (Surat Tugas Module)
+- Tujuan: Menyediakan schema validasi form Surat Tugas mobile sebelum task form shell dan submit API.
+
+### Implementasi
+- **Schema**:
+  - Membuat [assignmentFormSchema.ts](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/assignmentFormSchema.ts) berbasis Zod.
+  - Memvalidasi field inti: maksud/tujuan, tanggal mulai/selesai, tempat tujuan, sumber dana, dan daftar pegawai.
+  - Menormalisasi input form seperti string kosong opsional menjadi `null` dan ID pegawai string menjadi number.
+  - Menambahkan validasi urutan tanggal agar tanggal selesai tidak lebih awal dari tanggal mulai.
+  - Menambahkan validasi conditional untuk `sumber_dana_other` saat sumber dana lainnya/other dan `transportasi` saat `transport_required` aktif.
+  - Semua pesan validasi dibuat dalam Bahasa Indonesia.
+- **Tests**:
+  - Menambahkan [assignmentFormSchema.test.ts](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/__tests__/assignmentFormSchema.test.ts) untuk payload valid, field wajib, panjang maksud/tujuan, urutan tanggal, sumber dana lainnya, transport conditional, dan pegawai tanpa ID.
+- **Checklist**:
+  - Mencentang Task 67 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/surat-tugas/__tests__/assignmentFormSchema.test.ts`: 7 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 68: Build Surat Tugas form shell.
+
+---
+
 # Progress - Phase 109: Mobile Surat Tugas Detail Screen
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/surat-tugas/__tests__/assignmentFormSchema.test.ts
+++ b/mobile/src/features/surat-tugas/__tests__/assignmentFormSchema.test.ts
@@ -1,0 +1,129 @@
+import { assignmentFormSchema } from '../assignmentFormSchema';
+
+describe('assignmentFormSchema', () => {
+  const validPayload = {
+    nomor_surat: 'ST.001/BKSDA/2026',
+    kode_surat: 'ST',
+    tanggal_surat: '2026-06-19',
+    maksud_tujuan: 'Patroli kawasan konservasi',
+    dasar_hukum: 'Surat permohonan patroli',
+    tanggal_mulai: '2026-06-20',
+    tanggal_selesai: '2026-06-21',
+    tempat_tujuan: 'Samarinda',
+    sumber_dana: 'dipa',
+    sumber_dana_other: '',
+    template_type: 'default',
+    menimbang: ['Bahwa perlu dilakukan patroli'],
+    dasar: ['Undang-undang konservasi'],
+    tembusan: ['Kepala Balai'],
+    penandatangan_nama: 'Kepala Balai',
+    penandatangan_nip: '197001012000011001',
+    transport_required: false,
+    transportasi: '',
+    employees: [
+      {
+        id: '12',
+        peran: 'Ketua Tim',
+      },
+    ],
+  };
+
+  it('validates a complete Surat Tugas payload and normalizes form values', () => {
+    const result = assignmentFormSchema.safeParse(validPayload);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.maksud_tujuan).toBe('Patroli kawasan konservasi');
+      expect(result.data.sumber_dana_other).toBeNull();
+      expect(result.data.transportasi).toBeNull();
+      expect(result.data.employees[0].id).toBe(12);
+      expect(result.data.employees[0].peran).toBe('Ketua Tim');
+    }
+  });
+
+  it('fails validation with Indonesian messages when required fields are missing', () => {
+    const result = assignmentFormSchema.safeParse({
+      employees: [],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const errors = result.error.flatten().fieldErrors;
+      expect(errors.maksud_tujuan).toContain('Maksud dan tujuan wajib diisi');
+      expect(errors.tanggal_mulai).toContain('Tanggal mulai wajib diisi');
+      expect(errors.tanggal_selesai).toContain('Tanggal selesai wajib diisi');
+      expect(errors.tempat_tujuan).toContain('Tempat tujuan wajib diisi');
+      expect(errors.sumber_dana).toContain('Sumber dana wajib dipilih');
+      expect(errors.employees).toContain('Pilih minimal satu pegawai untuk Surat Tugas');
+    }
+  });
+
+  it('fails validation when the activity description is too short', () => {
+    const result = assignmentFormSchema.safeParse({
+      ...validPayload,
+      maksud_tujuan: 'Patroli',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.flatten().fieldErrors.maksud_tujuan).toContain(
+        'Maksud dan tujuan minimal 10 karakter'
+      );
+    }
+  });
+
+  it('fails validation when the end date is before the start date', () => {
+    const result = assignmentFormSchema.safeParse({
+      ...validPayload,
+      tanggal_mulai: '2026-06-22',
+      tanggal_selesai: '2026-06-21',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.flatten().fieldErrors.tanggal_selesai).toContain(
+        'Tanggal selesai tidak boleh sebelum tanggal mulai'
+      );
+    }
+  });
+
+  it('requires funding detail when sumber_dana is lainnya', () => {
+    const result = assignmentFormSchema.safeParse({
+      ...validPayload,
+      sumber_dana: 'lainnya',
+      sumber_dana_other: '',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.flatten().fieldErrors.sumber_dana_other).toContain(
+        'Detail sumber dana wajib diisi'
+      );
+    }
+  });
+
+  it('requires transport when transport_required is true', () => {
+    const result = assignmentFormSchema.safeParse({
+      ...validPayload,
+      transport_required: true,
+      transportasi: '   ',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.flatten().fieldErrors.transportasi).toContain('Transportasi wajib diisi');
+    }
+  });
+
+  it('fails validation when a selected employee has no valid id', () => {
+    const result = assignmentFormSchema.safeParse({
+      ...validPayload,
+      employees: [{ id: '', peran: 'Anggota' }],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.flatten().fieldErrors.employees?.join(' ')).toContain('Pegawai wajib dipilih');
+    }
+  });
+});

--- a/mobile/src/features/surat-tugas/assignmentFormSchema.ts
+++ b/mobile/src/features/surat-tugas/assignmentFormSchema.ts
@@ -1,0 +1,108 @@
+import { z } from 'zod';
+
+const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+const toTrimmedString = (value: unknown) => {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  return String(value).trim();
+};
+
+const requiredString = (message: string, max?: number) => {
+  const schema = z.preprocess(
+    toTrimmedString,
+    z.string().min(1, message)
+  );
+
+  return max ? schema.pipe(z.string().max(max, `Maksimal ${max} karakter`)) : schema;
+};
+
+const optionalString = (max?: number) => {
+  const schema = z.preprocess((value) => {
+    const text = toTrimmedString(value);
+    return text === '' ? null : text;
+  }, z.string().nullable());
+
+  return max ? schema.pipe(z.string().max(max, `Maksimal ${max} karakter`).nullable()) : schema;
+};
+
+const requiredDateString = (message: string) =>
+  requiredString(message).refine((value) => datePattern.test(value) && !Number.isNaN(Date.parse(value)), {
+    message: 'Tanggal harus berformat YYYY-MM-DD',
+  });
+
+const employeeIdSchema = z.preprocess((value) => {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : null;
+}, z.custom<number>((value) => typeof value === 'number' && value > 0, 'Pegawai wajib dipilih'));
+
+export const assignmentEmployeeSchema = z.object({
+  id: employeeIdSchema,
+  peran: optionalString(100).optional().nullable(),
+});
+
+export const assignmentFormSchema = z
+  .object({
+    nomor_surat: optionalString().optional().nullable(),
+    kode_surat: optionalString().optional().nullable(),
+    tanggal_surat: optionalString().optional().nullable(),
+    maksud_tujuan: z.preprocess(
+      toTrimmedString,
+      z
+        .string()
+        .min(1, 'Maksud dan tujuan wajib diisi')
+        .min(10, 'Maksud dan tujuan minimal 10 karakter')
+    ),
+    dasar_hukum: optionalString().optional().nullable(),
+    tanggal_mulai: requiredDateString('Tanggal mulai wajib diisi'),
+    tanggal_selesai: requiredDateString('Tanggal selesai wajib diisi'),
+    tempat_tujuan: requiredString('Tempat tujuan wajib diisi', 255),
+    sumber_dana: requiredString('Sumber dana wajib dipilih'),
+    sumber_dana_other: optionalString().optional().nullable(),
+    template_type: optionalString(50).optional().nullable(),
+    menimbang: z.array(z.string()).optional().nullable(),
+    dasar: z.array(z.string()).optional().nullable(),
+    tembusan: z.array(z.string()).optional().nullable(),
+    penandatangan_nama: optionalString(255).optional().nullable(),
+    penandatangan_nip: optionalString(50).optional().nullable(),
+    transport_required: z.boolean().optional().default(false),
+    transportasi: optionalString(100).optional().nullable(),
+    employees: z
+      .array(assignmentEmployeeSchema)
+      .min(1, 'Pilih minimal satu pegawai untuk Surat Tugas'),
+  })
+  .superRefine((value, context) => {
+    if (Date.parse(value.tanggal_selesai) < Date.parse(value.tanggal_mulai)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['tanggal_selesai'],
+        message: 'Tanggal selesai tidak boleh sebelum tanggal mulai',
+      });
+    }
+
+    const requiresOtherFunding = ['lainnya', 'other'].includes(value.sumber_dana.toLowerCase());
+    if (requiresOtherFunding && !value.sumber_dana_other) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['sumber_dana_other'],
+        message: 'Detail sumber dana wajib diisi',
+      });
+    }
+
+    if (value.transport_required && !value.transportasi) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['transportasi'],
+        message: 'Transportasi wajib diisi',
+      });
+    }
+  });
+
+export type AssignmentEmployeeFormData = z.infer<typeof assignmentEmployeeSchema>;
+export type AssignmentFormData = z.infer<typeof assignmentFormSchema>;


### PR DESCRIPTION
## Summary
- add a Zod schema for the mobile Surat Tugas form
- validate core fields, date order, location, funding detail, selected personnel, and conditional transport
- keep validation messages in Indonesian and normalize form values for submit
- update Task 67 checklist and progress notes

## Validation
- npm test -- --runTestsByPath src/features/surat-tugas/__tests__/assignmentFormSchema.test.ts
- npm run typecheck
- npm run lint