### PR TITLE
feat(mobile): add logout confirmation flow (#478)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1075,7 +1075,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: token/session values are never displayed.
   - _Requirements: 2, 19, 20_
 
-- [ ] 77. Add logout confirmation flow
+- [x] 77. Add logout confirmation flow
   - Target area: profile/auth flow.
   - Confirm logout, call API, clear secure storage, reset navigation.
   - Acceptance check: logout works even if API request fails.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,39 @@
+# Progress - Phase 120: Mobile Logout Confirmation Flow
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-logout-confirmation-task-77`.
+> GitHub Issue: #478.
+
+---
+
+## Mobile Logout Confirmation Flow
+
+### Status: SELESAI
+- Scope: Mobile App (Profile/Auth Flow)
+- Tujuan: Menambahkan konfirmasi sebelum logout dan memastikan flow logout tetap aman saat API logout gagal.
+
+### Implementasi
+- **Profile Flow**:
+  - Memperbarui [ProfileScreen.tsx](file:///e:/bksda-superapp/mobile/src/features/profile/screens/ProfileScreen.tsx) agar tombol `Logout` membuka dialog konfirmasi native.
+  - Aksi logout hanya berjalan setelah pengguna memilih action destruktif `Logout`.
+  - Flow tetap menggunakan `AuthProvider.logout`, sehingga API logout, clear secure storage, dan reset state auth tetap berada pada satu jalur.
+- **Tests**:
+  - Memperluas [ProfileScreen.test.tsx](file:///e:/bksda-superapp/mobile/src/features/profile/screens/__tests__/ProfileScreen.test.tsx) untuk memastikan tombol logout meminta konfirmasi dan baru memanggil logout setelah confirm.
+  - Memvalidasi [AuthProvider.test.tsx](file:///e:/bksda-superapp/mobile/src/features/auth/__tests__/AuthProvider.test.tsx) yang sudah memastikan local cleanup tetap berjalan walaupun API logout gagal.
+- **Checklist**:
+  - Mencentang Task 77 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/profile/screens/__tests__/ProfileScreen.test.tsx`: 5 tests passed.
+- `npm test -- --runTestsByPath src/features/auth/__tests__/AuthProvider.test.tsx`: 4 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 78: Add online-only network state.
+
+---
+
 # Progress - Phase 119: Mobile Profile Screen
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/profile/screens/ProfileScreen.tsx
+++ b/mobile/src/features/profile/screens/ProfileScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Alert, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { AppButton } from '@/components/AppButton';
 import { useAuth } from '@/features/auth/AuthProvider';
 import { useAppTheme } from '@/hooks/useAppTheme';
@@ -21,6 +21,19 @@ export default function ProfileScreen() {
     ['Email pegawai', employee?.email],
     ['Telepon', employee?.phone],
   ];
+  const confirmLogout = () => {
+    Alert.alert('Logout', 'Keluar dari aplikasi di perangkat ini?', [
+      {
+        text: 'Batal',
+        style: 'cancel',
+      },
+      {
+        text: 'Logout',
+        style: 'destructive',
+        onPress: logout,
+      },
+    ]);
+  };
 
   return (
     <ScrollView
@@ -137,7 +150,13 @@ export default function ProfileScreen() {
         <Text style={[styles.emptyText, { color: colors.mutedForeground }]}>
           Keluar dari perangkat ini untuk mengakhiri akses aplikasi mobile.
         </Text>
-        <AppButton title="Logout" onPress={logout} variant="danger" loading={isLoading} accessibilityLabel="Logout" />
+        <AppButton
+          title="Logout"
+          onPress={confirmLogout}
+          variant="danger"
+          loading={isLoading}
+          accessibilityLabel="Logout"
+        />
       </View>
     </ScrollView>
   );

--- a/mobile/src/features/profile/screens/__tests__/ProfileScreen.test.tsx
+++ b/mobile/src/features/profile/screens/__tests__/ProfileScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text } from 'react-native';
+import { Alert, Text } from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 import ProfileScreen from '../ProfileScreen';
 import { useAuth } from '@/features/auth/AuthProvider';
@@ -91,13 +91,17 @@ function getTextValues(root: renderer.ReactTestInstance) {
 }
 
 describe('ProfileScreen', () => {
+  let alertSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.useFakeTimers();
     mockLogout.mockClear();
+    alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
     mockAuth();
   });
 
   afterEach(() => {
+    alertSpy.mockRestore();
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
   });
@@ -160,7 +164,7 @@ describe('ProfileScreen', () => {
     expect(texts).toContain('Tidak ada modul akses');
   });
 
-  it('calls logout from auth context when logout action is pressed', () => {
+  it('asks for confirmation before calling logout from auth context', () => {
     let tree: renderer.ReactTestRenderer;
 
     act(() => {
@@ -169,6 +173,34 @@ describe('ProfileScreen', () => {
 
     act(() => {
       tree!.root.findByProps({ accessibilityLabel: 'Logout' }).props.onPress();
+    });
+
+    expect(mockLogout).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Logout',
+      'Keluar dari aplikasi di perangkat ini?',
+      expect.arrayContaining([
+        expect.objectContaining({ text: 'Batal', style: 'cancel' }),
+        expect.objectContaining({ text: 'Logout', style: 'destructive', onPress: mockLogout }),
+      ])
+    );
+  });
+
+  it('calls logout when destructive confirmation is selected', () => {
+    let tree: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(<ProfileScreen />);
+    });
+
+    act(() => {
+      tree!.root.findByProps({ accessibilityLabel: 'Logout' }).props.onPress();
+    });
+
+    const confirmAction = alertSpy.mock.calls[0][2].find((action: { text: string }) => action.text === 'Logout');
+
+    act(() => {
+      confirmAction.onPress();
     });
 
     expect(mockLogout).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- add native confirmation before executing mobile logout
- keep logout routed through AuthProvider so API logout, local secure storage cleanup, and auth state reset remain centralized
- extend profile tests and mark Task 77 complete

## Validation
- npm test -- --runTestsByPath src/features/profile/screens/__tests__/ProfileScreen.test.tsx
- npm test -- --runTestsByPath src/features/auth/__tests__/AuthProvider.test.tsx
- npm run typecheck
- npm run lint