### PR TITLE
feat(mobile): add file viewer share helper (#470)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1049,7 +1049,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: helper does not expose unauthenticated file URLs.
   - _Requirements: 14, 19_
 
-- [ ] 73. Add file viewer/share helper
+- [x] 73. Add file viewer/share helper
   - Target area: `mobile/src/lib/files/share.ts`.
   - Open file with viewer or share sheet.
   - Acceptance check: missing file shows user-friendly error.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,40 @@
+# Progress - Phase 116: Mobile File Viewer and Share Helper
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-surat-tugas-task-73`.
+> GitHub Issue: #470.
+
+---
+
+## Mobile File Viewer and Share Helper
+
+### Status: SELESAI
+- Scope: Mobile App (File Helpers / Surat Tugas Module)
+- Tujuan: Menyediakan helper untuk membuka file lokal dengan viewer perangkat atau membagikannya melalui share sheet.
+
+### Implementasi
+- **Dependency**:
+  - Menambahkan `expo-sharing` agar aplikasi dapat membuka native share sheet.
+- **Share/View Helper**:
+  - Membuat [share.ts](file:///e:/bksda-superapp/mobile/src/lib/files/share.ts).
+  - `shareFile` memvalidasi file lokal sebelum membuka share sheet.
+  - `openFile` mencoba membuka file dengan viewer perangkat melalui `Linking.openURL`, lalu fallback ke share sheet.
+  - Missing file, share unavailable, dan open unavailable dikembalikan sebagai error user-friendly.
+- **Tests**:
+  - Menambahkan [share.test.ts](file:///e:/bksda-superapp/mobile/src/lib/files/__tests__/share.test.ts) untuk share success, missing file, unavailable share sheet, viewer open, fallback share, dan unavailable viewer/share.
+- **Checklist**:
+  - Mencentang Task 73 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/lib/files/__tests__/share.test.ts`: 6 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 74: Build employee selector API hook.
+
+---
+
 # Progress - Phase 115: Mobile Authenticated File Download Helper
 
 > Document updated: 2026-06-19

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -18,6 +18,7 @@
         "expo-file-system": "^56.0.8",
         "expo-location": "~56.0.18",
         "expo-secure-store": "~56.0.4",
+        "expo-sharing": "^56.0.18",
         "expo-status-bar": "~56.0.4",
         "react": "19.2.3",
         "react-hook-form": "^7.79.0",
@@ -6860,6 +6861,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-sharing": {
+      "version": "56.0.18",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-56.0.18.tgz",
+      "integrity": "sha512-45w4BWNFmdTczp+fJX6YfwJrn9sX+VeRWz2VWLhauygcCrym44HtVDXX5yVYPB9TW9ZesLcEI+CCrCBNWL7smQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-plugins": "^56.0.9",
+        "@expo/config-types": "^56.0.6",
+        "@expo/plist": "^0.7.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -13,6 +13,7 @@
     "expo-file-system": "^56.0.8",
     "expo-location": "~56.0.18",
     "expo-secure-store": "~56.0.4",
+    "expo-sharing": "^56.0.18",
     "expo-status-bar": "~56.0.4",
     "react": "19.2.3",
     "react-hook-form": "^7.79.0",

--- a/mobile/src/lib/files/__tests__/share.test.ts
+++ b/mobile/src/lib/files/__tests__/share.test.ts
@@ -1,0 +1,101 @@
+import * as FileSystem from 'expo-file-system/legacy';
+import * as Sharing from 'expo-sharing';
+import { Linking } from 'react-native';
+import { FileShareError, openFile, shareFile } from '../share';
+
+jest.mock('expo-file-system/legacy', () => ({
+  getInfoAsync: jest.fn(),
+}));
+
+jest.mock('expo-sharing', () => ({
+  isAvailableAsync: jest.fn(),
+  shareAsync: jest.fn(),
+}));
+
+describe('file share helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({
+      exists: true,
+      isDirectory: false,
+      uri: 'file:///cache/surat-tugas.pdf',
+      size: 1024,
+      modificationTime: 1,
+    });
+    (Sharing.isAvailableAsync as jest.Mock).mockResolvedValue(true);
+    (Sharing.shareAsync as jest.Mock).mockResolvedValue(undefined);
+    jest.spyOn(Linking, 'canOpenURL').mockResolvedValue(true);
+    jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
+  });
+
+  it('opens a share sheet for an existing local file', async () => {
+    await shareFile({
+      localUri: 'file:///cache/surat-tugas.pdf',
+      mimeType: 'application/pdf',
+      dialogTitle: 'Bagikan Surat Tugas',
+      uti: 'com.adobe.pdf',
+    });
+
+    expect(FileSystem.getInfoAsync).toHaveBeenCalledWith('file:///cache/surat-tugas.pdf');
+    expect(Sharing.shareAsync).toHaveBeenCalledWith('file:///cache/surat-tugas.pdf', {
+      dialogTitle: 'Bagikan Surat Tugas',
+      mimeType: 'application/pdf',
+      UTI: 'com.adobe.pdf',
+    });
+  });
+
+  it('throws a friendly missing-file error before sharing', async () => {
+    (FileSystem.getInfoAsync as jest.Mock).mockResolvedValue({
+      exists: false,
+      isDirectory: false,
+    });
+
+    await expect(shareFile({ localUri: 'file:///cache/missing.pdf' })).rejects.toMatchObject({
+      kind: 'missing',
+      message: 'File tidak ditemukan atau sudah dihapus dari perangkat.',
+    });
+    expect(Sharing.shareAsync).not.toHaveBeenCalled();
+  });
+
+  it('throws a friendly error when share sheet is unavailable', async () => {
+    (Sharing.isAvailableAsync as jest.Mock).mockResolvedValue(false);
+
+    await expect(shareFile({ localUri: 'file:///cache/surat-tugas.pdf' })).rejects.toMatchObject({
+      kind: 'share_unavailable',
+      message: 'Fitur berbagi file tidak tersedia di perangkat ini.',
+    });
+  });
+
+  it('opens an existing file with the device viewer when available', async () => {
+    await openFile({ localUri: 'file:///cache/surat-tugas.pdf' });
+
+    expect(Linking.canOpenURL).toHaveBeenCalledWith('file:///cache/surat-tugas.pdf');
+    expect(Linking.openURL).toHaveBeenCalledWith('file:///cache/surat-tugas.pdf');
+    expect(Sharing.shareAsync).not.toHaveBeenCalled();
+  });
+
+  it('falls back to share sheet when no direct viewer can open the file', async () => {
+    jest.spyOn(Linking, 'canOpenURL').mockResolvedValue(false);
+
+    await openFile({ localUri: 'file:///cache/surat-tugas.pdf' });
+
+    expect(Sharing.shareAsync).toHaveBeenCalledWith('file:///cache/surat-tugas.pdf', {
+      dialogTitle: 'Bagikan File',
+      mimeType: undefined,
+      UTI: undefined,
+    });
+  });
+
+  it('maps unavailable viewer and share sheet to a friendly open error', async () => {
+    jest.spyOn(Linking, 'canOpenURL').mockResolvedValue(false);
+    (Sharing.isAvailableAsync as jest.Mock).mockResolvedValue(false);
+
+    await expect(openFile({ localUri: 'file:///cache/surat-tugas.pdf' })).rejects.toBeInstanceOf(
+      FileShareError
+    );
+    await expect(openFile({ localUri: 'file:///cache/surat-tugas.pdf' })).rejects.toMatchObject({
+      kind: 'open_unavailable',
+      message: 'Tidak ada aplikasi yang dapat membuka file ini di perangkat.',
+    });
+  });
+});

--- a/mobile/src/lib/files/share.ts
+++ b/mobile/src/lib/files/share.ts
@@ -1,0 +1,79 @@
+import * as FileSystem from 'expo-file-system/legacy';
+import * as Sharing from 'expo-sharing';
+import { Linking } from 'react-native';
+
+export type FileShareErrorKind = 'missing' | 'share_unavailable' | 'open_unavailable' | 'unknown';
+
+export class FileShareError extends Error {
+  kind: FileShareErrorKind;
+
+  constructor(kind: FileShareErrorKind, message: string) {
+    super(message);
+    this.name = 'FileShareError';
+    this.kind = kind;
+  }
+}
+
+export type ShareFileOptions = {
+  localUri: string;
+  mimeType?: string | null;
+  dialogTitle?: string;
+  uti?: string;
+};
+
+async function ensureLocalFile(localUri: string) {
+  const info = await FileSystem.getInfoAsync(localUri);
+
+  if (!info.exists || info.isDirectory) {
+    throw new FileShareError('missing', 'File tidak ditemukan atau sudah dihapus dari perangkat.');
+  }
+
+  return info;
+}
+
+export async function shareFile({
+  localUri,
+  mimeType,
+  dialogTitle = 'Bagikan File',
+  uti,
+}: ShareFileOptions): Promise<void> {
+  await ensureLocalFile(localUri);
+
+  const isSharingAvailable = await Sharing.isAvailableAsync();
+  if (!isSharingAvailable) {
+    throw new FileShareError('share_unavailable', 'Fitur berbagi file tidak tersedia di perangkat ini.');
+  }
+
+  await Sharing.shareAsync(localUri, {
+    dialogTitle,
+    mimeType: mimeType || undefined,
+    UTI: uti,
+  });
+}
+
+export async function openFile(options: ShareFileOptions): Promise<void> {
+  await ensureLocalFile(options.localUri);
+
+  try {
+    const canOpen = await Linking.canOpenURL(options.localUri);
+    if (canOpen) {
+      await Linking.openURL(options.localUri);
+      return;
+    }
+  } catch {
+    // Fall through to share sheet fallback below.
+  }
+
+  try {
+    await shareFile(options);
+  } catch (error) {
+    if (error instanceof FileShareError && error.kind === 'share_unavailable') {
+      throw new FileShareError(
+        'open_unavailable',
+        'Tidak ada aplikasi yang dapat membuka file ini di perangkat.'
+      );
+    }
+
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- add expo-sharing as a direct mobile dependency
- add shareFile helper that validates local files before opening native share sheet
- add openFile helper that tries device viewer first and falls back to share sheet
- return user-friendly missing file and unavailable viewer/share errors
- update Task 73 checklist and progress notes

## Validation
- npm test -- --runTestsByPath src/lib/files/__tests__/share.test.ts
- npm run typecheck
- npm run lint