### PR TITLE
feat(mobile): build profile screen (#476)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1069,7 +1069,7 @@ Use this matrix together with the numbered task. A lower-capability model should
 
 ### Milestone 4: Android Internal Beta
 
-- [ ] 76. Build profile screen
+- [x] 76. Build profile screen
   - Target area: `mobile/src/features/profile/ProfileScreen.tsx`.
   - Show user identity, employee data, role, access modules, and logout action.
   - Acceptance check: token/session values are never displayed.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,38 @@
+# Progress - Phase 119: Mobile Profile Screen
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-profile-screen-task-76`.
+> GitHub Issue: #476.
+
+---
+
+## Mobile Profile Screen
+
+### Status: SELESAI
+- Scope: Mobile App (Profile Feature)
+- Tujuan: Mengganti placeholder profil dengan layar profil yang menampilkan identitas pengguna tanpa membocorkan token/session.
+
+### Implementasi
+- **Screen**:
+  - Memperbarui [ProfileScreen.tsx](file:///e:/bksda-superapp/mobile/src/features/profile/screens/ProfileScreen.tsx), lokasi yang dipakai oleh `AppTabs`.
+  - Menampilkan identitas pengguna, username/NIP, role, data pegawai, modul akses, dan tombol logout.
+  - Menyediakan fallback saat akun belum terhubung ke data pegawai.
+  - Tidak merender nilai token/session walaupun token tersedia di `useAuth`.
+- **Tests**:
+  - Menambahkan [ProfileScreen.test.tsx](file:///e:/bksda-superapp/mobile/src/features/profile/screens/__tests__/ProfileScreen.test.tsx) untuk render data profil, fallback tanpa pegawai, aksi logout, dan guard token/session tidak tampil.
+- **Checklist**:
+  - Mencentang Task 76 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/profile/screens/__tests__/ProfileScreen.test.tsx`: 4 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 77: Add logout confirmation flow.
+
+---
+
 # Progress - Phase 118: Mobile Employee Selector Sheet
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/profile/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/screens/ProfileScreen.tsx
@@ -1,27 +1,293 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { AppButton } from '@/components/AppButton';
+import { useAuth } from '@/features/auth/AuthProvider';
 import { useAppTheme } from '@/hooks/useAppTheme';
 
 export default function ProfileScreen() {
-  const { colors, spacing } = useAppTheme();
+  const { colors, spacing, radius, typography } = useAppTheme();
+  const { user, employee, logout, isLoading } = useAuth();
+
+  const displayName = employee?.name || user?.name || 'Pengguna';
+  const displaySub = employee?.nip ? `NIP. ${employee.nip}` : user?.username ? `@${user.username}` : '-';
+  const role = formatLabel(user?.role);
+  const accessModules = user?.access_modules?.length ? user.access_modules : ['Tidak ada modul akses'];
+  const employeeRows: [string, string | null | undefined][] = [
+    ['Nama pegawai', employee?.name],
+    ['NIP', employee?.nip],
+    ['Jabatan', employee?.position],
+    ['Unit kerja', employee?.department],
+    ['Pangkat/Golongan', employee?.rank],
+    ['Email pegawai', employee?.email],
+    ['Telepon', employee?.phone],
+  ];
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background, padding: spacing.lg }]}>
-      <Text style={[styles.title, { color: colors.foreground }]}>Profil Saya</Text>
-      <Text style={{ color: colors.mutedForeground }}>Kelola akun dan profil Anda di sini.</Text>
+    <ScrollView
+      style={[styles.screen, { backgroundColor: colors.background }]}
+      contentContainerStyle={[styles.content, { padding: spacing.lg, gap: spacing.lg }]}
+    >
+      <View
+        style={[
+          styles.hero,
+          {
+            backgroundColor: colors.card,
+            borderColor: colors.border,
+            borderRadius: radius.lg,
+            padding: spacing.lg,
+          },
+        ]}
+        accessibilityLabel="Informasi identitas pengguna"
+      >
+        <View
+          style={[
+            styles.avatar,
+            {
+              backgroundColor: colors.primary + '20',
+              borderRadius: radius.full,
+            },
+          ]}
+        >
+          <Text
+            style={[
+              styles.avatarText,
+              {
+                color: colors.primary,
+                fontWeight: typography.fontWeights.bold,
+              },
+            ]}
+          >
+            {displayName.charAt(0).toUpperCase()}
+          </Text>
+        </View>
+        <View style={styles.heroText}>
+          <Text
+            style={[
+              styles.name,
+              {
+                color: colors.foreground,
+                fontWeight: typography.fontWeights.bold,
+              },
+            ]}
+          >
+            {displayName}
+          </Text>
+          <Text style={[styles.mutedText, { color: colors.mutedForeground }]}>{displaySub}</Text>
+          <Text style={[styles.roleText, { color: colors.primary, fontWeight: typography.fontWeights.semibold }]}>
+            {role}
+          </Text>
+        </View>
+      </View>
+
+      <Section title="Akun" colors={colors} spacing={spacing} radius={radius} typography={typography}>
+        <InfoRow label="Nama akun" value={user?.name} colors={colors} typography={typography} />
+        <InfoRow label="Username" value={user?.username} colors={colors} typography={typography} />
+        <InfoRow label="Email akun" value={user?.email} colors={colors} typography={typography} />
+        <InfoRow label="Role" value={role} colors={colors} typography={typography} />
+      </Section>
+
+      <Section title="Data Pegawai" colors={colors} spacing={spacing} radius={radius} typography={typography}>
+        {employee ? (
+          employeeRows.map(([label, value]) => (
+            <InfoRow key={label} label={label} value={value} colors={colors} typography={typography} />
+          ))
+        ) : (
+          <Text style={[styles.emptyText, { color: colors.mutedForeground }]}>Belum terhubung dengan data pegawai.</Text>
+        )}
+      </Section>
+
+      <Section title="Modul Akses" colors={colors} spacing={spacing} radius={radius} typography={typography}>
+        <View style={styles.moduleGrid}>
+          {accessModules.map((module) => (
+            <View
+              key={module}
+              style={[
+                styles.moduleBadge,
+                {
+                  backgroundColor: colors.muted,
+                  borderColor: colors.border,
+                  borderRadius: radius.full,
+                  paddingHorizontal: spacing.md,
+                  paddingVertical: spacing.sm,
+                },
+              ]}
+            >
+              <Text style={[styles.moduleText, { color: colors.foreground, fontWeight: typography.fontWeights.medium }]}>
+                {formatLabel(module)}
+              </Text>
+            </View>
+          ))}
+        </View>
+      </Section>
+
+      <View
+        style={[
+          styles.logoutPanel,
+          {
+            backgroundColor: colors.card,
+            borderColor: colors.border,
+            borderRadius: radius.lg,
+            padding: spacing.lg,
+          },
+        ]}
+      >
+        <Text style={[styles.sectionTitle, { color: colors.foreground, fontWeight: typography.fontWeights.semibold }]}>
+          Sesi Aplikasi
+        </Text>
+        <Text style={[styles.emptyText, { color: colors.mutedForeground }]}>
+          Keluar dari perangkat ini untuk mengakhiri akses aplikasi mobile.
+        </Text>
+        <AppButton title="Logout" onPress={logout} variant="danger" loading={isLoading} accessibilityLabel="Logout" />
+      </View>
+    </ScrollView>
+  );
+}
+
+function Section({
+  title,
+  children,
+  colors,
+  spacing,
+  radius,
+  typography,
+}: {
+  title: string;
+  children: React.ReactNode;
+  colors: ReturnType<typeof useAppTheme>['colors'];
+  spacing: ReturnType<typeof useAppTheme>['spacing'];
+  radius: ReturnType<typeof useAppTheme>['radius'];
+  typography: ReturnType<typeof useAppTheme>['typography'];
+}) {
+  return (
+    <View
+      style={[
+        styles.section,
+        {
+          backgroundColor: colors.card,
+          borderColor: colors.border,
+          borderRadius: radius.lg,
+          padding: spacing.lg,
+          gap: spacing.md,
+        },
+      ]}
+    >
+      <Text style={[styles.sectionTitle, { color: colors.foreground, fontWeight: typography.fontWeights.semibold }]}>
+        {title}
+      </Text>
+      {children}
     </View>
   );
 }
 
+function InfoRow({
+  label,
+  value,
+  colors,
+  typography,
+}: {
+  label: string;
+  value?: string | null;
+  colors: ReturnType<typeof useAppTheme>['colors'];
+  typography: ReturnType<typeof useAppTheme>['typography'];
+}) {
+  return (
+    <View style={styles.infoRow}>
+      <Text style={[styles.label, { color: colors.mutedForeground }]}>{label}</Text>
+      <Text style={[styles.value, { color: colors.foreground, fontWeight: typography.fontWeights.medium }]}>
+        {value || '-'}
+      </Text>
+    </View>
+  );
+}
+
+function formatLabel(value?: string | null) {
+  if (!value) return '-';
+  return value
+    .split(/[_-]/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
 const styles = StyleSheet.create({
-  container: {
+  screen: {
     flex: 1,
-    justifyContent: 'center',
+  },
+  content: {
+    paddingBottom: 32,
+  },
+  hero: {
+    borderWidth: 1,
+    flexDirection: 'row',
     alignItems: 'center',
   },
-  title: {
+  avatar: {
+    width: 64,
+    height: 64,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: 16,
+  },
+  avatarText: {
     fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 8,
+  },
+  heroText: {
+    flex: 1,
+  },
+  name: {
+    fontSize: 20,
+    lineHeight: 26,
+  },
+  mutedText: {
+    fontSize: 14,
+    lineHeight: 20,
+    marginTop: 2,
+  },
+  roleText: {
+    fontSize: 14,
+    lineHeight: 20,
+    marginTop: 4,
+  },
+  section: {
+    borderWidth: 1,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  infoRow: {
+    minHeight: 48,
+    justifyContent: 'center',
+  },
+  label: {
+    fontSize: 12,
+    lineHeight: 16,
+    marginBottom: 2,
+  },
+  value: {
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  emptyText: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  moduleGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  moduleBadge: {
+    borderWidth: 1,
+    minHeight: 40,
+    justifyContent: 'center',
+  },
+  moduleText: {
+    fontSize: 14,
+    lineHeight: 18,
+  },
+  logoutPanel: {
+    borderWidth: 1,
+    gap: 12,
   },
 });

--- a/mobile/src/features/profile/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/screens/__tests__/ProfileScreen.test.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { Text } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+import ProfileScreen from '../ProfileScreen';
+import { useAuth } from '@/features/auth/AuthProvider';
+
+jest.mock('@/features/auth/AuthProvider', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppTheme', () => ({
+  useAppTheme: () => ({
+    colors: {
+      background: '#ffffff',
+      card: '#ffffff',
+      border: '#e2e8f0',
+      primary: '#16a34a',
+      foreground: '#09090b',
+      muted: '#f1f5f9',
+      mutedForeground: '#64748b',
+      danger: '#ef4444',
+      dangerForeground: '#ffffff',
+      primaryForeground: '#ffffff',
+      secondary: '#f1f5f9',
+      secondaryForeground: '#0f172a',
+    },
+    spacing: {
+      sm: 8,
+      md: 12,
+      lg: 16,
+    },
+    radius: {
+      lg: 8,
+      full: 9999,
+    },
+    typography: {
+      fontWeights: {
+        medium: '500',
+        semibold: '600',
+        bold: '700',
+      },
+      fontSizes: {
+        md: 16,
+      },
+    },
+  }),
+}));
+
+const mockLogout = jest.fn();
+
+const mockUser = {
+  id: 1,
+  name: 'Ayu Lestari',
+  username: 'ayu',
+  email: 'ayu@example.test',
+  role: 'staff_bmn',
+  access_modules: ['bmn', 'surat_tugas'],
+  permissions: ['bmn.view'],
+  is_active: true,
+  employee: null,
+};
+
+const mockEmployee = {
+  id: 10,
+  nip: '198501012010011002',
+  name: 'Ayu Lestari Pegawai',
+  position: 'Pengelola BMN',
+  department: 'Seksi Wilayah I',
+  email: 'pegawai@example.test',
+  phone: '08123456789',
+  photo: null,
+  rank: 'Penata Muda',
+  is_active: true,
+};
+
+function mockAuth(overrides: Partial<ReturnType<typeof useAuth>> = {}) {
+  (useAuth as jest.Mock).mockReturnValue({
+    user: mockUser,
+    employee: mockEmployee,
+    token: 'super-secret-token',
+    isLoading: false,
+    login: jest.fn(),
+    logout: mockLogout,
+    refreshUser: jest.fn(),
+    ...overrides,
+  });
+}
+
+function getTextValues(root: renderer.ReactTestInstance) {
+  return root.findAllByType(Text).map((node) => node.props.children).flat();
+}
+
+describe('ProfileScreen', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockLogout.mockClear();
+    mockAuth();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('renders user identity, employee data, role, access modules, and logout action', () => {
+    let tree: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(<ProfileScreen />);
+    });
+
+    const root = tree!.root;
+    const texts = getTextValues(root);
+
+    expect(texts).toContain('Ayu Lestari Pegawai');
+    expect(texts).toContain('NIP. 198501012010011002');
+    expect(texts).toContain('Pengelola BMN');
+    expect(texts).toContain('Seksi Wilayah I');
+    expect(texts).toContain('Penata Muda');
+    expect(texts).toContain('Staff Bmn');
+    expect(texts).toContain('Bmn');
+    expect(texts).toContain('Surat Tugas');
+    expect(root.findByProps({ accessibilityLabel: 'Logout' })).toBeTruthy();
+  });
+
+  it('does not display token or session values from auth context', () => {
+    let tree: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(<ProfileScreen />);
+    });
+
+    const serialized = JSON.stringify(tree!.toJSON());
+
+    expect(serialized).not.toContain('super-secret-token');
+    expect(serialized.toLowerCase()).not.toContain('session');
+    expect(serialized.toLowerCase()).not.toContain('bearer');
+  });
+
+  it('renders account fallback when employee data is not linked', () => {
+    mockAuth({
+      employee: null,
+      user: {
+        ...mockUser,
+        access_modules: [],
+      },
+    });
+
+    let tree: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(<ProfileScreen />);
+    });
+
+    const texts = getTextValues(tree!.root);
+
+    expect(texts).toContain('Ayu Lestari');
+    expect(texts).toContain('@ayu');
+    expect(texts).toContain('Belum terhubung dengan data pegawai.');
+    expect(texts).toContain('Tidak ada modul akses');
+  });
+
+  it('calls logout from auth context when logout action is pressed', () => {
+    let tree: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(<ProfileScreen />);
+    });
+
+    act(() => {
+      tree!.root.findByProps({ accessibilityLabel: 'Logout' }).props.onPress();
+    });
+
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- replace the mobile profile placeholder with an authenticated profile screen
- show identity, employee data, role, access modules, and logout action without rendering token/session values
- add profile screen tests and mark Task 76 complete

## Validation
- npm test -- --runTestsByPath src/features/profile/screens/__tests__/ProfileScreen.test.tsx
- npm run typecheck
- npm run lint