### PR TITLE
test(mobile): cover permission helpers (#486)

### DIFF
--- a/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
+++ b/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md
@@ -1099,7 +1099,7 @@ Use this matrix together with the numbered task. A lower-capability model should
   - Acceptance check: tests pass through mobile test script.
   - _Requirements: 17, 18, 19_
 
-- [ ] 81. Add unit tests for permissions
+- [x] 81. Add unit tests for permissions
   - Target area: permission helper tests.
   - Test can, hasModule, isSuperAdmin, empty permission state, and missing module state.
   - Acceptance check: helpers fail closed, not open.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,36 @@
+# Progress - Phase 124: Mobile Permission Helper Unit Tests
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-permission-tests-task-81`.
+> GitHub Issue: #486.
+
+---
+
+## Mobile Permission Helper Unit Tests
+
+### Status: SELESAI
+- Scope: Mobile App (Permission Helper Tests)
+- Tujuan: Memastikan helper permission fail closed untuk role, module, dan permission state yang kosong/hilang.
+
+### Implementasi
+- **Tests**:
+  - Memperluas [permissions.test.tsx](file:///e:/bksda-superapp/mobile/src/lib/__tests__/permissions.test.tsx).
+  - Menguji `isSuperAdmin`, `hasModule`, `can`, dan `usePermissions`.
+  - Menambahkan coverage untuk role mirip superadmin yang tidak exact, empty `access_modules`, dan empty `permissions`.
+  - Memastikan missing/null user, missing module data, dan missing permission data tidak membuka akses.
+- **Checklist**:
+  - Mencentang Task 81 di [.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md](file:///e:/bksda-superapp/.kiro/specs/mobile-app-bmn-kepegawaian/tasks.md).
+
+### Validasi
+- `npm test -- --runTestsByPath src/lib/__tests__/permissions.test.tsx`: 16 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Task 82: Add form validation tests.
+
+---
+
 # Progress - Phase 123: Mobile API Client Unit Tests
 
 > Document updated: 2026-06-19

--- a/mobile/src/lib/__tests__/permissions.test.tsx
+++ b/mobile/src/lib/__tests__/permissions.test.tsx
@@ -60,6 +60,11 @@ describe('Permission Helpers', () => {
       expect(isSuperAdmin(normalUser)).toBe(false);
     });
 
+    it('does not grant admin access for similar but non-exact roles', () => {
+      expect(isSuperAdmin({ ...normalUser, role: 'super_admin' })).toBe(false);
+      expect(isSuperAdmin({ ...normalUser, role: 'admin' })).toBe(false);
+    });
+
     it('fails closed (returns false) if user is null or undefined', () => {
       expect(isSuperAdmin(null)).toBe(false);
       expect(isSuperAdmin(undefined as any)).toBe(false);
@@ -73,6 +78,10 @@ describe('Permission Helpers', () => {
 
     it('returns false if module is not in access_modules', () => {
       expect(hasModule(normalUser, 'bmn')).toBe(false);
+    });
+
+    it('fails closed when access_modules is an empty list for non-superadmin users', () => {
+      expect(hasModule({ ...normalUser, access_modules: [] }, 'kepegawaian')).toBe(false);
     });
 
     it('returns true for superadmin even if access_modules is empty', () => {
@@ -93,6 +102,10 @@ describe('Permission Helpers', () => {
 
     it('returns false if permission is not granted', () => {
       expect(can(normalUser, 'delete-assignments')).toBe(false);
+    });
+
+    it('fails closed when permissions is an empty list for non-superadmin users', () => {
+      expect(can({ ...normalUser, permissions: [] }, 'view-assignments')).toBe(false);
     });
 
     it('returns true for superadmin even if permissions list is empty', () => {


### PR DESCRIPTION
## Summary
- add explicit fail-closed permission tests for similar non-superadmin roles
- cover empty module and permission arrays for non-superadmin users
- mark Task 81 complete and update progress

## Validation
- npm test -- --runTestsByPath src/lib/__tests__/permissions.test.tsx
- npm run typecheck
- npm run lint