### PR TITLE
feat(mobile): add online status banner (#480)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1081,7 +1081,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: logout works even if API request fails.
   - _Requirements: 1, 19_
 
-- [ ] 78. Add online-only network state
+- [x] 78. Add online-only network state
   - Target area: `mobile/src/hooks/useOnlineStatus.ts`.
   - Detect no connection and expose status to screens.
   - Acceptance check: offline banner appears when network request fails due to connection.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,42 @@
+# Progress - Phase 121: Mobile Online-Only Network State
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-online-status-task-78`.
+> GitHub Issue: #480.
+
+---
+
+## Mobile Online-Only Network State
+
+### Status: SELESAI
+- Scope: Mobile App (Hooks/App Shell)
+- Tujuan: Mengekspos status online/offline ke screen dan memberi banner saat request gagal karena koneksi.
+
+### Implementasi
+- **Hook**:
+  - Menambahkan [useOnlineStatus.ts](file:///e:/bksda-superapp/mobile/src/hooks/useOnlineStatus.ts).
+  - Mendeteksi `ApiError.kind === 'network'` dan pesan error koneksi/fetch/timeout.
+  - Mengekspos `isOnline`, `isOffline`, `lastNetworkErrorAt`, `markOnline`, dan `markOffline`.
+- **UI**:
+  - Menambahkan [OfflineBanner.tsx](file:///e:/bksda-superapp/mobile/src/components/OfflineBanner.tsx).
+  - Mengintegrasikan banner offline ke [DashboardScreen.tsx](file:///e:/bksda-superapp/mobile/src/features/dashboard/screens/DashboardScreen.tsx) saat request dashboard gagal karena koneksi.
+- **Tests**:
+  - Menambahkan [useOnlineStatus.test.tsx](file:///e:/bksda-superapp/mobile/src/hooks/__tests__/useOnlineStatus.test.tsx) untuk deteksi network error dan transisi kembali online.
+  - Memperluas [DashboardScreen.test.tsx](file:///e:/bksda-superapp/mobile/src/features/dashboard/screens/__tests__/DashboardScreen.test.tsx) agar banner offline muncul pada network error.
+- **Checklist**:
+  - Mencentang Task 78 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/hooks/__tests__/useOnlineStatus.test.tsx`: 3 tests passed.
+- `npm test -- --runTestsByPath src/features/dashboard/screens/__tests__/DashboardScreen.test.tsx`: 6 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 79: Add foreground refresh behavior.
+
+---
+
 # Progress - Phase 120: Mobile Logout Confirmation Flow
 
 > Document updated: 2026-06-19

--- a/mobile/src/components/OfflineBanner.tsx
+++ b/mobile/src/components/OfflineBanner.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { useAppTheme } from '@/hooks/useAppTheme';
+
+export type OfflineBannerProps = {
+  visible?: boolean;
+  message?: string;
+};
+
+export function OfflineBanner({
+  visible = true,
+  message = 'Tidak ada koneksi internet. Beberapa data mungkin belum terbaru.',
+}: OfflineBannerProps) {
+  const { colors, spacing, radius, typography } = useAppTheme();
+
+  if (!visible) return null;
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.warning,
+          borderRadius: radius.lg,
+          paddingHorizontal: spacing.lg,
+          paddingVertical: spacing.md,
+        },
+      ]}
+      accessibilityRole="alert"
+      accessibilityLabel="Banner offline"
+    >
+      <Text
+        style={[
+          styles.title,
+          {
+            color: colors.warningForeground,
+            fontWeight: typography.fontWeights.semibold,
+          },
+        ]}
+      >
+        Mode Offline
+      </Text>
+      <Text style={[styles.message, { color: colors.warningForeground }]}>{message}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+  },
+  title: {
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  message: {
+    fontSize: 14,
+    lineHeight: 20,
+    marginTop: 2,
+  },
+});

--- a/mobile/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/mobile/src/features/dashboard/screens/DashboardScreen.tsx
@@ -8,10 +8,12 @@ import {
   Alert,
 } from 'react-native';
 import { useAppTheme } from '@/hooks/useAppTheme';
+import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useMobileDashboard } from '../useMobileDashboard';
 import { usePermissions } from '@/lib/permissions';
 import { LoadingSkeleton } from '@/components/LoadingSkeleton';
 import { ErrorState } from '@/components/ErrorState';
+import { OfflineBanner } from '@/components/OfflineBanner';
 import ProfileSummary from '../components/ProfileSummary';
 import MetricCard from '../components/MetricCard';
 import AlertCard from '../components/AlertCard';
@@ -20,6 +22,7 @@ import QuickActions from '../components/QuickActions';
 export default function DashboardScreen({ navigation }: any) {
   const { colors, spacing, typography } = useAppTheme();
   const { data, isLoading, error, refetch } = useMobileDashboard();
+  const onlineStatus = useOnlineStatus(error);
   const { hasModule, can } = usePermissions();
 
   const showBmn = hasModule('bmn');
@@ -57,7 +60,8 @@ export default function DashboardScreen({ navigation }: any) {
 
   if (error) {
     return (
-      <View style={[styles.center, { backgroundColor: colors.background, padding: spacing.lg }]}>
+      <View style={[styles.errorContainer, { backgroundColor: colors.background, padding: spacing.lg, gap: spacing.lg }]}>
+        <OfflineBanner visible={onlineStatus.isOffline} />
         <ErrorState
           message={error.message || 'Gagal memuat data dashboard. Silakan coba kembali.'}
           onRetry={refetch}
@@ -186,6 +190,11 @@ const styles = StyleSheet.create({
     gap: 20,
   },
   center: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  errorContainer: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',

--- a/mobile/src/features/dashboard/screens/__tests__/DashboardScreen.test.tsx
+++ b/mobile/src/features/dashboard/screens/__tests__/DashboardScreen.test.tsx
@@ -17,6 +17,8 @@ jest.mock('@/hooks/useAppTheme', () => ({
       muted: '#f1f5f9',
       border: '#e2e8f0',
       card: '#ffffff',
+      warning: '#f59e0b',
+      warningForeground: '#ffffff',
     },
     spacing: {
       xs: 4,
@@ -186,6 +188,34 @@ describe('DashboardScreen', () => {
       errorState.props.onRetry();
     });
     expect(mockRefetch).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      tree.unmount();
+    });
+  });
+
+  it('renders offline banner when dashboard request fails due to connection', () => {
+    const apiError = {
+      kind: 'network',
+      message: 'Koneksi internet terganggu. Silakan periksa koneksi Anda dan coba lagi.',
+    };
+
+    (useMobileDashboard as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: apiError,
+      refetch: mockRefetch,
+    });
+
+    let tree: any;
+    act(() => {
+      tree = renderer.create(<DashboardScreen navigation={mockNavigation} />);
+    });
+
+    const root = tree.root;
+
+    expect(root.findByProps({ accessibilityLabel: 'Banner offline' })).toBeTruthy();
+    expect(root.findByProps({ message: apiError.message })).toBeTruthy();
 
     act(() => {
       tree.unmount();

--- a/mobile/src/hooks/__tests__/useOnlineStatus.test.tsx
+++ b/mobile/src/hooks/__tests__/useOnlineStatus.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { ApiError } from '@/types/api';
+import { isNetworkError, OnlineStatus, useOnlineStatus } from '../useOnlineStatus';
+
+describe('useOnlineStatus', () => {
+  let capturedStatus!: OnlineStatus;
+
+  function TestComponent({ error }: { error?: ApiError | null }) {
+    capturedStatus = useOnlineStatus(error);
+    return null;
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-06-19T08:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('detects normalized network errors', () => {
+    expect(isNetworkError({ kind: 'network', message: 'Koneksi internet terganggu.' })).toBe(true);
+    expect(isNetworkError({ kind: 'server', message: 'Failed to fetch dashboard' })).toBe(true);
+    expect(isNetworkError({ kind: 'validation', message: 'Nama wajib diisi' })).toBe(false);
+  });
+
+  it('exposes offline state when the observed request error is network related', () => {
+    const error: ApiError = {
+      kind: 'network',
+      message: 'Koneksi internet terganggu.',
+    };
+
+    act(() => {
+      renderer.create(<TestComponent error={error} />);
+    });
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(capturedStatus.isOnline).toBe(false);
+    expect(capturedStatus.isOffline).toBe(true);
+    expect(capturedStatus.lastNetworkErrorAt).toBe(Date.parse('2026-06-19T08:00:00.000Z'));
+  });
+
+  it('can be marked back online after a successful request', () => {
+    let tree!: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(
+        <TestComponent
+          error={{
+            kind: 'network',
+            message: 'Koneksi internet terganggu.',
+          }}
+        />
+      );
+    });
+
+    expect(capturedStatus.isOffline).toBe(true);
+
+    act(() => {
+      tree.update(<TestComponent error={null} />);
+    });
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(capturedStatus.isOnline).toBe(true);
+    expect(capturedStatus.isOffline).toBe(false);
+  });
+});

--- a/mobile/src/hooks/useOnlineStatus.ts
+++ b/mobile/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ApiError } from '@/types/api';
+
+export type OnlineStatus = {
+  isOnline: boolean;
+  isOffline: boolean;
+  lastNetworkErrorAt: number | null;
+  markOnline: () => void;
+  markOffline: () => void;
+};
+
+export function isNetworkError(error?: Pick<ApiError, 'kind' | 'message'> | null): boolean {
+  if (!error) return false;
+  if (error.kind === 'network') return true;
+
+  const message = String(error.message || '').toLowerCase();
+  return (
+    message.includes('network') ||
+    message.includes('connection') ||
+    message.includes('koneksi') ||
+    message.includes('internet') ||
+    message.includes('failed to fetch') ||
+    message.includes('timeout')
+  );
+}
+
+export function useOnlineStatus(observedError?: Pick<ApiError, 'kind' | 'message'> | null): OnlineStatus {
+  const initialObservedOffline = isNetworkError(observedError);
+  const [observedStatus, setObservedStatus] = useState({
+    isOffline: initialObservedOffline,
+    lastNetworkErrorAt: null as number | null,
+  });
+  const [manualOnlineStatus, setManualOnlineStatus] = useState<boolean | null>(null);
+  const [manualNetworkErrorAt, setManualNetworkErrorAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      const nextOffline = isNetworkError(observedError);
+      setObservedStatus((current) => ({
+        isOffline: nextOffline,
+        lastNetworkErrorAt: nextOffline
+          ? current.lastNetworkErrorAt ?? Date.now()
+          : observedError
+            ? current.lastNetworkErrorAt
+            : null,
+      }));
+    }, 0);
+
+    return () => clearTimeout(timeout);
+  }, [observedError]);
+
+  const isOnline = observedStatus.isOffline ? false : manualOnlineStatus ?? true;
+
+  const markOnline = useCallback(() => {
+    setManualOnlineStatus(true);
+  }, []);
+
+  const markOffline = useCallback(() => {
+    setManualOnlineStatus(false);
+    setManualNetworkErrorAt(Date.now());
+  }, []);
+
+  return {
+    isOnline,
+    isOffline: !isOnline,
+    lastNetworkErrorAt: observedStatus.lastNetworkErrorAt ?? manualNetworkErrorAt,
+    markOnline,
+    markOffline,
+  };
+}


### PR DESCRIPTION
## Summary
- add reusable useOnlineStatus hook for network/no-connection errors
- add OfflineBanner and render it on dashboard network request failures
- cover hook state transitions and dashboard offline banner acceptance
- mark Task 78 complete

## Validation
- npm test -- --runTestsByPath src/hooks/__tests__/useOnlineStatus.test.tsx
- npm test -- --runTestsByPath src/features/dashboard/screens/__tests__/DashboardScreen.test.tsx
- npm run typecheck
- npm run lint