### PR TITLE
feat(mobile): wire Surat Tugas form submit (#462)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1025,7 +1025,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: keyboard does not hide active input on Android.
   - _Requirements: 12, 20_
 
-- [ ] 69. Wire Surat Tugas create/edit submit
+- [x] 69. Wire Surat Tugas create/edit submit
   - Target area: Surat Tugas form API helper.
   - Submit create/edit and map 422 errors to fields.
   - Acceptance check: success opens detail or refreshes relevant list.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,43 @@
+# Progress - Phase 112: Mobile Surat Tugas Create/Edit Submit
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-69`.
+> GitHub Issue: #462.
+
+---
+
+## Mobile Surat Tugas Create/Edit Submit
+
+### Status: SELESAI
+- Scope: Mobile App (Surat Tugas Module)
+- Tujuan: Menghubungkan form Surat Tugas mobile ke API create/edit dan menampilkan error validasi backend pada field terkait.
+
+### Implementasi
+- **API Helper**:
+  - Membuat `assignmentFormApi.ts` untuk transform payload form ke kontrak backend.
+  - Menambahkan `createAssignment` untuk `POST /surat-tugas`.
+  - Menambahkan `updateAssignment` untuk `PUT /surat-tugas/{id}`.
+- **Screen Wiring**:
+  - Mengubah `AssignmentFormScreen` agar submit create/edit memanggil API helper.
+  - Mode edit mengambil detail Surat Tugas, prefill form, dan menampilkan loading/error state.
+  - Mapping 422 `fieldErrors` backend ke field React Hook Form, termasuk nested `employees.{index}.id`.
+  - Submit sukses menampilkan konfirmasi dan membuka detail Surat Tugas mode manajemen.
+- **Tests**:
+  - Menambahkan test payload helper, create endpoint, dan update endpoint.
+  - Memperbarui test form untuk create success, edit prefill/update success, dan mapping error 422 backend.
+- **Checklist**:
+  - Mencentang Task 69 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/surat-tugas/__tests__/assignmentFormApi.test.ts src/features/surat-tugas/screens/__tests__/AssignmentFormScreen.test.tsx`: 12 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 70: Add approval/status action component.
+
+---
+
 # Progress - Phase 111: Mobile Surat Tugas Form Shell
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/surat-tugas/__tests__/assignmentFormApi.test.ts
+++ b/mobile/src/features/surat-tugas/__tests__/assignmentFormApi.test.ts
@@ -1,0 +1,108 @@
+import {
+  createAssignment,
+  toAssignmentFormPayload,
+  updateAssignment,
+} from '../assignmentFormApi';
+import { apiClient } from '@/lib/api/client';
+import { AssignmentFormData } from '../assignmentFormSchema';
+
+jest.mock('@/lib/api/client', () => ({
+  apiClient: {
+    post: jest.fn(),
+    put: jest.fn(),
+  },
+}));
+
+describe('assignmentFormApi', () => {
+  const formData: AssignmentFormData = {
+    nomor_surat: 'ST.001/BKSDA/2026',
+    kode_surat: 'ST',
+    tanggal_surat: '2026-06-19',
+    maksud_tujuan: 'Patroli kawasan konservasi',
+    dasar_hukum: 'Dasar hukum',
+    tanggal_mulai: '2026-06-20',
+    tanggal_selesai: '2026-06-21',
+    tempat_tujuan: 'Samarinda',
+    sumber_dana: 'lainnya',
+    sumber_dana_other: 'Mitra',
+    template_type: 'default',
+    menimbang: ['Menimbang satu'],
+    dasar: ['Dasar satu'],
+    tembusan: ['Tembusan satu'],
+    penandatangan_nama: 'Kepala Balai',
+    penandatangan_nip: '197001012000011001',
+    transport_required: true,
+    transportasi: 'Kendaraan dinas',
+    employees: [
+      { id: 12, peran: 'Ketua Tim' },
+      { id: '13' as any, peran: '' },
+    ],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('maps form data to backend payload', () => {
+    expect(toAssignmentFormPayload(formData)).toEqual({
+      nomor_surat: 'ST.001/BKSDA/2026',
+      kode_surat: 'ST',
+      tanggal_surat: '2026-06-19',
+      maksud_tujuan: 'Patroli kawasan konservasi',
+      dasar_hukum: 'Dasar hukum',
+      tanggal_mulai: '2026-06-20',
+      tanggal_selesai: '2026-06-21',
+      tempat_tujuan: 'Samarinda',
+      sumber_dana: 'lainnya',
+      sumber_dana_other: 'Mitra',
+      template_type: 'default',
+      menimbang: ['Menimbang satu'],
+      dasar: ['Dasar satu'],
+      tembusan: ['Tembusan satu'],
+      penandatangan_nama: 'Kepala Balai',
+      penandatangan_nip: '197001012000011001',
+      transportasi: 'Kendaraan dinas',
+      employees: [
+        { id: 12, peran: 'Ketua Tim' },
+        { id: 13, peran: null },
+      ],
+    });
+  });
+
+  it('omits transport when transport is not required', () => {
+    expect(
+      toAssignmentFormPayload({
+        ...formData,
+        transport_required: false,
+        transportasi: 'Kendaraan dinas',
+      }).transportasi
+    ).toBeNull();
+  });
+
+  it('posts create payload to the Surat Tugas endpoint', async () => {
+    (apiClient.post as jest.Mock).mockResolvedValue({
+      data: { data: { id: 'st-new' } },
+    });
+
+    const result = await createAssignment(formData);
+
+    expect(apiClient.post).toHaveBeenCalledWith('/surat-tugas', expect.objectContaining({
+      maksud_tujuan: 'Patroli kawasan konservasi',
+      employees: expect.arrayContaining([{ id: 12, peran: 'Ketua Tim' }]),
+    }));
+    expect(result).toEqual({ id: 'st-new' });
+  });
+
+  it('puts update payload to the Surat Tugas endpoint', async () => {
+    (apiClient.put as jest.Mock).mockResolvedValue({
+      data: { data: { id: 'st-1' } },
+    });
+
+    const result = await updateAssignment('st-1', formData);
+
+    expect(apiClient.put).toHaveBeenCalledWith('/surat-tugas/st-1', expect.objectContaining({
+      maksud_tujuan: 'Patroli kawasan konservasi',
+    }));
+    expect(result).toEqual({ id: 'st-1' });
+  });
+});

--- a/mobile/src/features/surat-tugas/assignmentFormApi.ts
+++ b/mobile/src/features/surat-tugas/assignmentFormApi.ts
@@ -1,0 +1,66 @@
+import { apiClient } from '@/lib/api/client';
+import { AssignmentFormData } from './assignmentFormSchema';
+import { AssignmentDetail } from './types';
+
+export type AssignmentFormPayload = {
+  nomor_surat?: string | null;
+  kode_surat?: string | null;
+  tanggal_surat?: string | null;
+  maksud_tujuan: string;
+  dasar_hukum?: string | null;
+  tanggal_mulai: string;
+  tanggal_selesai: string;
+  tempat_tujuan: string;
+  sumber_dana: string;
+  sumber_dana_other?: string | null;
+  template_type?: string | null;
+  menimbang?: string[] | null;
+  dasar?: string[] | null;
+  tembusan?: string[] | null;
+  penandatangan_nama?: string | null;
+  penandatangan_nip?: string | null;
+  transportasi?: string | null;
+  employees: {
+    id: number;
+    peran?: string | null;
+  }[];
+};
+
+export function toAssignmentFormPayload(data: AssignmentFormData): AssignmentFormPayload {
+  return {
+    nomor_surat: data.nomor_surat || null,
+    kode_surat: data.kode_surat || null,
+    tanggal_surat: data.tanggal_surat || null,
+    maksud_tujuan: data.maksud_tujuan,
+    dasar_hukum: data.dasar_hukum || null,
+    tanggal_mulai: data.tanggal_mulai,
+    tanggal_selesai: data.tanggal_selesai,
+    tempat_tujuan: data.tempat_tujuan,
+    sumber_dana: data.sumber_dana,
+    sumber_dana_other: data.sumber_dana_other || null,
+    template_type: data.template_type || null,
+    menimbang: data.menimbang || null,
+    dasar: data.dasar || null,
+    tembusan: data.tembusan || null,
+    penandatangan_nama: data.penandatangan_nama || null,
+    penandatangan_nip: data.penandatangan_nip || null,
+    transportasi: data.transport_required ? data.transportasi || null : null,
+    employees: data.employees.map((employee) => ({
+      id: Number(employee.id),
+      peran: employee.peran || null,
+    })),
+  };
+}
+
+export async function createAssignment(data: AssignmentFormData): Promise<AssignmentDetail | { id: string | number }> {
+  const response = await apiClient.post('/surat-tugas', toAssignmentFormPayload(data));
+  return response.data.data;
+}
+
+export async function updateAssignment(
+  id: string | number,
+  data: AssignmentFormData
+): Promise<AssignmentDetail | { id: string | number }> {
+  const response = await apiClient.put(`/surat-tugas/${id}`, toAssignmentFormPayload(data));
+  return response.data.data;
+}

--- a/mobile/src/features/surat-tugas/screens/AssignmentFormScreen.tsx
+++ b/mobile/src/features/surat-tugas/screens/AssignmentFormScreen.tsx
@@ -13,14 +13,20 @@ import {
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { Controller, useFieldArray, useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { AppButton } from '@/components/AppButton';
 import { AppTextInput } from '@/components/AppTextInput';
+import { ErrorState } from '@/components/ErrorState';
 import { IconButton } from '@/components/IconButton';
+import { LoadingSkeleton } from '@/components/LoadingSkeleton';
 import { SectionCard } from '@/components/SectionCard';
 import { useAppTheme } from '@/hooks/useAppTheme';
+import { ApiError } from '@/types/api';
+import { createAssignment, updateAssignment } from '../assignmentFormApi';
 import { assignmentFormSchema, AssignmentFormData } from '../assignmentFormSchema';
 import { SuratTugasStackParamList } from '../navigation/SuratTugasNavigator';
+import { useAssignmentDetail } from '../useAssignmentDetail';
 
 const defaultValues: AssignmentFormData = {
   nomor_surat: null,
@@ -44,15 +50,61 @@ const defaultValues: AssignmentFormData = {
   employees: [{ id: '' as any, peran: null }],
 };
 
+function mapDetailToFormValues(detail: any): AssignmentFormData {
+  return {
+    nomor_surat: detail.nomor ?? null,
+    kode_surat: detail.kode_surat ?? null,
+    tanggal_surat: detail.tanggal_surat ?? null,
+    maksud_tujuan: detail.kegiatan ?? '',
+    dasar_hukum: detail.dasar_hukum ?? null,
+    tanggal_mulai: detail.tanggal_mulai ?? '',
+    tanggal_selesai: detail.tanggal_selesai ?? '',
+    tempat_tujuan: detail.tujuan ?? '',
+    sumber_dana: detail.sumber_dana ?? 'dipa',
+    sumber_dana_other: null,
+    template_type: detail.template_type ?? null,
+    menimbang: null,
+    dasar: null,
+    tembusan: null,
+    penandatangan_nama: null,
+    penandatangan_nip: null,
+    transport_required: false,
+    transportasi: null,
+    employees:
+      detail.personel?.length > 0
+        ? detail.personel.map((personel: any) => ({
+            id: Number(personel.id),
+            peran: personel.peran ?? null,
+          }))
+        : [{ id: '' as any, peran: null }],
+  };
+}
+
+function fieldErrorKeyToFormPath(field: string): string {
+  return field
+    .replace(/^employee_ids\.(\d+)$/, 'employees.$1.id')
+    .replace(/^employees\.(\d+)\.id$/, 'employees.$1.id')
+    .replace(/^employees\.(\d+)\.peran$/, 'employees.$1.peran');
+}
+
 export default function AssignmentFormScreen() {
   const { colors, spacing, typography, radius } = useAppTheme();
-  const navigation = useNavigation();
+  const navigation = useNavigation<NativeStackNavigationProp<SuratTugasStackParamList>>();
   const route = useRoute<RouteProp<SuratTugasStackParamList, 'AssignmentForm'>>();
-  const isEdit = route.params?.id !== undefined;
+  const assignmentId = route.params?.id;
+  const isEdit = assignmentId !== undefined;
+  const {
+    data: assignmentDetail,
+    isLoading,
+    error,
+    refetch,
+  } = useAssignmentDetail(assignmentId, 'management');
 
   const {
     control,
     handleSubmit,
+    reset,
+    setError,
     formState: { errors, isSubmitting },
   } = useForm<AssignmentFormData>({
     resolver: zodResolver(assignmentFormSchema) as any,
@@ -67,11 +119,59 @@ export default function AssignmentFormScreen() {
   const watchedValues = useWatch({ control });
   const transportRequired = watchedValues.transport_required;
 
-  const onSubmit = () => {
-    Alert.alert(
-      isEdit ? 'Ubah Surat Tugas' : 'Buat Surat Tugas',
-      'Form sudah valid. Submit API akan disambungkan pada task berikutnya.'
-    );
+  React.useEffect(() => {
+    if (isEdit && assignmentDetail) {
+      reset(mapDetailToFormValues(assignmentDetail));
+    }
+  }, [assignmentDetail, isEdit, reset]);
+
+  const mapServerFieldErrors = (apiError: ApiError) => {
+    if (apiError.kind !== 'validation' || !apiError.fieldErrors) {
+      return false;
+    }
+
+    Object.entries(apiError.fieldErrors).forEach(([field, messages]) => {
+      const message = messages[0];
+      if (message) {
+        setError(fieldErrorKeyToFormPath(field) as any, {
+          type: 'server',
+          message,
+        });
+      }
+    });
+
+    return true;
+  };
+
+  const onSubmit = async (data: AssignmentFormData) => {
+    try {
+      const savedAssignment =
+        isEdit && assignmentId !== undefined
+          ? await updateAssignment(assignmentId, data)
+          : await createAssignment(data);
+      const savedId = savedAssignment?.id ?? assignmentId;
+
+      Alert.alert(
+        isEdit ? 'Ubah Surat Tugas' : 'Buat Surat Tugas',
+        isEdit ? 'Surat Tugas berhasil diubah.' : 'Surat Tugas berhasil dibuat.'
+      );
+
+      if (savedId !== undefined) {
+        navigation.navigate('AssignmentDetail', { id: savedId, mode: 'management' });
+      } else {
+        navigation.navigate('SuratTugasList');
+      }
+    } catch (submitError) {
+      const apiError = submitError as ApiError;
+      if (mapServerFieldErrors(apiError)) {
+        return;
+      }
+
+      Alert.alert(
+        isEdit ? 'Gagal Mengubah Surat Tugas' : 'Gagal Membuat Surat Tugas',
+        apiError.message || 'Terjadi kesalahan saat menyimpan Surat Tugas.'
+      );
+    }
   };
 
   const renderHeader = () => (
@@ -97,6 +197,32 @@ export default function AssignmentFormScreen() {
       </Text>
     </View>
   );
+
+  if (isEdit && isLoading && !assignmentDetail) {
+    return (
+      <SafeAreaView style={[styles.safeArea, { backgroundColor: colors.background }]}>
+        {renderHeader()}
+        <View style={{ flex: 1, paddingHorizontal: spacing.lg }}>
+          <LoadingSkeleton variant="detail" count={1} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (isEdit && error) {
+    return (
+      <SafeAreaView style={[styles.safeArea, { backgroundColor: colors.background }]}>
+        {renderHeader()}
+        <View style={{ flex: 1, justifyContent: 'center', padding: spacing.lg }}>
+          <ErrorState
+            title="Gagal Memuat Surat Tugas"
+            message={error.message || 'Terjadi kesalahan saat memuat data Surat Tugas.'}
+            onRetry={refetch}
+          />
+        </View>
+      </SafeAreaView>
+    );
+  }
 
   return (
     <SafeAreaView style={[styles.safeArea, { backgroundColor: colors.background }]}>
@@ -405,10 +531,10 @@ export default function AssignmentFormScreen() {
           </SectionCard>
 
           <AppButton
-            title="Validasi Form"
+            title={isEdit ? 'Simpan Perubahan' : 'Buat Surat Tugas'}
             onPress={handleSubmit(onSubmit)}
             loading={isSubmitting}
-            accessibilityLabel="Validasi form Surat Tugas"
+            accessibilityLabel={isEdit ? 'Simpan perubahan Surat Tugas' : 'Buat Surat Tugas'}
           />
         </ScrollView>
       </KeyboardAvoidingView>

--- a/mobile/src/features/surat-tugas/screens/__tests__/AssignmentFormScreen.test.tsx
+++ b/mobile/src/features/surat-tugas/screens/__tests__/AssignmentFormScreen.test.tsx
@@ -2,17 +2,30 @@ import React from 'react';
 import { Alert, KeyboardAvoidingView, Switch, Text } from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 import AssignmentFormScreen from '../AssignmentFormScreen';
+import { createAssignment, updateAssignment } from '../../assignmentFormApi';
+import { useAssignmentDetail } from '../../useAssignmentDetail';
 
 const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
 let mockRouteParams: { id?: string | number } | undefined;
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
     goBack: mockGoBack,
+    navigate: mockNavigate,
   }),
   useRoute: () => ({
     params: mockRouteParams,
   }),
+}));
+
+jest.mock('../../assignmentFormApi', () => ({
+  createAssignment: jest.fn(),
+  updateAssignment: jest.fn(),
+}));
+
+jest.mock('../../useAssignmentDetail', () => ({
+  useAssignmentDetail: jest.fn(),
 }));
 
 jest.mock('@/hooks/useAppTheme', () => ({
@@ -70,6 +83,16 @@ describe('AssignmentFormScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockRouteParams = undefined;
+    (useAssignmentDetail as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: undefined,
+      refetch: jest.fn(),
+      isForbidden: false,
+      isNotFound: false,
+    });
+    (createAssignment as jest.Mock).mockResolvedValue({ id: 'st-new' });
+    (updateAssignment as jest.Mock).mockResolvedValue({ id: 'st-1' });
   });
 
   it('renders the sectioned create form shell inside a keyboard-aware container', () => {
@@ -88,7 +111,7 @@ describe('AssignmentFormScreen', () => {
     expect(tree!.root.findByType(KeyboardAvoidingView).props.style).toEqual({ flex: 1 });
     expect(tree!.root.findByProps({ accessibilityLabel: 'Maksud dan Tujuan *' })).toBeTruthy();
     expect(tree!.root.findByProps({ accessibilityLabel: 'Tempat Tujuan *' })).toBeTruthy();
-    expect(tree!.root.findByProps({ accessibilityLabel: 'Validasi form Surat Tugas' })).toBeTruthy();
+    expect(tree!.root.findByProps({ accessibilityLabel: 'Buat Surat Tugas' })).toBeTruthy();
 
     act(() => {
       tree!.unmount();
@@ -97,6 +120,29 @@ describe('AssignmentFormScreen', () => {
 
   it('renders edit title when an assignment id is provided', () => {
     mockRouteParams = { id: 'st-1' };
+    (useAssignmentDetail as jest.Mock).mockReturnValue({
+      data: {
+        id: 'st-1',
+        nomor: 'ST.001/BKSDA/2026',
+        kode_surat: 'ST',
+        kegiatan: 'Patroli kawasan konservasi',
+        dasar_hukum: 'Dasar hukum',
+        tanggal_mulai: '2026-06-20',
+        tanggal_selesai: '2026-06-21',
+        tanggal_surat: '2026-06-19',
+        tujuan: 'Samarinda',
+        sumber_dana: 'dipa',
+        template_type: 'default',
+        personel: [{ id: 12, name: 'Pegawai Satu', peran: 'Ketua Tim' }],
+        file: { available: false },
+        allowed_actions: { can_view: true },
+      },
+      isLoading: false,
+      error: undefined,
+      refetch: jest.fn(),
+      isForbidden: false,
+      isNotFound: false,
+    });
 
     let tree: renderer.ReactTestRenderer;
     act(() => {
@@ -105,6 +151,9 @@ describe('AssignmentFormScreen', () => {
 
     const texts = tree!.root.findAllByType(Text).map((node) => node.props.children);
     expect(texts).toContain('Ubah Surat Tugas');
+    expect(tree!.root.findByProps({ accessibilityLabel: 'Maksud dan Tujuan *' }).props.value).toBe(
+      'Patroli kawasan konservasi'
+    );
 
     act(() => {
       tree!.unmount();
@@ -147,13 +196,13 @@ describe('AssignmentFormScreen', () => {
     });
   });
 
-  it('shows Indonesian validation errors before the submit API task', async () => {
+  it('shows Indonesian validation errors before submit', async () => {
     let tree: renderer.ReactTestRenderer;
     await act(async () => {
       tree = renderer.create(<AssignmentFormScreen />);
     });
 
-    const submitButton = tree!.root.findByProps({ accessibilityLabel: 'Validasi form Surat Tugas' });
+    const submitButton = tree!.root.findByProps({ accessibilityLabel: 'Buat Surat Tugas' });
     await act(async () => {
       submitButton.props.onPress();
     });
@@ -168,7 +217,7 @@ describe('AssignmentFormScreen', () => {
     });
   });
 
-  it('shows a placeholder alert when the form shell is valid', async () => {
+  it('creates an assignment and opens detail when the form is valid', async () => {
     const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
 
     let tree: renderer.ReactTestRenderer;
@@ -190,15 +239,113 @@ describe('AssignmentFormScreen', () => {
     setText('Sumber Dana *', 'dipa');
     setText('ID Pegawai 1 *', '12');
 
-    const submitButton = tree!.root.findByProps({ accessibilityLabel: 'Validasi form Surat Tugas' });
+    const submitButton = tree!.root.findByProps({ accessibilityLabel: 'Buat Surat Tugas' });
     await act(async () => {
       submitButton.props.onPress();
     });
 
+    expect(createAssignment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maksud_tujuan: 'Patroli kawasan konservasi',
+        tempat_tujuan: 'Samarinda',
+      })
+    );
     expect(alertSpy).toHaveBeenCalledWith(
       'Buat Surat Tugas',
-      'Form sudah valid. Submit API akan disambungkan pada task berikutnya.'
+      'Surat Tugas berhasil dibuat.'
     );
+    expect(mockNavigate).toHaveBeenCalledWith('AssignmentDetail', { id: 'st-new', mode: 'management' });
+
+    alertSpy.mockRestore();
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('maps backend 422 field errors to form inputs', async () => {
+    (createAssignment as jest.Mock).mockRejectedValue({
+      kind: 'validation',
+      message: 'Validasi gagal',
+      fieldErrors: {
+        maksud_tujuan: ['Maksud tujuan dari server wajib diisi'],
+        'employees.0.id': ['Pegawai dari server wajib dipilih'],
+      },
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<AssignmentFormScreen />);
+    });
+
+    const setText = (label: string, value: string) => {
+      const input = tree!.root.findByProps({ accessibilityLabel: label });
+      act(() => {
+        input.props.onChangeText(value);
+      });
+    };
+
+    setText('Maksud dan Tujuan *', 'Patroli kawasan konservasi');
+    setText('Tanggal Mulai *', '2026-06-20');
+    setText('Tanggal Selesai *', '2026-06-21');
+    setText('Tempat Tujuan *', 'Samarinda');
+    setText('Sumber Dana *', 'dipa');
+    setText('ID Pegawai 1 *', '12');
+
+    const submitButton = tree!.root.findByProps({ accessibilityLabel: 'Buat Surat Tugas' });
+    await act(async () => {
+      submitButton.props.onPress();
+    });
+
+    const texts = tree!.root.findAllByType(Text).map((node) => node.props.children);
+    expect(texts).toContain('Maksud tujuan dari server wajib diisi');
+    expect(texts).toContain('Pegawai dari server wajib dipilih');
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('updates an assignment and opens management detail', async () => {
+    mockRouteParams = { id: 'st-1' };
+    (useAssignmentDetail as jest.Mock).mockReturnValue({
+      data: {
+        id: 'st-1',
+        nomor: 'ST.001/BKSDA/2026',
+        kode_surat: 'ST',
+        kegiatan: 'Patroli kawasan konservasi',
+        dasar_hukum: 'Dasar hukum',
+        tanggal_mulai: '2026-06-20',
+        tanggal_selesai: '2026-06-21',
+        tanggal_surat: '2026-06-19',
+        tujuan: 'Samarinda',
+        sumber_dana: 'dipa',
+        template_type: 'default',
+        personel: [{ id: 12, name: 'Pegawai Satu', peran: 'Ketua Tim' }],
+        file: { available: false },
+        allowed_actions: { can_view: true },
+      },
+      isLoading: false,
+      error: undefined,
+      refetch: jest.fn(),
+      isForbidden: false,
+      isNotFound: false,
+    });
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<AssignmentFormScreen />);
+    });
+
+    const submitButton = tree!.root.findByProps({ accessibilityLabel: 'Simpan perubahan Surat Tugas' });
+    await act(async () => {
+      submitButton.props.onPress();
+    });
+
+    expect(updateAssignment).toHaveBeenCalledWith('st-1', expect.objectContaining({ tempat_tujuan: 'Samarinda' }));
+    expect(alertSpy).toHaveBeenCalledWith('Ubah Surat Tugas', 'Surat Tugas berhasil diubah.');
+    expect(mockNavigate).toHaveBeenCalledWith('AssignmentDetail', { id: 'st-1', mode: 'management' });
 
     alertSpy.mockRestore();
     act(() => {


### PR DESCRIPTION
## Summary
- add Surat Tugas assignmentFormApi helper for create/update payloads
- wire AssignmentFormScreen create and edit submit to the API helper
- prefill edit mode from assignment detail and show loading/error states
- map 422 backend field errors back to React Hook Form fields, including employees.*.id
- navigate to management detail after successful submit
- update Task 69 checklist and progress notes

## Validation
- npm test -- --runTestsByPath src/features/surat-tugas/__tests__/assignmentFormApi.test.ts src/features/surat-tugas/screens/__tests__/AssignmentFormScreen.test.tsx
- npm run typecheck
- npm run lint