### PR TITLE
feat(mobile): add employee search hook (#472)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1055,7 +1055,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: missing file shows user-friendly error.
   - _Requirements: 14, 17_
 
-- [ ] 74. Build employee selector API hook
+- [x] 74. Build employee selector API hook
   - Target area: `mobile/src/features/employees/useEmployeeSearch.ts`.
   - Search employees by name and NIP with pagination.
   - Acceptance check: hook does not fetch all employees at once.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,42 @@
+# Progress - Phase 117: Mobile Employee Selector Search Hook
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-employee-search-task-74`.
+> GitHub Issue: #472.
+
+---
+
+## Mobile Employee Selector Search Hook
+
+### Status: SELESAI
+- Scope: Mobile App (Employees Feature)
+- Tujuan: Menyediakan hook pencarian pegawai paginated untuk selector mobile yang dapat dipakai BMN dan Surat Tugas.
+
+### Implementasi
+- **Types**:
+  - Menambahkan `EmployeeSelectorItem` dan `EmployeeSearchFilters` di [types.ts](file:///e:/bksda-superapp/mobile/src/features/employees/types.ts).
+- **Hook**:
+  - Membuat [useEmployeeSearch.ts](file:///e:/bksda-superapp/mobile/src/features/employees/useEmployeeSearch.ts).
+  - Menggunakan endpoint paginated `/kepegawaian/employees`, bukan endpoint select yang masih `limit(200)`.
+  - Mengirim `mobile=true`, `page`, `per_page`, dan `search` melalui `withMobileParams`.
+  - Default `per_page=20` agar hook tidak mengambil seluruh pegawai sekaligus.
+  - Menormalisasi field pegawai menjadi `id`, `name`, `nip`, `jabatan`, dan `unit_kerja`.
+  - Mendukung refresh, fetch next page, loading state, pagination state, dan error state.
+- **Tests**:
+  - Menambahkan [useEmployeeSearch.test.tsx](file:///e:/bksda-superapp/mobile/src/features/employees/__tests__/useEmployeeSearch.test.tsx) untuk params mobile, default per_page, append next page, dan API error.
+- **Checklist**:
+  - Mencentang Task 74 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/employees/__tests__/useEmployeeSearch.test.tsx`: 4 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 75: Build employee selector sheet.
+
+---
+
 # Progress - Phase 116: Mobile File Viewer and Share Helper
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/employees/__tests__/useEmployeeSearch.test.tsx
+++ b/mobile/src/features/employees/__tests__/useEmployeeSearch.test.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { apiClient } from '@/lib/api/client';
+import { useEmployeeSearch } from '../useEmployeeSearch';
+import { EmployeeSearchFilters } from '../types';
+
+jest.mock('@/lib/api/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+  },
+}));
+
+describe('useEmployeeSearch', () => {
+  let capturedResult: ReturnType<typeof useEmployeeSearch> | null = null;
+
+  const TestComponent = ({ filters }: { filters?: EmployeeSearchFilters }) => {
+    capturedResult = useEmployeeSearch(filters);
+    return null;
+  };
+
+  const flushPromises = () => new Promise(jest.requireActual('timers').setImmediate);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedResult = null;
+  });
+
+  it('searches employees with mobile pagination params', async () => {
+    (apiClient.get as jest.Mock).mockResolvedValue({
+      data: {
+        data: [
+          {
+            id: 1,
+            nama_lengkap: 'Pegawai Satu',
+            nip: '199001012020011001',
+            jabatan: 'Polhut',
+            satuan_kerja: 'BKSDA Kaltim',
+          },
+        ],
+        meta: { current_page: 1, last_page: 1 },
+      },
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<TestComponent filters={{ search: '199001', per_page: 10 }} />);
+      await flushPromises();
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      '/kepegawaian/employees',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          mobile: true,
+          page: 1,
+          per_page: 10,
+          search: '199001',
+        }),
+      })
+    );
+    expect(capturedResult?.items).toEqual([
+      {
+        id: 1,
+        name: 'Pegawai Satu',
+        nip: '199001012020011001',
+        jabatan: 'Polhut',
+        unit_kerja: 'BKSDA Kaltim',
+      },
+    ]);
+    expect(capturedResult?.hasNextPage).toBe(false);
+
+    act(() => {
+      tree.unmount();
+    });
+  });
+
+  it('uses per_page 20 by default so it does not fetch all employees', async () => {
+    (apiClient.get as jest.Mock).mockResolvedValue({
+      data: {
+        data: [],
+        meta: { current_page: 1, last_page: 1 },
+      },
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<TestComponent />);
+      await flushPromises();
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      '/kepegawaian/employees',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          page: 1,
+          per_page: 20,
+          mobile: true,
+        }),
+      })
+    );
+
+    act(() => {
+      tree.unmount();
+    });
+  });
+
+  it('appends next page results', async () => {
+    (apiClient.get as jest.Mock).mockResolvedValueOnce({
+      data: {
+        data: [{ id: 1, name: 'Pegawai Satu' }],
+        meta: { current_page: 1, last_page: 2 },
+      },
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<TestComponent filters={{ search: 'pegawai' }} />);
+      await flushPromises();
+    });
+
+    expect(capturedResult?.hasNextPage).toBe(true);
+
+    (apiClient.get as jest.Mock).mockResolvedValueOnce({
+      data: {
+        data: [{ id: 2, name: 'Pegawai Dua' }],
+        meta: { current_page: 2, last_page: 2 },
+      },
+    });
+
+    await act(async () => {
+      capturedResult?.fetchNextPage();
+      await flushPromises();
+    });
+
+    expect(apiClient.get).toHaveBeenLastCalledWith(
+      '/kepegawaian/employees',
+      expect.objectContaining({
+        params: expect.objectContaining({ page: 2, per_page: 20, search: 'pegawai' }),
+      })
+    );
+    expect(capturedResult?.items.map((item) => item.name)).toEqual(['Pegawai Satu', 'Pegawai Dua']);
+    expect(capturedResult?.hasNextPage).toBe(false);
+
+    act(() => {
+      tree.unmount();
+    });
+  });
+
+  it('captures API errors without clearing previous state shape', async () => {
+    const apiError = { kind: 'server', message: 'Server error', status: 500 };
+    (apiClient.get as jest.Mock).mockRejectedValue(apiError);
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<TestComponent />);
+      await flushPromises();
+    });
+
+    expect(capturedResult?.error).toBe(apiError);
+    expect(capturedResult?.isLoading).toBe(false);
+
+    act(() => {
+      tree.unmount();
+    });
+  });
+});

--- a/mobile/src/features/employees/types.ts
+++ b/mobile/src/features/employees/types.ts
@@ -1,0 +1,12 @@
+export interface EmployeeSelectorItem {
+  id: string | number;
+  name: string;
+  nip?: string | null;
+  jabatan?: string | null;
+  unit_kerja?: string | null;
+}
+
+export interface EmployeeSearchFilters {
+  search?: string;
+  per_page?: number;
+}

--- a/mobile/src/features/employees/useEmployeeSearch.ts
+++ b/mobile/src/features/employees/useEmployeeSearch.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { apiClient } from '@/lib/api/client';
+import { withMobileParams } from '@/lib/api/mobileParams';
+import { ApiError, ApiSuccess } from '@/types/api';
+import { EmployeeSearchFilters, EmployeeSelectorItem } from './types';
+
+type LoadMode = 'initial' | 'refresh' | 'next';
+
+type EmployeeApiItem = {
+  id: string | number;
+  name?: string | null;
+  nama_lengkap?: string | null;
+  nip?: string | null;
+  jabatan?: string | null;
+  position?: string | null;
+  satuan_kerja?: string | null;
+  department?: string | null;
+  unit_kerja?: string | null;
+};
+
+export interface UseEmployeeSearchResult {
+  items: EmployeeSelectorItem[];
+  isLoading: boolean;
+  isRefreshing: boolean;
+  isFetchingNextPage: boolean;
+  error?: ApiError;
+  refetch: () => void;
+  fetchNextPage: () => void;
+  hasNextPage: boolean;
+}
+
+function normalizeEmployee(item: EmployeeApiItem): EmployeeSelectorItem {
+  return {
+    id: item.id,
+    name: item.name || item.nama_lengkap || '-',
+    nip: item.nip ?? null,
+    jabatan: item.jabatan || item.position || null,
+    unit_kerja: item.unit_kerja || item.satuan_kerja || item.department || null,
+  };
+}
+
+export function useEmployeeSearch(filters?: EmployeeSearchFilters): UseEmployeeSearchResult {
+  const [items, setItems] = useState<EmployeeSelectorItem[]>([]);
+  const [page, setPage] = useState<number>(1);
+  const [hasNextPage, setHasNextPage] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
+  const [isFetchingNextPage, setIsFetchingNextPage] = useState<boolean>(false);
+  const [error, setError] = useState<ApiError | undefined>(undefined);
+
+  const prevFilterKeyRef = useRef<string>('');
+  const search = filters?.search;
+  const perPage = filters?.per_page ?? 20;
+  const filterKey = JSON.stringify({
+    search,
+    per_page: perPage,
+  });
+
+  const loadData = useCallback(
+    async (targetPage: number, mode: LoadMode) => {
+      if (mode === 'initial') {
+        setIsLoading(true);
+      } else if (mode === 'refresh') {
+        setIsRefreshing(true);
+      } else {
+        setIsFetchingNextPage(true);
+      }
+      setError(undefined);
+
+      try {
+        const queryParams = withMobileParams({
+          page: targetPage,
+          per_page: perPage,
+          search: search || undefined,
+        });
+
+        const response = await apiClient.get<ApiSuccess<EmployeeApiItem[]>>('/kepegawaian/employees', {
+          params: queryParams,
+        });
+
+        const newItems = (response.data.data || []).map(normalizeEmployee);
+        const meta = response.data.meta;
+
+        setItems((previousItems) => (targetPage === 1 ? newItems : [...previousItems, ...newItems]));
+        setPage(targetPage);
+
+        if (meta && typeof meta.current_page === 'number' && typeof meta.last_page === 'number') {
+          setHasNextPage(meta.current_page < meta.last_page);
+        } else {
+          setHasNextPage(newItems.length >= perPage);
+        }
+      } catch (err: unknown) {
+        setError(err as ApiError);
+      } finally {
+        setIsLoading(false);
+        setIsRefreshing(false);
+        setIsFetchingNextPage(false);
+      }
+    },
+    [search, perPage]
+  );
+
+  useEffect(() => {
+    if (prevFilterKeyRef.current !== filterKey) {
+      prevFilterKeyRef.current = filterKey;
+      loadData(1, 'initial');
+    }
+  }, [filterKey, loadData]);
+
+  const refetch = useCallback(() => {
+    loadData(1, 'refresh');
+  }, [loadData]);
+
+  const fetchNextPage = useCallback(() => {
+    if (!isFetchingNextPage && hasNextPage && !isLoading) {
+      loadData(page + 1, 'next');
+    }
+  }, [hasNextPage, isFetchingNextPage, isLoading, loadData, page]);
+
+  return {
+    items,
+    isLoading,
+    isRefreshing,
+    isFetchingNextPage,
+    error,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+  };
+}


### PR DESCRIPTION
## Summary
- add reusable EmployeeSelectorItem and EmployeeSearchFilters types
- add useEmployeeSearch hook with paginated mobile params
- use /kepegawaian/employees with page/per_page/search instead of fetching all selector results
- normalize employee name, NIP, position, and unit fields for selector reuse
- update Task 74 checklist and progress notes

## Validation
- npm test -- --runTestsByPath src/features/employees/__tests__/useEmployeeSearch.test.tsx
- npm run typecheck
- npm run lint