### PR TITLE
feat(mobile): add authenticated file download helper (#468)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1043,7 +1043,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: success refreshes list and detail.
   - _Requirements: 13, 17, 19_
 
-- [ ] 72. Add authenticated file download helper
+- [x] 72. Add authenticated file download helper
   - Target area: `mobile/src/lib/files/download.ts`.
   - Download files with auth header and save to app cache/documents.
   - Acceptance check: helper does not expose unauthenticated file URLs.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,42 @@
+# Progress - Phase 115: Mobile Authenticated File Download Helper
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-72`.
+> GitHub Issue: #468.
+
+---
+
+## Mobile Authenticated File Download Helper
+
+### Status: SELESAI
+- Scope: Mobile App (Surat Tugas Module)
+- Tujuan: Menyediakan helper download file Surat Tugas melalui endpoint authenticated dan menyimpan hasilnya ke storage aplikasi.
+
+### Implementasi
+- **Dependency**:
+  - Menambahkan `expo-file-system` versi SDK 56 agar aplikasi dapat menyimpan file ke cache/documents.
+- **Download Helper**:
+  - Membuat [download.ts](file:///e:/bksda-superapp/mobile/src/lib/files/download.ts).
+  - Helper membangun endpoint authenticated berdasarkan `assignmentId` dan mode: personal memakai `/surat-tugas/my/{id}/download`, management memakai `/surat-tugas/{id}/download`.
+  - Menambahkan header `Authorization: Bearer <token>`, `Accept`, dan `X-Client: mobile` pada request download.
+  - Menyimpan file ke folder `surat-tugas/` di cache atau document storage.
+  - Membersihkan file hasil download gagal dan mengembalikan error user-friendly untuk 401, 403, 404, server, dan network.
+  - Tidak mengandalkan atau mengekspos unauthenticated file URL dari payload detail.
+- **Tests**:
+  - Menambahkan [download.test.ts](file:///e:/bksda-superapp/mobile/src/lib/files/__tests__/download.test.ts) untuk personal/management endpoint, auth header, missing token, 404 cleanup, dan filesystem/network failure.
+- **Checklist**:
+  - Mencentang Task 72 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/lib/files/__tests__/download.test.ts`: 5 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 73: Add file viewer/share helper.
+
+---
+
 # Progress - Phase 114: Mobile Surat Tugas Status Action API
 
 > Document updated: 2026-06-19

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^1.18.0",
         "expo": "~56.0.12",
         "expo-camera": "~56.0.8",
+        "expo-file-system": "^56.0.8",
         "expo-location": "~56.0.18",
         "expo-secure-store": "~56.0.4",
         "expo-status-bar": "~56.0.4",
@@ -6776,6 +6777,16 @@
         }
       }
     },
+    "node_modules/expo-file-system": {
+      "version": "56.0.8",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-56.0.8.tgz",
+      "integrity": "sha512-NrH41/8snGIBSbYicwVLB4txPdgCATd7ZYhMAGS3YJZ9GbnduhlAoV4/YCbGayjrbpE9bJb/6wegPL/zmvRMnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-location": {
       "version": "56.0.18",
       "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-56.0.18.tgz",
@@ -7171,16 +7182,6 @@
       "dependencies": {
         "@expo/env": "~2.3.0"
       },
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/expo-file-system": {
-      "version": "56.0.8",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-56.0.8.tgz",
-      "integrity": "sha512-NrH41/8snGIBSbYicwVLB4txPdgCATd7ZYhMAGS3YJZ9GbnduhlAoV4/YCbGayjrbpE9bJb/6wegPL/zmvRMnQ==",
-      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,6 +10,7 @@
     "axios": "^1.18.0",
     "expo": "~56.0.12",
     "expo-camera": "~56.0.8",
+    "expo-file-system": "^56.0.8",
     "expo-location": "~56.0.18",
     "expo-secure-store": "~56.0.4",
     "expo-status-bar": "~56.0.4",

--- a/mobile/src/lib/files/__tests__/download.test.ts
+++ b/mobile/src/lib/files/__tests__/download.test.ts
@@ -1,0 +1,117 @@
+import * as FileSystem from 'expo-file-system/legacy';
+import { getToken } from '@/lib/auth/tokenStorage';
+import { downloadAssignmentFile, FileDownloadError } from '../download';
+
+jest.mock('expo-file-system/legacy', () => ({
+  cacheDirectory: 'file:///cache/',
+  documentDirectory: 'file:///documents/',
+  makeDirectoryAsync: jest.fn(),
+  downloadAsync: jest.fn(),
+  deleteAsync: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/tokenStorage', () => ({
+  getToken: jest.fn(),
+}));
+
+jest.mock('@/lib/api/config', () => ({
+  config: {
+    apiUrl: 'https://api.test.com/api',
+  },
+}));
+
+describe('downloadAssignmentFile', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getToken as jest.Mock).mockResolvedValue('secure-token');
+    (FileSystem.downloadAsync as jest.Mock).mockResolvedValue({
+      uri: 'file:///cache/surat-tugas/surat-tugas.pdf',
+      status: 200,
+      mimeType: 'application/pdf',
+      headers: {},
+    });
+  });
+
+  it('downloads personal assignment files through an authenticated API endpoint', async () => {
+    const result = await downloadAssignmentFile({
+      assignmentId: 'st-1',
+      mode: 'personal',
+      filename: 'ST.001/BKSDA/2026.pdf',
+    });
+
+    expect(FileSystem.makeDirectoryAsync).toHaveBeenCalledWith('file:///cache/surat-tugas/', {
+      intermediates: true,
+    });
+    expect(FileSystem.downloadAsync).toHaveBeenCalledWith(
+      'https://api.test.com/api/surat-tugas/my/st-1/download',
+      'file:///cache/surat-tugas/ST.001-BKSDA-2026.pdf',
+      {
+        headers: {
+          Accept: 'application/pdf,application/octet-stream',
+          Authorization: 'Bearer secure-token',
+          'X-Client': 'mobile',
+        },
+      }
+    );
+    expect(result).toEqual({
+      localUri: 'file:///cache/surat-tugas/surat-tugas.pdf',
+      filename: 'ST.001-BKSDA-2026.pdf',
+      mimeType: 'application/pdf',
+      status: 200,
+    });
+  });
+
+  it('downloads management assignment files to document storage when requested', async () => {
+    await downloadAssignmentFile({
+      assignmentId: 42,
+      mode: 'management',
+      filename: 'surat tugas.pdf',
+      storage: 'document',
+    });
+
+    expect(FileSystem.downloadAsync).toHaveBeenCalledWith(
+      'https://api.test.com/api/surat-tugas/42/download',
+      'file:///documents/surat-tugas/surat tugas.pdf',
+      expect.any(Object)
+    );
+  });
+
+  it('rejects before downloading when no auth token is available', async () => {
+    (getToken as jest.Mock).mockResolvedValue(null);
+
+    await expect(downloadAssignmentFile({ assignmentId: 'st-1' })).rejects.toMatchObject({
+      kind: 'auth',
+      status: 401,
+      message: 'Sesi Anda telah berakhir. Silakan login kembali.',
+    });
+    expect(FileSystem.downloadAsync).not.toHaveBeenCalled();
+  });
+
+  it('deletes failed downloads and returns a user-friendly not found error', async () => {
+    (FileSystem.downloadAsync as jest.Mock).mockResolvedValue({
+      uri: 'file:///cache/surat-tugas/surat-tugas.pdf',
+      status: 404,
+      mimeType: null,
+      headers: {},
+    });
+
+    await expect(downloadAssignmentFile({ assignmentId: 'st-missing' })).rejects.toMatchObject({
+      kind: 'not_found',
+      status: 404,
+      message: 'File Surat Tugas tidak ditemukan atau belum tersedia.',
+    });
+    expect(FileSystem.deleteAsync).toHaveBeenCalledWith('file:///cache/surat-tugas/surat-tugas.pdf', {
+      idempotent: true,
+    });
+  });
+
+  it('wraps filesystem failures as network download errors', async () => {
+    (FileSystem.downloadAsync as jest.Mock).mockRejectedValue(new Error('native failure'));
+
+    await expect(downloadAssignmentFile({ assignmentId: 'st-1' })).rejects.toBeInstanceOf(FileDownloadError);
+    await expect(downloadAssignmentFile({ assignmentId: 'st-1' })).rejects.toMatchObject({
+      kind: 'network',
+      message: 'Koneksi internet terganggu. Silakan periksa koneksi Anda dan coba lagi.',
+    });
+  });
+});

--- a/mobile/src/lib/files/download.ts
+++ b/mobile/src/lib/files/download.ts
@@ -1,0 +1,142 @@
+import * as FileSystem from 'expo-file-system/legacy';
+import { getToken } from '@/lib/auth/tokenStorage';
+import { config } from '@/lib/api/config';
+import { AssignmentListMode } from '@/features/surat-tugas/types';
+
+export type DownloadStorage = 'cache' | 'document';
+
+export type DownloadFileOptions = {
+  assignmentId: string | number;
+  mode?: AssignmentListMode;
+  filename?: string | null;
+  storage?: DownloadStorage;
+};
+
+export type DownloadedFile = {
+  localUri: string;
+  filename: string;
+  mimeType?: string | null;
+  status: number;
+};
+
+export type FileDownloadErrorKind =
+  | 'auth'
+  | 'forbidden'
+  | 'not_found'
+  | 'server'
+  | 'network'
+  | 'unavailable';
+
+export class FileDownloadError extends Error {
+  kind: FileDownloadErrorKind;
+  status?: number;
+
+  constructor(kind: FileDownloadErrorKind, message: string, status?: number) {
+    super(message);
+    this.name = 'FileDownloadError';
+    this.kind = kind;
+    this.status = status;
+  }
+}
+
+function getAssignmentDownloadEndpoint(assignmentId: string | number, mode: AssignmentListMode) {
+  const encodedId = encodeURIComponent(String(assignmentId));
+  return mode === 'personal'
+    ? `/surat-tugas/my/${encodedId}/download`
+    : `/surat-tugas/${encodedId}/download`;
+}
+
+function buildApiUrl(endpoint: string) {
+  return `${config.apiUrl.replace(/\/$/, '')}${endpoint}`;
+}
+
+function sanitizeFilename(filename?: string | null) {
+  const fallback = 'surat-tugas.pdf';
+  const cleaned = (filename || fallback)
+    .trim()
+    .replace(/[\\/:*?"<>|]+/g, '-')
+    .replace(/\s+/g, ' ');
+
+  return cleaned || fallback;
+}
+
+function getBaseDirectory(storage: DownloadStorage) {
+  const baseDirectory = storage === 'document' ? FileSystem.documentDirectory : FileSystem.cacheDirectory;
+
+  if (!baseDirectory) {
+    throw new FileDownloadError('unavailable', 'Penyimpanan file tidak tersedia di perangkat ini.');
+  }
+
+  return baseDirectory;
+}
+
+function getDownloadError(status: number) {
+  if (status === 401) {
+    return new FileDownloadError('auth', 'Sesi Anda telah berakhir. Silakan login kembali.', status);
+  }
+
+  if (status === 403) {
+    return new FileDownloadError('forbidden', 'Anda tidak memiliki akses untuk mengunduh file ini.', status);
+  }
+
+  if (status === 404) {
+    return new FileDownloadError('not_found', 'File Surat Tugas tidak ditemukan atau belum tersedia.', status);
+  }
+
+  if (status >= 500) {
+    return new FileDownloadError('server', 'Server gagal menyiapkan file. Silakan coba lagi nanti.', status);
+  }
+
+  return new FileDownloadError('network', 'Gagal mengunduh file Surat Tugas.', status);
+}
+
+export async function downloadAssignmentFile({
+  assignmentId,
+  mode = 'personal',
+  filename,
+  storage = 'cache',
+}: DownloadFileOptions): Promise<DownloadedFile> {
+  const token = await getToken();
+  if (!token) {
+    throw new FileDownloadError('auth', 'Sesi Anda telah berakhir. Silakan login kembali.', 401);
+  }
+
+  const safeFilename = sanitizeFilename(filename);
+  const directory = `${getBaseDirectory(storage)}surat-tugas/`;
+  const localUri = `${directory}${safeFilename}`;
+  const endpoint = getAssignmentDownloadEndpoint(assignmentId, mode);
+  const downloadUrl = buildApiUrl(endpoint);
+
+  try {
+    await FileSystem.makeDirectoryAsync(directory, { intermediates: true });
+
+    const result = await FileSystem.downloadAsync(downloadUrl, localUri, {
+      headers: {
+        Accept: 'application/pdf,application/octet-stream',
+        Authorization: `Bearer ${token}`,
+        'X-Client': 'mobile',
+      },
+    });
+
+    if (result.status < 200 || result.status >= 300) {
+      await FileSystem.deleteAsync(localUri, { idempotent: true });
+      throw getDownloadError(result.status);
+    }
+
+    return {
+      localUri: result.uri,
+      filename: safeFilename,
+      mimeType: result.mimeType,
+      status: result.status,
+    };
+  } catch (error) {
+    if (error instanceof FileDownloadError) {
+      throw error;
+    }
+
+    throw new FileDownloadError(
+      'network',
+      'Koneksi internet terganggu. Silakan periksa koneksi Anda dan coba lagi.'
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add expo-file-system as a direct mobile dependency
- add downloadAssignmentFile helper for authenticated Surat Tugas file downloads
- build API endpoints from assignment id and mode instead of relying on public file URLs
- save files into app cache/documents and clean failed downloads
- return user-friendly errors for auth, forbidden, missing file, server, and network failures
- update Task 72 checklist and progress notes

## Validation
- npm test -- --runTestsByPath src/lib/files/__tests__/download.test.ts
- npm run typecheck
- npm run lint