### PR TITLE
feat(mobile): add Surat Tugas action component (#464)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1031,7 +1031,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: success opens detail or refreshes relevant list.
   - _Requirements: 12, 17, 19_
 
-- [ ] 70. Add approval/status action component
+- [x] 70. Add approval/status action component
   - Target area: `mobile/src/features/surat-tugas/components/AssignmentActions.tsx`.
   - Render approve, reject, and status update actions based on allowed actions.
   - Acceptance check: each action requires confirmation.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,43 @@
+# Progress - Phase 113: Mobile Surat Tugas Approval Action Component
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-70`.
+> GitHub Issue: #464.
+
+---
+
+## Mobile Surat Tugas Approval Action Component
+
+### Status: SELESAI
+- Scope: Mobile App (Surat Tugas Module)
+- Tujuan: Menyediakan komponen aksi status Surat Tugas yang menampilkan aksi sesuai permission backend dan selalu meminta konfirmasi.
+
+### Implementasi
+- **Component**:
+  - Membuat `AssignmentActions` untuk render aksi `Ajukan`, `Setujui`, `Tolak`, dan `Selesai`.
+  - Aksi hanya muncul berdasarkan `allowed_actions` dari backend dan tidak menampilkan aksi untuk status saat ini.
+  - Setiap aksi membuka `ConfirmDialog` sebelum callback `onAction(status)` dipanggil.
+  - Aksi destruktif seperti `Tolak` memakai variant danger dan dialog destruktif.
+- **Detail Wiring**:
+  - Menambahkan `AssignmentActions` ke `AssignmentDetailScreen`.
+  - Callback detail masih placeholder alert karena pemanggilan API status masuk Task 71.
+- **Tests**:
+  - Menambahkan test gating action berdasarkan `allowed_actions`.
+  - Menambahkan test bahwa callback tidak terpanggil sebelum user confirm.
+  - Memastikan detail screen tetap render dengan action component baru.
+- **Checklist**:
+  - Mencentang Task 70 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/surat-tugas/components/__tests__/AssignmentActions.test.tsx src/features/surat-tugas/screens/__tests__/AssignmentDetailScreen.test.tsx`: 8 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 71: Wire approval/status API.
+
+---
+
 # Progress - Phase 112: Mobile Surat Tugas Create/Edit Submit
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/surat-tugas/components/AssignmentActions.tsx
+++ b/mobile/src/features/surat-tugas/components/AssignmentActions.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { AppButton } from '@/components/AppButton';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { SectionCard } from '@/components/SectionCard';
+import { useAppTheme } from '@/hooks/useAppTheme';
+import { AssignmentAllowedActions, AssignmentStatus } from '../types';
+
+export type AssignmentActionType = Extract<AssignmentStatus, 'pending' | 'approved' | 'rejected' | 'completed'>;
+
+type ActionConfig = {
+  status: AssignmentActionType;
+  title: string;
+  message: string;
+  buttonTitle: string;
+  confirmText: string;
+  variant: 'primary' | 'secondary' | 'danger';
+  destructive?: boolean;
+};
+
+export type AssignmentActionsProps = {
+  allowedActions: AssignmentAllowedActions;
+  currentStatus?: AssignmentStatus | null;
+  onAction: (status: AssignmentActionType) => void;
+  disabled?: boolean;
+};
+
+const actionConfigs: ActionConfig[] = [
+  {
+    status: 'pending',
+    title: 'Ajukan Surat Tugas',
+    message: 'Ajukan Surat Tugas ini untuk proses persetujuan?',
+    buttonTitle: 'Ajukan',
+    confirmText: 'Ya, Ajukan',
+    variant: 'secondary',
+  },
+  {
+    status: 'approved',
+    title: 'Setujui Surat Tugas',
+    message: 'Setujui Surat Tugas ini dan lanjutkan proses penerbitan?',
+    buttonTitle: 'Setujui',
+    confirmText: 'Ya, Setujui',
+    variant: 'primary',
+  },
+  {
+    status: 'rejected',
+    title: 'Tolak Surat Tugas',
+    message: 'Tolak Surat Tugas ini? Tindakan ini perlu alasan pada proses berikutnya.',
+    buttonTitle: 'Tolak',
+    confirmText: 'Ya, Tolak',
+    variant: 'danger',
+    destructive: true,
+  },
+  {
+    status: 'completed',
+    title: 'Selesaikan Surat Tugas',
+    message: 'Tandai Surat Tugas ini sebagai selesai?',
+    buttonTitle: 'Selesai',
+    confirmText: 'Ya, Selesai',
+    variant: 'secondary',
+  },
+];
+
+function getVisibleActions(allowedActions: AssignmentAllowedActions, currentStatus?: AssignmentStatus | null) {
+  return actionConfigs.filter((config) => {
+    if (config.status === currentStatus) {
+      return false;
+    }
+
+    if (config.status === 'pending') {
+      return allowedActions.can_update;
+    }
+
+    if (config.status === 'approved') {
+      return allowedActions.can_approve;
+    }
+
+    if (config.status === 'rejected') {
+      return allowedActions.can_reject;
+    }
+
+    if (config.status === 'completed') {
+      return allowedActions.can_complete;
+    }
+
+    return false;
+  });
+}
+
+export default function AssignmentActions({
+  allowedActions,
+  currentStatus,
+  onAction,
+  disabled = false,
+}: AssignmentActionsProps) {
+  const { colors, spacing, typography } = useAppTheme();
+  const visibleActions = getVisibleActions(allowedActions, currentStatus);
+  const [pendingAction, setPendingAction] = React.useState<ActionConfig | null>(null);
+
+  const confirmAction = () => {
+    if (!pendingAction) {
+      return;
+    }
+
+    const action = pendingAction;
+    setPendingAction(null);
+    onAction(action.status);
+  };
+
+  if (visibleActions.length === 0) {
+    return null;
+  }
+
+  return (
+    <SectionCard title="Aksi Surat Tugas">
+      <Text
+        style={[
+          styles.helper,
+          {
+            color: colors.mutedForeground,
+            fontSize: typography.fontSizes.sm,
+            marginBottom: spacing.md,
+          },
+        ]}
+      >
+        Setiap perubahan status memerlukan konfirmasi.
+      </Text>
+      <View style={[styles.actionRow, { gap: spacing.sm }]}>
+        {visibleActions.map((action) => (
+          <View key={action.status} style={styles.actionButton}>
+            <AppButton
+              title={action.buttonTitle}
+              variant={action.variant}
+              disabled={disabled}
+              onPress={() => setPendingAction(action)}
+              accessibilityLabel={`${action.buttonTitle} Surat Tugas`}
+            />
+          </View>
+        ))}
+      </View>
+      <ConfirmDialog
+        visible={!!pendingAction}
+        title={pendingAction?.title || ''}
+        message={pendingAction?.message || ''}
+        confirmText={pendingAction?.confirmText}
+        isDestructive={pendingAction?.destructive}
+        onCancel={() => setPendingAction(null)}
+        onConfirm={confirmAction}
+      />
+    </SectionCard>
+  );
+}
+
+const styles = StyleSheet.create({
+  helper: {
+    lineHeight: 20,
+  },
+  actionRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  actionButton: {
+    flexBasis: '48%',
+    flexGrow: 1,
+    minWidth: 140,
+  },
+});

--- a/mobile/src/features/surat-tugas/components/__tests__/AssignmentActions.test.tsx
+++ b/mobile/src/features/surat-tugas/components/__tests__/AssignmentActions.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { Modal, Text, TouchableOpacity } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+import AssignmentActions from '../AssignmentActions';
+
+jest.mock('@/hooks/useAppTheme', () => ({
+  useAppTheme: () => ({
+    isDark: false,
+    colors: {
+      background: '#ffffff',
+      primary: '#16a34a',
+      primaryForeground: '#ffffff',
+      secondary: '#f1f5f9',
+      secondaryForeground: '#0f172a',
+      danger: '#dc2626',
+      dangerForeground: '#ffffff',
+      foreground: '#09090b',
+      card: '#ffffff',
+      border: '#e2e8f0',
+      mutedForeground: '#64748b',
+    },
+    spacing: {
+      xs: 4,
+      sm: 8,
+      md: 12,
+      lg: 16,
+      xl: 20,
+    },
+    radius: {
+      lg: 8,
+      xl: 12,
+    },
+    shadows: {
+      sm: {},
+    },
+    typography: {
+      fontWeights: {
+        bold: '700',
+        semibold: '600',
+      },
+      fontSizes: {
+        xs: 12,
+        sm: 14,
+        md: 16,
+        lg: 18,
+      },
+    },
+  }),
+}));
+
+describe('AssignmentActions', () => {
+  it('renders only actions allowed by the backend', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <AssignmentActions
+          allowedActions={{
+            can_view: true,
+            can_approve: true,
+            can_reject: true,
+            can_complete: false,
+            can_update: false,
+          }}
+          currentStatus="pending"
+          onAction={jest.fn()}
+        />
+      );
+    });
+
+    const texts = tree!.root.findAllByType(Text).map((node) => node.props.children);
+    expect(texts).toContain('Aksi Surat Tugas');
+    expect(texts).toContain('Setujui');
+    expect(texts).toContain('Tolak');
+    expect(texts).not.toContain('Selesai');
+    expect(texts).not.toContain('Ajukan');
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('requires confirmation before calling the action callback', () => {
+    const handleAction = jest.fn();
+
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <AssignmentActions
+          allowedActions={{
+            can_view: true,
+            can_approve: true,
+            can_reject: false,
+            can_complete: false,
+            can_update: false,
+          }}
+          currentStatus="pending"
+          onAction={handleAction}
+        />
+      );
+    });
+
+    const approveButton = tree!.root.findByProps({ accessibilityLabel: 'Setujui Surat Tugas' });
+    act(() => {
+      approveButton.props.onPress();
+    });
+
+    expect(handleAction).not.toHaveBeenCalled();
+    expect(tree!.root.findByType(Modal).props.visible).toBe(true);
+    expect(tree!.root.findAllByType(Text).map((node) => node.props.children)).toContain('Setujui Surat Tugas');
+
+    const touchables = tree!.root.findAllByType(TouchableOpacity);
+    const confirmTouchable = touchables[touchables.length - 1];
+    act(() => {
+      confirmTouchable.props.onPress();
+    });
+
+    expect(handleAction).toHaveBeenCalledWith('approved');
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('renders nothing when no status actions are allowed', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <AssignmentActions
+          allowedActions={{ can_view: true }}
+          currentStatus="approved"
+          onAction={jest.fn()}
+        />
+      );
+    });
+
+    expect(tree!.toJSON()).toBeNull();
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+});

--- a/mobile/src/features/surat-tugas/screens/AssignmentDetailScreen.tsx
+++ b/mobile/src/features/surat-tugas/screens/AssignmentDetailScreen.tsx
@@ -7,6 +7,7 @@ import { ErrorState } from '@/components/ErrorState';
 import { IconButton } from '@/components/IconButton';
 import { LoadingSkeleton } from '@/components/LoadingSkeleton';
 import { useAppTheme } from '@/hooks/useAppTheme';
+import AssignmentActions, { AssignmentActionType } from '../components/AssignmentActions';
 import {
   AssignmentContentSection,
   AssignmentDatesSection,
@@ -27,6 +28,10 @@ export default function AssignmentDetailScreen() {
 
   const handleDownload = () => {
     Alert.alert('Unduh Surat Tugas', 'Fitur unduh berkas akan disiapkan pada task file download berikutnya.');
+  };
+
+  const handleStatusAction = (status: AssignmentActionType) => {
+    Alert.alert('Aksi Surat Tugas', `Aksi status ${status} akan disambungkan pada task berikutnya.`);
   };
 
   const renderHeader = (title = 'Detail Surat Tugas') => (
@@ -122,6 +127,11 @@ export default function AssignmentDetailScreen() {
         <AssignmentContentSection assignment={data} />
         <AssignmentFileSection assignment={data} />
         <AssignmentStatusSection assignment={data} />
+        <AssignmentActions
+          allowedActions={data.allowed_actions}
+          currentStatus={data.status}
+          onAction={handleStatusAction}
+        />
 
         {canDownload ? (
           <View style={{ marginTop: spacing.sm }}>


### PR DESCRIPTION
## Summary
- add AssignmentActions for approve, reject, pending, and complete status actions
- gate each action by backend allowed_actions and current status
- require ConfirmDialog confirmation before invoking any status callback
- wire the component into AssignmentDetailScreen with placeholder handling for Task 71 API wiring
- update Task 70 checklist and progress notes

## Validation
- npm test -- --runTestsByPath src/features/surat-tugas/components/__tests__/AssignmentActions.test.tsx src/features/surat-tugas/screens/__tests__/AssignmentDetailScreen.test.tsx
- npm run typecheck
- npm run lint