### PR TITLE
feat(mobile): wire Surat Tugas status actions (#466)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1037,7 +1037,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: each action requires confirmation.
   - _Requirements: 13, 19, 20_
 
-- [ ] 71. Wire approval/status API
+- [x] 71. Wire approval/status API
   - Target area: Surat Tugas action API helper.
   - Call backend status endpoints and handle invalid transition errors.
   - Acceptance check: success refreshes list and detail.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,41 @@
+# Progress - Phase 114: Mobile Surat Tugas Status Action API
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-71`.
+> GitHub Issue: #466.
+
+---
+
+## Mobile Surat Tugas Status Action API
+
+### Status: SELESAI
+- Scope: Mobile App (Surat Tugas Module)
+- Tujuan: Menghubungkan aksi status Surat Tugas mobile ke endpoint backend dan refresh detail setelah berhasil.
+
+### Implementasi
+- **API Helper**:
+  - Membuat `assignmentActionsApi.ts` untuk `PUT /surat-tugas/{id}/status`.
+  - Mendukung payload `status` dan optional `nomor_surat` sesuai backend.
+- **Detail Wiring**:
+  - Mengubah `AssignmentDetailScreen` agar `AssignmentActions` memanggil API status.
+  - Sukses menampilkan pesan berhasil dan memanggil `refetch()` detail.
+  - Error validasi/transisi status ditampilkan sebagai pesan user-friendly tanpa stack trace.
+- **Tests**:
+  - Menambahkan test helper endpoint status.
+  - Memperbarui test detail untuk success refresh dan error transition.
+- **Checklist**:
+  - Mencentang Task 71 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/surat-tugas/__tests__/assignmentActionsApi.test.ts src/features/surat-tugas/screens/__tests__/AssignmentDetailScreen.test.tsx`: 9 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 72: Add authenticated file download helper.
+
+---
+
 # Progress - Phase 113: Mobile Surat Tugas Approval Action Component
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/surat-tugas/__tests__/assignmentActionsApi.test.ts
+++ b/mobile/src/features/surat-tugas/__tests__/assignmentActionsApi.test.ts
@@ -1,0 +1,43 @@
+import { updateAssignmentStatus } from '../assignmentActionsApi';
+import { apiClient } from '@/lib/api/client';
+
+jest.mock('@/lib/api/client', () => ({
+  apiClient: {
+    put: jest.fn(),
+  },
+}));
+
+describe('assignmentActionsApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('puts status payload to the Surat Tugas status endpoint', async () => {
+    (apiClient.put as jest.Mock).mockResolvedValue({
+      data: { data: { id: 'st-1', status: 'approved' } },
+    });
+
+    const result = await updateAssignmentStatus('st-1', { status: 'approved' });
+
+    expect(apiClient.put).toHaveBeenCalledWith('/surat-tugas/st-1/status', {
+      status: 'approved',
+    });
+    expect(result).toEqual({ id: 'st-1', status: 'approved' });
+  });
+
+  it('passes optional nomor_surat when included', async () => {
+    (apiClient.put as jest.Mock).mockResolvedValue({
+      data: { data: { id: 'st-1', status: 'approved' } },
+    });
+
+    await updateAssignmentStatus('st-1', {
+      status: 'approved',
+      nomor_surat: 'ST.001/BKSDA/2026',
+    });
+
+    expect(apiClient.put).toHaveBeenCalledWith('/surat-tugas/st-1/status', {
+      status: 'approved',
+      nomor_surat: 'ST.001/BKSDA/2026',
+    });
+  });
+});

--- a/mobile/src/features/surat-tugas/assignmentActionsApi.ts
+++ b/mobile/src/features/surat-tugas/assignmentActionsApi.ts
@@ -1,0 +1,10 @@
+import { apiClient } from '@/lib/api/client';
+import { AssignmentStatusActionPayload, AssignmentDetail } from './types';
+
+export async function updateAssignmentStatus(
+  id: string | number,
+  payload: AssignmentStatusActionPayload
+): Promise<AssignmentDetail | { id: string | number }> {
+  const response = await apiClient.put(`/surat-tugas/${id}/status`, payload);
+  return response.data.data;
+}

--- a/mobile/src/features/surat-tugas/screens/AssignmentDetailScreen.tsx
+++ b/mobile/src/features/surat-tugas/screens/AssignmentDetailScreen.tsx
@@ -7,6 +7,8 @@ import { ErrorState } from '@/components/ErrorState';
 import { IconButton } from '@/components/IconButton';
 import { LoadingSkeleton } from '@/components/LoadingSkeleton';
 import { useAppTheme } from '@/hooks/useAppTheme';
+import { ApiError } from '@/types/api';
+import { updateAssignmentStatus } from '../assignmentActionsApi';
 import AssignmentActions, { AssignmentActionType } from '../components/AssignmentActions';
 import {
   AssignmentContentSection,
@@ -30,8 +32,20 @@ export default function AssignmentDetailScreen() {
     Alert.alert('Unduh Surat Tugas', 'Fitur unduh berkas akan disiapkan pada task file download berikutnya.');
   };
 
-  const handleStatusAction = (status: AssignmentActionType) => {
-    Alert.alert('Aksi Surat Tugas', `Aksi status ${status} akan disambungkan pada task berikutnya.`);
+  const handleStatusAction = async (status: AssignmentActionType) => {
+    try {
+      await updateAssignmentStatus(id, { status });
+      Alert.alert('Aksi Surat Tugas', 'Status Surat Tugas berhasil diperbarui.');
+      refetch();
+    } catch (actionError) {
+      const apiError = actionError as ApiError;
+      const message =
+        apiError.kind === 'validation'
+          ? apiError.message || 'Status Surat Tugas tidak valid untuk kondisi saat ini.'
+          : apiError.message || 'Gagal memperbarui status Surat Tugas.';
+
+      Alert.alert('Gagal Memproses Aksi', message);
+    }
   };
 
   const renderHeader = (title = 'Detail Surat Tugas') => (

--- a/mobile/src/features/surat-tugas/screens/__tests__/AssignmentDetailScreen.test.tsx
+++ b/mobile/src/features/surat-tugas/screens/__tests__/AssignmentDetailScreen.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Alert, Text } from 'react-native';
+import { Alert, Text, TouchableOpacity } from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 import AssignmentDetailScreen from '../AssignmentDetailScreen';
 import { useAssignmentDetail } from '../../useAssignmentDetail';
+import { updateAssignmentStatus } from '../../assignmentActionsApi';
 
 const mockGoBack = jest.fn();
 let mockRouteParams: { id: string | number; mode?: 'personal' | 'management' } = {
@@ -72,6 +73,10 @@ jest.mock('../../useAssignmentDetail', () => ({
   useAssignmentDetail: jest.fn(),
 }));
 
+jest.mock('../../assignmentActionsApi', () => ({
+  updateAssignmentStatus: jest.fn(),
+}));
+
 describe('AssignmentDetailScreen', () => {
   const refetch = jest.fn();
   const assignment = {
@@ -109,6 +114,7 @@ describe('AssignmentDetailScreen', () => {
       isForbidden: false,
       isNotFound: false,
     });
+    (updateAssignmentStatus as jest.Mock).mockResolvedValue({ id: 'st-1', status: 'completed' });
   });
 
   it('renders detail sections and gated file action when file is allowed', () => {
@@ -222,6 +228,102 @@ describe('AssignmentDetailScreen', () => {
       'Unduh Surat Tugas',
       'Fitur unduh berkas akan disiapkan pada task file download berikutnya.'
     );
+
+    alertSpy.mockRestore();
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('updates status and refreshes detail after confirmed action', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    (useAssignmentDetail as jest.Mock).mockReturnValue({
+      data: {
+        ...assignment,
+        status: 'pending',
+        allowed_actions: {
+          can_view: true,
+          can_download: true,
+          can_approve: true,
+        },
+      },
+      isLoading: false,
+      error: undefined,
+      refetch,
+      isForbidden: false,
+      isNotFound: false,
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<AssignmentDetailScreen />);
+    });
+
+    const approveButton = tree!.root.findByProps({ accessibilityLabel: 'Setujui Surat Tugas' });
+    await act(async () => {
+      approveButton.props.onPress();
+    });
+
+    const confirmTouchable = tree!.root.findAllByType(TouchableOpacity).find((node) =>
+      node.findAllByType(Text).some((textNode) => textNode.props.children === 'Ya, Setujui')
+    );
+    await act(async () => {
+      confirmTouchable?.props.onPress();
+    });
+
+    expect(updateAssignmentStatus).toHaveBeenCalledWith('st-1', { status: 'approved' });
+    expect(alertSpy).toHaveBeenCalledWith('Aksi Surat Tugas', 'Status Surat Tugas berhasil diperbarui.');
+    expect(refetch).toHaveBeenCalledTimes(1);
+
+    alertSpy.mockRestore();
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('shows a user-friendly message when status transition fails', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    (updateAssignmentStatus as jest.Mock).mockRejectedValue({
+      kind: 'validation',
+      message: 'Status Surat Tugas tidak valid.',
+      status: 422,
+    });
+    (useAssignmentDetail as jest.Mock).mockReturnValue({
+      data: {
+        ...assignment,
+        status: 'pending',
+        allowed_actions: {
+          can_view: true,
+          can_download: true,
+          can_approve: true,
+        },
+      },
+      isLoading: false,
+      error: undefined,
+      refetch,
+      isForbidden: false,
+      isNotFound: false,
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<AssignmentDetailScreen />);
+    });
+
+    const approveButton = tree!.root.findByProps({ accessibilityLabel: 'Setujui Surat Tugas' });
+    await act(async () => {
+      approveButton.props.onPress();
+    });
+
+    const confirmTouchable = tree!.root.findAllByType(TouchableOpacity).find((node) =>
+      node.findAllByType(Text).some((textNode) => textNode.props.children === 'Ya, Setujui')
+    );
+    await act(async () => {
+      confirmTouchable?.props.onPress();
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith('Gagal Memproses Aksi', 'Status Surat Tugas tidak valid.');
+    expect(refetch).not.toHaveBeenCalled();
 
     alertSpy.mockRestore();
     act(() => {


### PR DESCRIPTION
## Summary
- add assignmentActionsApi helper for PUT /surat-tugas/{id}/status
- wire AssignmentDetailScreen status actions to the backend helper
- show success/error alerts and refetch detail on successful status update
- cover invalid status transition errors with user-friendly messaging
- update Task 71 checklist and progress notes

## Validation
- npm test -- --runTestsByPath src/features/surat-tugas/__tests__/assignmentActionsApi.test.ts src/features/surat-tugas/screens/__tests__/AssignmentDetailScreen.test.tsx
- npm run typecheck
- npm run lint