### PR TITLE
fix(mobile): wire root app shell (#508)

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,34 @@
+# Progress - Phase 135: Mobile Root App Shell Wiring
+
+> Document updated: 2026-06-19
+> Status: Selesai di branch `codex/mobile-wire-root-app-shell`.
+> GitHub Issue: #508.
+
+---
+
+## Mobile Root App Shell Wiring
+
+### Status: SELESAI
+- Scope: Mobile App (Root Entry)
+- Tujuan: Mengganti template Expo default di `App.tsx` dengan app shell BKSDA SuperApp yang sebenarnya.
+
+### Implementasi
+- **Root App**:
+  - Memperbarui [App.tsx](file:///e:/bksda-superapp/mobile/App.tsx) agar merender `AuthProvider`, `NavigationContainer`, `RootNavigation`, dan `StatusBar`.
+  - Menghapus tampilan template default `Open up App.tsx to start working on your app`.
+- **Tests**:
+  - Menambahkan [App.test.tsx](file:///e:/bksda-superapp/mobile/src/__tests__/App.test.tsx) untuk memastikan root app memuat auth/navigation shell dan tidak kembali ke template Expo.
+
+### Validasi
+- `npm test -- --runTestsByPath src/__tests__/App.test.tsx`: 1 test passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Jalankan ulang `npx expo start --clear` dan scan QR Expo Go.
+
+---
+
 # Progress - Phase 134: Mobile Expo SDK Dependency Alignment
 
 > Document updated: 2026-06-19

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,22 +1,16 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
-import { aliasMessage } from '@/test-alias';
+import { AuthProvider } from '@/features/auth/AuthProvider';
+import RootNavigation from '@/navigation';
 
 export default function App() {
   return (
-    <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
-      <Text>{aliasMessage}</Text>
-      <StatusBar style="auto" />
-    </View>
+    <AuthProvider>
+      <NavigationContainer>
+        <RootNavigation />
+        <StatusBar style="auto" />
+      </NavigationContainer>
+    </AuthProvider>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/mobile/src/__tests__/App.test.tsx
+++ b/mobile/src/__tests__/App.test.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import App from '../../App';
+
+jest.mock('@react-navigation/native', () => {
+  const React = require('react');
+  return {
+    NavigationContainer: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('NavigationContainerMock', { testID: 'navigation-container' }, children),
+  };
+});
+
+jest.mock('@/features/auth/AuthProvider', () => {
+  const React = require('react');
+  return {
+    AuthProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('AuthProviderMock', { testID: 'auth-provider' }, children),
+  };
+});
+
+jest.mock('@/navigation', () => {
+  const React = require('react');
+  return function RootNavigationMock() {
+    return React.createElement('RootNavigationMock', { testID: 'root-navigation' });
+  };
+});
+
+describe('App', () => {
+  it('renders the authenticated navigation shell instead of the Expo template', () => {
+    let tree!: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(<App />);
+    });
+
+    expect(tree.root.findByProps({ testID: 'auth-provider' })).toBeTruthy();
+    expect(tree.root.findByProps({ testID: 'navigation-container' })).toBeTruthy();
+    expect(tree.root.findByProps({ testID: 'root-navigation' })).toBeTruthy();
+    expect(JSON.stringify(tree.toJSON())).not.toContain('Open up App.tsx to start working on your app');
+  });
+});


### PR DESCRIPTION
## Summary
- replace default Expo App.tsx template with the real BKSDA app shell
- render AuthProvider, NavigationContainer, RootNavigation, and StatusBar
- add App root test to prevent regression to the Expo starter screen
- update progress log

## Validation
- npm test -- --runTestsByPath src/__tests__/App.test.tsx
- npm run typecheck
- npm run lint