### PR TITLE
feat(mobile): add employee selector sheet (#474)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1061,7 +1061,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: hook does not fetch all employees at once.
   - _Requirements: 15, 18, 19_
 
-- [ ] 75. Build employee selector sheet
+- [x] 75. Build employee selector sheet
   - Target area: `mobile/src/features/employees/EmployeeSelectorSheet.tsx`.
   - Display name, NIP, jabatan, and unit kerja summary.
   - Acceptance check: selector can be reused by BMN loan and Surat Tugas forms.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,40 @@
+# Progress - Phase 118: Mobile Employee Selector Sheet
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-employee-selector-task-75`.
+> GitHub Issue: #474.
+
+---
+
+## Mobile Employee Selector Sheet
+
+### Status: SELESAI
+- Scope: Mobile App (Employees Feature)
+- Tujuan: Menyediakan bottom sheet selector pegawai reusable untuk form BMN dan Surat Tugas.
+
+### Implementasi
+- **Component**:
+  - Membuat [EmployeeSelectorSheet.tsx](file:///e:/bksda-superapp/mobile/src/features/employees/EmployeeSelectorSheet.tsx).
+  - Menampilkan nama pegawai, NIP, jabatan, dan unit kerja ringkas.
+  - Mendukung search nama/NIP dengan debounce 350ms lewat `useEmployeeSearch`.
+  - Menggunakan `FlatList` untuk data panjang, pull-to-refresh, dan fetch next page.
+  - Menampilkan loading, empty, dan error state.
+  - Mendukung selected state dan callback `onSelect(employee)` agar reusable untuk BMN dan Surat Tugas.
+- **Tests**:
+  - Menambahkan [EmployeeSelectorSheet.test.tsx](file:///e:/bksda-superapp/mobile/src/features/employees/__tests__/EmployeeSelectorSheet.test.tsx) untuk render summary pegawai, select/close callback, debounced search, pagination/refresh wiring, dan state loading/empty/error.
+- **Checklist**:
+  - Mencentang Task 75 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/employees/__tests__/EmployeeSelectorSheet.test.tsx`: 5 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 76: Build profile screen.
+
+---
+
 # Progress - Phase 117: Mobile Employee Selector Search Hook
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/employees/EmployeeSelectorSheet.tsx
+++ b/mobile/src/features/employees/EmployeeSelectorSheet.tsx
@@ -1,0 +1,295 @@
+import React from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Modal,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View,
+} from 'react-native';
+import { EmptyState } from '@/components/EmptyState';
+import { ErrorState } from '@/components/ErrorState';
+import { SearchInput } from '@/components/SearchInput';
+import { useAppTheme } from '@/hooks/useAppTheme';
+import { EmployeeSelectorItem } from './types';
+import { useEmployeeSearch } from './useEmployeeSearch';
+
+export type EmployeeSelectorSheetProps = {
+  visible: boolean;
+  onClose: () => void;
+  onSelect: (employee: EmployeeSelectorItem) => void;
+  selectedEmployeeIds?: (string | number)[];
+  title?: string;
+};
+
+export default function EmployeeSelectorSheet({
+  visible,
+  onClose,
+  onSelect,
+  selectedEmployeeIds = [],
+  title = 'Pilih Pegawai',
+}: EmployeeSelectorSheetProps) {
+  const { colors, spacing, radius, typography } = useAppTheme();
+  const [search, setSearch] = React.useState('');
+  const [debouncedSearch, setDebouncedSearch] = React.useState('');
+  const selectedIds = React.useMemo(
+    () => new Set(selectedEmployeeIds.map((id) => String(id))),
+    [selectedEmployeeIds]
+  );
+
+  React.useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedSearch(search);
+    }, 350);
+
+    return () => clearTimeout(timeoutId);
+  }, [search]);
+
+  const {
+    items,
+    isLoading,
+    isRefreshing,
+    isFetchingNextPage,
+    error,
+    refetch,
+    fetchNextPage,
+  } = useEmployeeSearch({
+    search: debouncedSearch,
+    per_page: 20,
+  });
+
+  const handleSelect = (employee: EmployeeSelectorItem) => {
+    onSelect(employee);
+    onClose();
+  };
+
+  const renderFooter = () => {
+    if (!isFetchingNextPage) {
+      return null;
+    }
+
+    return (
+      <View style={[styles.footer, { paddingVertical: spacing.md }]}>
+        <ActivityIndicator color={colors.primary} size="small" />
+      </View>
+    );
+  };
+
+  const renderEmployee = ({ item }: { item: EmployeeSelectorItem }) => {
+    const isSelected = selectedIds.has(String(item.id));
+    const summaryParts = [item.nip, item.jabatan, item.unit_kerja].filter(Boolean);
+
+    return (
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel={`Pilih pegawai ${item.name}`}
+        accessibilityState={{ selected: isSelected }}
+        onPress={() => handleSelect(item)}
+        style={[
+          styles.employeeItem,
+          {
+            backgroundColor: isSelected ? colors.secondary : colors.card,
+            borderColor: isSelected ? colors.primary : colors.border,
+            borderRadius: radius.lg,
+            padding: spacing.md,
+            marginBottom: spacing.sm,
+          },
+        ]}
+      >
+        <View style={styles.employeeText}>
+          <Text
+            numberOfLines={2}
+            style={{
+              color: colors.foreground,
+              fontSize: typography.fontSizes.md,
+              fontWeight: typography.fontWeights.semibold,
+            }}
+          >
+            {item.name}
+          </Text>
+          <Text
+            numberOfLines={2}
+            style={{
+              color: colors.mutedForeground,
+              fontSize: typography.fontSizes.sm,
+              marginTop: spacing.xs,
+            }}
+          >
+            {summaryParts.length > 0 ? summaryParts.join(' • ') : 'Detail pegawai belum tersedia'}
+          </Text>
+        </View>
+        {isSelected ? (
+          <Text
+            style={{
+              color: colors.primary,
+              fontSize: typography.fontSizes.sm,
+              fontWeight: typography.fontWeights.bold,
+              marginLeft: spacing.sm,
+            }}
+          >
+            Dipilih
+          </Text>
+        ) : null}
+      </TouchableOpacity>
+    );
+  };
+
+  const renderContent = () => {
+    if (isLoading && items.length === 0) {
+      return (
+        <View style={styles.centerState}>
+          <ActivityIndicator color={colors.primary} size="small" />
+        </View>
+      );
+    }
+
+    if (error && items.length === 0) {
+      return (
+        <ErrorState
+          title="Gagal Memuat Pegawai"
+          message={error.message || 'Terjadi kesalahan saat memuat data pegawai.'}
+          onRetry={refetch}
+        />
+      );
+    }
+
+    if (items.length === 0) {
+      return (
+        <EmptyState
+          title="Pegawai Tidak Ditemukan"
+          message="Coba cari dengan nama atau NIP lain."
+        />
+      );
+    }
+
+    return (
+      <FlatList
+        data={items}
+        renderItem={renderEmployee}
+        keyExtractor={(item) => String(item.id)}
+        keyboardShouldPersistTaps="handled"
+        onEndReached={fetchNextPage}
+        onEndReachedThreshold={0.5}
+        refreshing={isRefreshing}
+        onRefresh={refetch}
+        ListFooterComponent={renderFooter}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: spacing.lg }}
+      />
+    );
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <TouchableWithoutFeedback onPress={onClose}>
+        <View style={styles.backdrop}>
+          <TouchableWithoutFeedback>
+            <View
+              style={[
+                styles.sheet,
+                {
+                  backgroundColor: colors.card,
+                  borderTopLeftRadius: radius.xl,
+                  borderTopRightRadius: radius.xl,
+                  padding: spacing.lg,
+                },
+              ]}
+            >
+              <View style={[styles.indicator, { backgroundColor: colors.border }]} />
+              <View style={[styles.header, { marginBottom: spacing.md }]}>
+                <Text
+                  style={{
+                    color: colors.foreground,
+                    fontSize: typography.fontSizes.lg,
+                    fontWeight: typography.fontWeights.bold,
+                  }}
+                >
+                  {title}
+                </Text>
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  accessibilityLabel="Tutup selector pegawai"
+                  onPress={onClose}
+                  style={styles.closeButton}
+                >
+                  <Text
+                    style={{
+                      color: colors.mutedForeground,
+                      fontSize: typography.fontSizes.md,
+                      fontWeight: typography.fontWeights.semibold,
+                    }}
+                  >
+                    Tutup
+                  </Text>
+                </TouchableOpacity>
+              </View>
+              <View style={{ marginBottom: spacing.md }}>
+                <SearchInput
+                  value={search}
+                  onChangeText={setSearch}
+                  placeholder="Cari nama atau NIP..."
+                  accessibilityLabel="Cari pegawai"
+                  onClear={() => setSearch('')}
+                />
+              </View>
+              <View style={styles.content}>{renderContent()}</View>
+            </View>
+          </TouchableWithoutFeedback>
+        </View>
+      </TouchableWithoutFeedback>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    maxHeight: '86%',
+    width: '100%',
+  },
+  indicator: {
+    alignSelf: 'center',
+    borderRadius: 2,
+    height: 4,
+    marginBottom: 12,
+    width: 40,
+  },
+  header: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  closeButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 48,
+    minWidth: 64,
+  },
+  content: {
+    minHeight: 260,
+  },
+  centerState: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 220,
+  },
+  employeeItem: {
+    alignItems: 'center',
+    borderWidth: 1,
+    flexDirection: 'row',
+    minHeight: 72,
+  },
+  employeeText: {
+    flex: 1,
+  },
+  footer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/mobile/src/features/employees/__tests__/EmployeeSelectorSheet.test.tsx
+++ b/mobile/src/features/employees/__tests__/EmployeeSelectorSheet.test.tsx
@@ -1,0 +1,264 @@
+import React from 'react';
+import { ActivityIndicator, FlatList, Modal, Text } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+import EmployeeSelectorSheet from '../EmployeeSelectorSheet';
+import { useEmployeeSearch } from '../useEmployeeSearch';
+
+jest.mock('../useEmployeeSearch', () => ({
+  useEmployeeSearch: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppTheme', () => ({
+  useAppTheme: () => ({
+    isDark: false,
+    colors: {
+      background: '#ffffff',
+      primary: '#16a34a',
+      primaryForeground: '#ffffff',
+      secondary: '#f1f5f9',
+      secondaryForeground: '#0f172a',
+      danger: '#dc2626',
+      foreground: '#09090b',
+      card: '#ffffff',
+      border: '#e2e8f0',
+      mutedForeground: '#64748b',
+    },
+    spacing: {
+      xs: 4,
+      sm: 8,
+      md: 12,
+      lg: 16,
+      xl: 20,
+      xxl: 24,
+    },
+    radius: {
+      md: 6,
+      lg: 8,
+      xl: 12,
+      full: 9999,
+    },
+    typography: {
+      fontFamilies: {
+        sans: 'System',
+      },
+      fontWeights: {
+        bold: '700',
+        semibold: '600',
+        medium: '500',
+      },
+      fontSizes: {
+        xs: 12,
+        sm: 14,
+        md: 16,
+        lg: 18,
+        xxxl: 32,
+      },
+    },
+  }),
+}));
+
+describe('EmployeeSelectorSheet', () => {
+  const employees = [
+    {
+      id: 1,
+      name: 'Pegawai Satu',
+      nip: '199001012020011001',
+      jabatan: 'Polhut',
+      unit_kerja: 'BKSDA Kaltim',
+    },
+    {
+      id: 2,
+      name: 'Pegawai Dua',
+      nip: '199101012020011002',
+      jabatan: 'Analis',
+      unit_kerja: 'Seksi Wilayah I',
+    },
+  ];
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    (useEmployeeSearch as jest.Mock).mockReturnValue({
+      items: employees,
+      isLoading: false,
+      isRefreshing: false,
+      isFetchingNextPage: false,
+      error: undefined,
+      refetch: jest.fn(),
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('renders employee name, NIP, jabatan, and unit summary', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <EmployeeSelectorSheet visible onClose={jest.fn()} onSelect={jest.fn()} />
+      );
+    });
+
+    expect(tree!.root.findByType(Modal).props.visible).toBe(true);
+    const texts = tree!.root.findAllByType(Text).map((node) => node.props.children);
+    expect(texts).toContain('Pilih Pegawai');
+    expect(texts).toContain('Pegawai Satu');
+    expect(texts).toContain('199001012020011001 • Polhut • BKSDA Kaltim');
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('selects an employee and closes the sheet', () => {
+    const handleSelect = jest.fn();
+    const handleClose = jest.fn();
+
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <EmployeeSelectorSheet visible onClose={handleClose} onSelect={handleSelect} />
+      );
+    });
+
+    const employeeButton = tree!.root.findByProps({ accessibilityLabel: 'Pilih pegawai Pegawai Satu' });
+    act(() => {
+      employeeButton.props.onPress();
+    });
+
+    expect(handleSelect).toHaveBeenCalledWith(employees[0]);
+    expect(handleClose).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('passes debounced search text to useEmployeeSearch', () => {
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <EmployeeSelectorSheet visible onClose={jest.fn()} onSelect={jest.fn()} />
+      );
+    });
+
+    const searchInput = tree!.root.findByProps({ accessibilityLabel: 'Cari pegawai' });
+    act(() => {
+      searchInput.props.onChangeText('199001');
+    });
+
+    expect(useEmployeeSearch).toHaveBeenLastCalledWith({ search: '', per_page: 20 });
+
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    expect(useEmployeeSearch).toHaveBeenLastCalledWith({ search: '199001', per_page: 20 });
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('wires pagination and refresh callbacks to FlatList', () => {
+    const refetch = jest.fn();
+    const fetchNextPage = jest.fn();
+    (useEmployeeSearch as jest.Mock).mockReturnValue({
+      items: employees,
+      isLoading: false,
+      isRefreshing: true,
+      isFetchingNextPage: true,
+      error: undefined,
+      refetch,
+      fetchNextPage,
+      hasNextPage: true,
+    });
+
+    let tree: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(
+        <EmployeeSelectorSheet visible onClose={jest.fn()} onSelect={jest.fn()} />
+      );
+    });
+
+    const list = tree!.root.findByType(FlatList);
+    act(() => {
+      list.props.onRefresh();
+      list.props.onEndReached();
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
+    expect(tree!.root.findByType(ActivityIndicator)).toBeTruthy();
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('renders loading, empty, and error states', () => {
+    (useEmployeeSearch as jest.Mock).mockReturnValueOnce({
+      items: [],
+      isLoading: true,
+      isRefreshing: false,
+      isFetchingNextPage: false,
+      error: undefined,
+      refetch: jest.fn(),
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+    });
+
+    let loadingTree: renderer.ReactTestRenderer;
+    act(() => {
+      loadingTree = renderer.create(
+        <EmployeeSelectorSheet visible onClose={jest.fn()} onSelect={jest.fn()} />
+      );
+    });
+    expect(loadingTree!.root.findByType(ActivityIndicator)).toBeTruthy();
+    act(() => loadingTree!.unmount());
+
+    (useEmployeeSearch as jest.Mock).mockReturnValueOnce({
+      items: [],
+      isLoading: false,
+      isRefreshing: false,
+      isFetchingNextPage: false,
+      error: undefined,
+      refetch: jest.fn(),
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+    });
+
+    let emptyTree: renderer.ReactTestRenderer;
+    act(() => {
+      emptyTree = renderer.create(
+        <EmployeeSelectorSheet visible onClose={jest.fn()} onSelect={jest.fn()} />
+      );
+    });
+    expect(emptyTree!.root.findByProps({ title: 'Pegawai Tidak Ditemukan' })).toBeTruthy();
+    act(() => emptyTree!.unmount());
+
+    (useEmployeeSearch as jest.Mock).mockReturnValueOnce({
+      items: [],
+      isLoading: false,
+      isRefreshing: false,
+      isFetchingNextPage: false,
+      error: { kind: 'server', message: 'Server error', status: 500 },
+      refetch: jest.fn(),
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+    });
+
+    let errorTree: renderer.ReactTestRenderer;
+    act(() => {
+      errorTree = renderer.create(
+        <EmployeeSelectorSheet visible onClose={jest.fn()} onSelect={jest.fn()} />
+      );
+    });
+    expect(errorTree!.root.findByProps({ title: 'Gagal Memuat Pegawai' })).toBeTruthy();
+    act(() => errorTree!.unmount());
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable mobile employee selector bottom sheet with search, pagination, refresh, and selected-state display
- cover loading, empty, error, selection, search debounce, pagination, and refresh behavior
- mark Task 75 complete and update progress log

## Validation
- npm test -- --runTestsByPath src/features/employees/__tests__/EmployeeSelectorSheet.test.tsx
- npm run typecheck
- npm run lint