### PR TITLE
test(mobile): cover API client behavior (#484)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1093,7 +1093,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: stale dashboard/list refetches after app resume.
   - _Requirements: 16, 18_
 
-- [ ] 80. Add unit tests for API client
+- [x] 80. Add unit tests for API client
   - Target area: mobile test files.
   - Test response normalizer, error normalizer, mobile params, and auth headers.
   - Acceptance check: tests pass through mobile test script.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,39 @@
+# Progress - Phase 123: Mobile API Client Unit Tests
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-api-client-tests-task-80`.
+> GitHub Issue: #484.
+
+---
+
+## Mobile API Client Unit Tests
+
+### Status: SELESAI
+- Scope: Mobile App (API Client Tests)
+- Tujuan: Memastikan API client, normalizer, error mapper, mobile params, dan auth headers punya coverage unit test yang stabil.
+
+### Implementasi
+- **Tests**:
+  - Memvalidasi response normalizer lewat [normalize.test.ts](file:///e:/bksda-superapp/mobile/src/lib/api/__tests__/normalize.test.ts).
+  - Memvalidasi error normalizer lewat [errors.test.ts](file:///e:/bksda-superapp/mobile/src/lib/api/__tests__/errors.test.ts).
+  - Memvalidasi mobile params lewat [mobileParams.test.ts](file:///e:/bksda-superapp/mobile/src/lib/api/__tests__/mobileParams.test.ts), termasuk explicit zero-like pagination values.
+  - Memvalidasi auth/mobile headers dan response/error interceptors lewat [client.test.ts](file:///e:/bksda-superapp/mobile/src/lib/api/__tests__/client.test.ts), termasuk fallback saat secure token lookup gagal.
+- **Checklist**:
+  - Mencentang Task 80 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/lib/api/__tests__/client.test.ts`: 6 tests passed.
+- `npm test -- --runTestsByPath src/lib/api/__tests__/normalize.test.ts`: 7 tests passed.
+- `npm test -- --runTestsByPath src/lib/api/__tests__/errors.test.ts`: 10 tests passed.
+- `npm test -- --runTestsByPath src/lib/api/__tests__/mobileParams.test.ts`: 7 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 81: Add unit tests for permissions.
+
+---
+
 # Progress - Phase 122: Mobile Foreground Refresh Behavior
 
 > Document updated: 2026-06-19

--- a/mobile/src/lib/api/__tests__/client.test.ts
+++ b/mobile/src/lib/api/__tests__/client.test.ts
@@ -58,6 +58,28 @@ describe('apiClient', () => {
     expect(requestConfig.headers.get('Authorization')).toBe('Bearer super-secret-token');
   });
 
+  it('continues requests without Authorization when secure token lookup fails', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(jest.fn());
+    mockAdapter.mockResolvedValue({
+      data: { id: 20 },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {},
+    });
+
+    (tokenStorage.getToken as jest.Mock).mockRejectedValue(new Error('SecureStore unavailable'));
+
+    await apiClient.get('/token-storage-failure');
+
+    expect(mockAdapter).toHaveBeenCalled();
+    const requestConfig = mockAdapter.mock.calls[0][0];
+    expect(requestConfig.headers.get('X-Client')).toBe('mobile');
+    expect(requestConfig.headers.get('Authorization')).toBeUndefined();
+
+    errorSpy.mockRestore();
+  });
+
   it('normalizes response payloads on success', async () => {
     mockAdapter.mockResolvedValue({
       data: {

--- a/mobile/src/lib/api/__tests__/mobileParams.test.ts
+++ b/mobile/src/lib/api/__tests__/mobileParams.test.ts
@@ -67,6 +67,19 @@ describe('withMobileParams', () => {
     });
   });
 
+  it('preserves explicit zero-like pagination values for backend-owned edge cases', () => {
+    const input = {
+      page: 0,
+      per_page: 0,
+    };
+
+    expect(withMobileParams(input)).toEqual({
+      mobile: true,
+      per_page: 0,
+      page: 0,
+    });
+  });
+
   it('always overrides mobile parameter to true even if set to false originally', () => {
     const input = {
       mobile: false,


### PR DESCRIPTION
## Summary
- add API client guard for SecureStore token lookup failures continuing without Authorization
- add mobile params coverage for explicit zero-like pagination values
- verify existing response normalizer, error normalizer, mobile params, and auth header tests
- mark Task 80 complete and update progress

## Validation
- npm test -- --runTestsByPath src/lib/api/__tests__/client.test.ts
- npm test -- --runTestsByPath src/lib/api/__tests__/normalize.test.ts
- npm test -- --runTestsByPath src/lib/api/__tests__/errors.test.ts
- npm test -- --runTestsByPath src/lib/api/__tests__/mobileParams.test.ts
- npm run typecheck
- npm run lint