### PR TITLE
feat(mobile): refresh stale screens on foreground (#482)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1087,7 +1087,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: offline banner appears when network request fails due to connection.
   - _Requirements: 16_
 
-- [ ] 79. Add foreground refresh behavior
+- [x] 79. Add foreground refresh behavior
   - Target area: app shell/query setup.
   - Refresh key screens when app returns to foreground.
   - Acceptance check: stale dashboard/list refetches after app resume.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,45 @@
+# Progress - Phase 122: Mobile Foreground Refresh Behavior
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-foreground-refresh-task-79`.
+> GitHub Issue: #482.
+
+---
+
+## Mobile Foreground Refresh Behavior
+
+### Status: SELESAI
+- Scope: Mobile App (App Shell / Query Setup)
+- Tujuan: Merefetch screen dashboard/list utama saat aplikasi kembali ke foreground setelah data stale.
+
+### Implementasi
+- **Hook**:
+  - Menambahkan [useForegroundRefresh.ts](file:///e:/bksda-superapp/mobile/src/hooks/useForegroundRefresh.ts).
+  - Menggunakan `AppState` untuk mendeteksi transisi `background/inactive -> active`.
+  - Merefetch hanya jika durasi background melewati `staleMs` agar resume singkat tidak memicu request berlebih.
+- **Integrasi Screen**:
+  - Menghubungkan [DashboardScreen.tsx](file:///e:/bksda-superapp/mobile/src/features/dashboard/screens/DashboardScreen.tsx) ke foreground refresh saat dashboard sudah punya data.
+  - Menghubungkan [BmnListScreen.tsx](file:///e:/bksda-superapp/mobile/src/features/bmn/screens/BmnListScreen.tsx) ke foreground refresh saat list aset sudah terisi.
+  - Menghubungkan [SuratTugasListScreen.tsx](file:///e:/bksda-superapp/mobile/src/features/surat-tugas/screens/SuratTugasListScreen.tsx) ke foreground refresh saat list surat tugas sudah terisi.
+- **Tests**:
+  - Menambahkan [useForegroundRefresh.test.tsx](file:///e:/bksda-superapp/mobile/src/hooks/__tests__/useForegroundRefresh.test.tsx) untuk stale resume, non-stale resume, dan cleanup listener.
+  - Memperluas test Dashboard, BMN List, dan Surat Tugas List agar refetch callback terbukti didaftarkan ke hook foreground refresh.
+- **Checklist**:
+  - Mencentang Task 79 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/hooks/__tests__/useForegroundRefresh.test.tsx`: 3 tests passed.
+- `npm test -- --runTestsByPath src/features/dashboard/screens/__tests__/DashboardScreen.test.tsx`: 6 tests passed.
+- `npm test -- --runTestsByPath src/features/bmn/screens/__tests__/BmnListScreen.test.tsx`: 7 tests passed.
+- `npm test -- --runTestsByPath src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx`: 9 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 80: Add unit tests for API client.
+
+---
+
 # Progress - Phase 121: Mobile Online-Only Network State
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/bmn/screens/BmnListScreen.tsx
+++ b/mobile/src/features/bmn/screens/BmnListScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { StyleSheet, View, Text, FlatList, SafeAreaView, ActivityIndicator } from 'react-native';
 import { useAppTheme } from '@/hooks/useAppTheme';
+import { useForegroundRefresh } from '@/hooks/useForegroundRefresh';
 import { useAssets } from '../useAssets';
 import AssetCard from '../components/AssetCard';
 import { LoadingSkeleton } from '@/components/LoadingSkeleton';
@@ -48,6 +49,7 @@ export default function BmnListScreen() {
     jenis_bmn: filters.jenis_bmn,
     lokasi_ruang: filters.lokasi_ruang,
   });
+  useForegroundRefresh(refetch, { enabled: items.length > 0, staleMs: 60_000 });
 
   const handleSearchChange = (text: string) => {
     setSearch(text);

--- a/mobile/src/features/bmn/screens/__tests__/BmnListScreen.test.tsx
+++ b/mobile/src/features/bmn/screens/__tests__/BmnListScreen.test.tsx
@@ -3,6 +3,7 @@ import { ActivityIndicator } from 'react-native';
 import renderer, { act } from 'react-test-renderer';
 import BmnListScreen from '../BmnListScreen';
 import { useAssets } from '../../useAssets';
+import { useForegroundRefresh } from '@/hooks/useForegroundRefresh';
 
 // Mock navigation
 jest.mock('@react-navigation/native', () => ({
@@ -55,6 +56,10 @@ jest.mock('@/hooks/useAppTheme', () => ({
       },
     },
   }),
+}));
+
+jest.mock('@/hooks/useForegroundRefresh', () => ({
+  useForegroundRefresh: jest.fn(),
 }));
 
 // Mock useAssets hook
@@ -154,6 +159,7 @@ describe('BmnListScreen', () => {
 
     expect(texts).toContain('Laptop Asus');
     expect(texts).toContain('Mobil Toyota');
+    expect(useForegroundRefresh).toHaveBeenCalledWith(mockRefetch, { enabled: true, staleMs: 60000 });
 
     act(() => {
       tree.unmount();

--- a/mobile/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/mobile/src/features/dashboard/screens/DashboardScreen.tsx
@@ -8,6 +8,7 @@ import {
   Alert,
 } from 'react-native';
 import { useAppTheme } from '@/hooks/useAppTheme';
+import { useForegroundRefresh } from '@/hooks/useForegroundRefresh';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useMobileDashboard } from '../useMobileDashboard';
 import { usePermissions } from '@/lib/permissions';
@@ -24,6 +25,7 @@ export default function DashboardScreen({ navigation }: any) {
   const { data, isLoading, error, refetch } = useMobileDashboard();
   const onlineStatus = useOnlineStatus(error);
   const { hasModule, can } = usePermissions();
+  useForegroundRefresh(refetch, { enabled: Boolean(data), staleMs: 60_000 });
 
   const showBmn = hasModule('bmn');
   const showSuratTugas = hasModule('surat_tugas') || hasModule('kepegawaian');

--- a/mobile/src/features/dashboard/screens/__tests__/DashboardScreen.test.tsx
+++ b/mobile/src/features/dashboard/screens/__tests__/DashboardScreen.test.tsx
@@ -6,6 +6,7 @@ import { Alert } from 'react-native';
 import DashboardScreen from '../DashboardScreen';
 import { useMobileDashboard } from '../../useMobileDashboard';
 import { usePermissions } from '@/lib/permissions';
+import { useForegroundRefresh } from '@/hooks/useForegroundRefresh';
 
 // Mock theme hook
 jest.mock('@/hooks/useAppTheme', () => ({
@@ -55,6 +56,10 @@ jest.mock('@/hooks/useAppTheme', () => ({
       },
     },
   }),
+}));
+
+jest.mock('@/hooks/useForegroundRefresh', () => ({
+  useForegroundRefresh: jest.fn(),
 }));
 
 // Mock dashboard API hook
@@ -253,6 +258,7 @@ describe('DashboardScreen', () => {
     // Alert Card and Quick Actions check
     expect(root.findByType('AlertCardMock')).toBeTruthy();
     expect(root.findByType('QuickActionsMock')).toBeTruthy();
+    expect(useForegroundRefresh).toHaveBeenCalledWith(mockRefetch, { enabled: true, staleMs: 60000 });
 
     act(() => {
       tree.unmount();

--- a/mobile/src/features/surat-tugas/screens/SuratTugasListScreen.tsx
+++ b/mobile/src/features/surat-tugas/screens/SuratTugasListScreen.tsx
@@ -9,6 +9,7 @@ import { AppButton } from '@/components/AppButton';
 import { LoadingSkeleton } from '@/components/LoadingSkeleton';
 import { SearchInput } from '@/components/SearchInput';
 import { useAppTheme } from '@/hooks/useAppTheme';
+import { useForegroundRefresh } from '@/hooks/useForegroundRefresh';
 import { usePermissions } from '@/lib/permissions';
 import AssignmentCard from '../components/AssignmentCard';
 import { SuratTugasStackParamList } from '../navigation/SuratTugasNavigator';
@@ -59,6 +60,7 @@ export default function SuratTugasListScreen() {
     search: debouncedSearch,
     status: status === 'all' ? undefined : status,
   });
+  useForegroundRefresh(refetch, { enabled: items.length > 0, staleMs: 60_000 });
 
   const renderAssignment = ({ item }: { item: AssignmentListItem }) => (
     <AssignmentCard

--- a/mobile/src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx
+++ b/mobile/src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx
@@ -3,6 +3,7 @@ import { ActivityIndicator, FlatList, Text, TouchableOpacity } from 'react-nativ
 import renderer, { act } from 'react-test-renderer';
 import SuratTugasListScreen from '../SuratTugasListScreen';
 import { useAssignments } from '../../useAssignments';
+import { useForegroundRefresh } from '@/hooks/useForegroundRefresh';
 
 const mockNavigate = jest.fn();
 const mockCan = jest.fn();
@@ -53,6 +54,10 @@ jest.mock('@/hooks/useAppTheme', () => ({
       },
     },
   }),
+}));
+
+jest.mock('@/hooks/useForegroundRefresh', () => ({
+  useForegroundRefresh: jest.fn(),
 }));
 
 jest.mock('@/lib/permissions', () => ({
@@ -119,6 +124,7 @@ describe('SuratTugasListScreen', () => {
     expect(texts).toContain('Menunggu');
     expect(texts).toContain('ST.001/BKSDA/2026');
     expect(texts).toContain('Patroli kawasan');
+    expect(useForegroundRefresh).toHaveBeenCalledWith(mockRefetch, { enabled: true, staleMs: 60000 });
 
     const searchInput = tree!.root.findByProps({ placeholder: 'Cari nomor, kegiatan, atau tujuan...' });
     expect(searchInput).toBeTruthy();

--- a/mobile/src/hooks/__tests__/useForegroundRefresh.test.tsx
+++ b/mobile/src/hooks/__tests__/useForegroundRefresh.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { AppState, AppStateStatus } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+import { useForegroundRefresh } from '../useForegroundRefresh';
+
+describe('useForegroundRefresh', () => {
+  let appStateHandler: ((state: AppStateStatus) => void) | undefined;
+  let removeListener: jest.Mock;
+  let currentState: AppStateStatus;
+
+  function TestComponent({
+    enabled = true,
+    refetch,
+    staleMs = 60_000,
+  }: {
+    enabled?: boolean;
+    refetch: () => void;
+    staleMs?: number;
+  }) {
+    useForegroundRefresh(refetch, { enabled, staleMs });
+    return null;
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-06-19T08:00:00.000Z'));
+    currentState = 'active';
+    appStateHandler = undefined;
+    removeListener = jest.fn();
+
+    Object.defineProperty(AppState, 'currentState', {
+      configurable: true,
+      get: () => currentState,
+    });
+
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, handler) => {
+      appStateHandler = handler;
+      return { remove: removeListener };
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('refetches when the app returns to foreground after stale threshold', () => {
+    const refetch = jest.fn();
+
+    act(() => {
+      renderer.create(<TestComponent refetch={refetch} staleMs={1_000} />);
+    });
+
+    act(() => {
+      appStateHandler?.('background');
+    });
+
+    jest.setSystemTime(new Date('2026-06-19T08:00:02.000Z'));
+
+    act(() => {
+      appStateHandler?.('active');
+    });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refetch when foreground resume is not stale yet', () => {
+    const refetch = jest.fn();
+
+    act(() => {
+      renderer.create(<TestComponent refetch={refetch} staleMs={60_000} />);
+    });
+
+    act(() => {
+      appStateHandler?.('inactive');
+    });
+
+    jest.setSystemTime(new Date('2026-06-19T08:00:10.000Z'));
+
+    act(() => {
+      appStateHandler?.('active');
+    });
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it('does not subscribe when disabled and removes listener on unmount', () => {
+    const refetch = jest.fn();
+    let tree!: renderer.ReactTestRenderer;
+
+    (AppState.addEventListener as jest.Mock).mockClear();
+
+    act(() => {
+      tree = renderer.create(<TestComponent refetch={refetch} enabled={false} />);
+    });
+
+    expect(AppState.addEventListener).not.toHaveBeenCalled();
+
+    act(() => {
+      tree.update(<TestComponent refetch={refetch} enabled />);
+    });
+
+    expect(AppState.addEventListener).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      tree.unmount();
+    });
+
+    expect(removeListener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/hooks/useForegroundRefresh.ts
+++ b/mobile/src/hooks/useForegroundRefresh.ts
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
+
+export type ForegroundRefreshOptions = {
+  enabled?: boolean;
+  staleMs?: number;
+};
+
+const DEFAULT_STALE_MS = 60_000;
+
+function isBackgroundState(state: AppStateStatus) {
+  return state === 'background' || state === 'inactive';
+}
+
+export function useForegroundRefresh(
+  refetch: () => void,
+  { enabled = true, staleMs = DEFAULT_STALE_MS }: ForegroundRefreshOptions = {}
+) {
+  useEffect(() => {
+    if (!enabled) return undefined;
+
+    let previousState = AppState.currentState;
+    let backgroundedAt: number | null = null;
+
+    const handleAppStateChange = (nextState: AppStateStatus) => {
+      if (isBackgroundState(nextState)) {
+        backgroundedAt = Date.now();
+      }
+
+      if (nextState === 'active' && isBackgroundState(previousState) && backgroundedAt !== null) {
+        const elapsedMs = Date.now() - backgroundedAt;
+
+        if (elapsedMs >= staleMs) {
+          refetch();
+        }
+
+        backgroundedAt = null;
+      }
+
+      previousState = nextState;
+    };
+
+    const subscription = AppState.addEventListener('change', handleAppStateChange);
+
+    return () => {
+      subscription.remove();
+    };
+  }, [enabled, refetch, staleMs]);
+}


### PR DESCRIPTION
## Summary
- add useForegroundRefresh based on React Native AppState
- refresh dashboard, BMN list, and Surat Tugas list when the app resumes after stale threshold
- cover stale/non-stale app resume and screen hook wiring
- mark Task 79 complete and update progress

## Validation
- npm test -- --runTestsByPath src/hooks/__tests__/useForegroundRefresh.test.tsx
- npm test -- --runTestsByPath src/features/dashboard/screens/__tests__/DashboardScreen.test.tsx
- npm test -- --runTestsByPath src/features/bmn/screens/__tests__/BmnListScreen.test.tsx
- npm test -- --runTestsByPath src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx
- npm run typecheck
- npm run lint