### PR TITLE
feat(mobile): implement login screen form

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,3 +1,36 @@
+# Progress - Phase 136: Mobile Login Screen Form
+
+> Document updated: 2026-06-19
+> Status: Selesai lokal, belum dibuat PR sesuai arahan pengguna.
+
+---
+
+## Mobile Login Screen Form
+
+### Status: SELESAI
+- Scope: Mobile App (Auth UI)
+- Tujuan: Mengganti placeholder LoginScreen dengan form login mobile yang benar-benar memanggil auth context.
+
+### Implementasi
+- **Screen**:
+  - Memperbarui [LoginScreen.tsx](file:///e:/bksda-superapp/mobile/src/features/auth/screens/LoginScreen.tsx).
+  - Menambahkan field username dan password, validasi wajib isi, loading state, dan error login generik.
+  - Menghubungkan tombol `Masuk` ke `useAuth().login(username, password)`.
+  - Menjaga password tersembunyi dan tidak menampilkan detail error mentah dari backend.
+- **Tests**:
+  - Menambahkan [LoginScreen.test.tsx](file:///e:/bksda-superapp/mobile/src/features/auth/screens/__tests__/LoginScreen.test.tsx).
+  - Menguji render field, validasi kosong, submit sukses, error generik, dan disabled/loading state.
+
+### Validasi
+- `npm test -- --runTestsByPath src/features/auth/screens/__tests__/LoginScreen.test.tsx`: 5 tests passed.
+- `npm run typecheck`: sukses tanpa error.
+- `npm run lint`: sukses tanpa warning.
+
+### Next Steps
+- [ ] Jalankan ulang Expo Go, isi username/password backend yang valid, lalu verifikasi masuk ke dashboard/tab app.
+
+---
+
 # Progress - Phase 135: Mobile Root App Shell Wiring
 
 > Document updated: 2026-06-19

--- a/mobile/src/features/auth/screens/LoginScreen.tsx
+++ b/mobile/src/features/auth/screens/LoginScreen.tsx
@@ -1,27 +1,193 @@
-import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import React, { useState } from 'react';
+import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { AppButton } from '@/components/AppButton';
+import { AppTextInput } from '@/components/AppTextInput';
+import { useAuth } from '@/features/auth/AuthProvider';
 import { useAppTheme } from '@/hooks/useAppTheme';
 
 export default function LoginScreen() {
-  const { colors, spacing } = useAppTheme();
+  const { colors, spacing, radius, typography } = useAppTheme();
+  const { login, isLoading } = useAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [usernameError, setUsernameError] = useState('');
+  const [passwordError, setPasswordError] = useState('');
+  const [submitError, setSubmitError] = useState('');
+
+  const handleSubmit = async () => {
+    const nextUsernameError = username.trim() ? '' : 'Username wajib diisi.';
+    const nextPasswordError = password ? '' : 'Password wajib diisi.';
+
+    setUsernameError(nextUsernameError);
+    setPasswordError(nextPasswordError);
+    setSubmitError('');
+
+    if (nextUsernameError || nextPasswordError) {
+      return;
+    }
+
+    try {
+      await login(username.trim(), password);
+    } catch {
+      setSubmitError('Login gagal. Periksa username dan password, lalu coba lagi.');
+    }
+  };
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background, padding: spacing.lg }]}>
-      <Text style={[styles.title, { color: colors.foreground }]}>Login Screen</Text>
-      <Text style={{ color: colors.mutedForeground }}>Silakan masuk untuk melanjutkan.</Text>
-    </View>
+    <KeyboardAvoidingView
+      style={[styles.screen, { backgroundColor: colors.background }]}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <ScrollView
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={[
+          styles.content,
+          {
+            padding: spacing.xl,
+          },
+        ]}
+      >
+        <View style={styles.header}>
+          <View
+            style={[
+              styles.brandMark,
+              {
+                backgroundColor: colors.primary,
+                borderRadius: radius.lg,
+              },
+            ]}
+            accessibilityLabel="BKSDA"
+          >
+            <Text
+              style={[
+                styles.brandMarkText,
+                {
+                  color: colors.primaryForeground,
+                  fontWeight: typography.fontWeights.bold,
+                },
+              ]}
+            >
+              BK
+            </Text>
+          </View>
+          <Text
+            style={[
+              styles.title,
+              {
+                color: colors.foreground,
+                fontWeight: typography.fontWeights.bold,
+              },
+            ]}
+          >
+            BKSDA SuperApp
+          </Text>
+          <Text style={[styles.subtitle, { color: colors.mutedForeground }]}>
+            Masuk untuk mengakses BMN dan Surat Tugas.
+          </Text>
+        </View>
+
+        <View
+          style={[
+            styles.form,
+            {
+              backgroundColor: colors.card,
+              borderColor: colors.border,
+              borderRadius: radius.lg,
+              padding: spacing.lg,
+            },
+          ]}
+        >
+          <AppTextInput
+            label="Username"
+            value={username}
+            onChangeText={(value) => {
+              setUsername(value);
+              if (usernameError) setUsernameError('');
+              if (submitError) setSubmitError('');
+            }}
+            placeholder="Masukkan username"
+            error={usernameError}
+            disabled={isLoading}
+          />
+          <AppTextInput
+            label="Password"
+            value={password}
+            onChangeText={(value) => {
+              setPassword(value);
+              if (passwordError) setPasswordError('');
+              if (submitError) setSubmitError('');
+            }}
+            placeholder="Masukkan password"
+            error={passwordError}
+            secureTextEntry
+            disabled={isLoading}
+          />
+
+          {submitError ? (
+            <Text
+              accessibilityLiveRegion="assertive"
+              style={[
+                styles.submitError,
+                {
+                  color: colors.danger,
+                  marginBottom: spacing.md,
+                },
+              ]}
+            >
+              {submitError}
+            </Text>
+          ) : null}
+
+          <AppButton
+            title="Masuk"
+            onPress={handleSubmit}
+            loading={isLoading}
+            disabled={isLoading}
+            accessibilityLabel="Masuk"
+          />
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  screen: {
     flex: 1,
+  },
+  content: {
+    flexGrow: 1,
     justifyContent: 'center',
+  },
+  header: {
+    marginBottom: 24,
+  },
+  brandMark: {
     alignItems: 'center',
+    height: 56,
+    justifyContent: 'center',
+    marginBottom: 16,
+    width: 56,
+  },
+  brandMarkText: {
+    fontSize: 18,
+    lineHeight: 24,
   },
   title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 8,
+    fontSize: 28,
+    lineHeight: 34,
+  },
+  subtitle: {
+    fontSize: 16,
+    lineHeight: 24,
+    marginTop: 8,
+  },
+  form: {
+    borderWidth: 1,
+    width: '100%',
+  },
+  submitError: {
+    fontSize: 14,
+    lineHeight: 20,
   },
 });

--- a/mobile/src/features/auth/screens/__tests__/LoginScreen.test.tsx
+++ b/mobile/src/features/auth/screens/__tests__/LoginScreen.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import LoginScreen from '../LoginScreen';
+import { useAuth } from '@/features/auth/AuthProvider';
+
+jest.mock('@/features/auth/AuthProvider', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppTheme', () => ({
+  useAppTheme: () => ({
+    colors: {
+      background: '#ffffff',
+      card: '#ffffff',
+      border: '#e2e8f0',
+      primary: '#16a34a',
+      primaryForeground: '#ffffff',
+      foreground: '#09090b',
+      muted: '#f1f5f9',
+      mutedForeground: '#64748b',
+      danger: '#ef4444',
+      dangerForeground: '#ffffff',
+      secondary: '#f1f5f9',
+      secondaryForeground: '#0f172a',
+    },
+    spacing: {
+      xs: 4,
+      md: 12,
+      lg: 16,
+      xl: 20,
+    },
+    radius: {
+      md: 6,
+      lg: 8,
+    },
+    typography: {
+      fontWeights: {
+        medium: '500',
+        semibold: '600',
+        bold: '700',
+      },
+      fontSizes: {
+        xs: 12,
+        sm: 14,
+        md: 16,
+      },
+    },
+  }),
+}));
+
+describe('LoginScreen', () => {
+  const login = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAuth as jest.Mock).mockReturnValue({
+      login,
+      isLoading: false,
+    });
+  });
+
+  it('renders username, password, and submit controls', () => {
+    let tree!: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(<LoginScreen />);
+    });
+
+    expect(tree.root.findByProps({ accessibilityLabel: 'Username' })).toBeTruthy();
+    expect(tree.root.findByProps({ accessibilityLabel: 'Password' })).toBeTruthy();
+    expect(tree.root.findByProps({ accessibilityLabel: 'Masuk' })).toBeTruthy();
+  });
+
+  it('validates required username and password before submitting', () => {
+    let tree!: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(<LoginScreen />);
+    });
+
+    act(() => {
+      tree.root.findByProps({ accessibilityLabel: 'Masuk' }).props.onPress();
+    });
+
+    expect(login).not.toHaveBeenCalled();
+    expect(tree.root.findByProps({ children: 'Username wajib diisi.' })).toBeTruthy();
+    expect(tree.root.findByProps({ children: 'Password wajib diisi.' })).toBeTruthy();
+  });
+
+  it('submits trimmed username and password to auth context', async () => {
+    login.mockResolvedValue(undefined);
+    let tree!: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(<LoginScreen />);
+    });
+
+    act(() => {
+      tree.root.findByProps({ accessibilityLabel: 'Username' }).props.onChangeText(' admin ');
+      tree.root.findByProps({ accessibilityLabel: 'Password' }).props.onChangeText('secret');
+    });
+
+    await act(async () => {
+      await tree.root.findByProps({ accessibilityLabel: 'Masuk' }).props.onPress();
+    });
+
+    expect(login).toHaveBeenCalledWith('admin', 'secret');
+  });
+
+  it('renders a generic login error without exposing raw exception details', async () => {
+    login.mockRejectedValue(new Error('SQLSTATE password debug token'));
+    let tree!: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(<LoginScreen />);
+    });
+
+    act(() => {
+      tree.root.findByProps({ accessibilityLabel: 'Username' }).props.onChangeText('admin');
+      tree.root.findByProps({ accessibilityLabel: 'Password' }).props.onChangeText('wrong');
+    });
+
+    await act(async () => {
+      await tree.root.findByProps({ accessibilityLabel: 'Masuk' }).props.onPress();
+    });
+
+    const serialized = JSON.stringify(tree.toJSON());
+
+    expect(serialized).toContain('Login gagal. Periksa username dan password, lalu coba lagi.');
+    expect(serialized).not.toContain('SQLSTATE');
+    expect(serialized).not.toContain('debug token');
+  });
+
+  it('disables inputs and shows busy submit state while auth is loading', () => {
+    (useAuth as jest.Mock).mockReturnValue({
+      login,
+      isLoading: true,
+    });
+
+    let tree!: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(<LoginScreen />);
+    });
+
+    expect(tree.root.findByProps({ accessibilityLabel: 'Username' }).props.editable).toBe(false);
+    expect(tree.root.findByProps({ accessibilityLabel: 'Password' }).props.editable).toBe(false);
+    const submitButton = tree.root
+      .findAllByProps({ accessibilityLabel: 'Masuk' })
+      .find((node) => node.props.accessibilityState);
+
+    expect(submitButton?.props.accessibilityState).toEqual({
+      disabled: true,
+      busy: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- replace the placeholder LoginScreen with a usable mobile login form
- wire username/password submission to useAuth().login
- add required-field validation, loading/disabled state, and generic safe login errors
- add LoginScreen tests and progress note

## Validation
- npm test -- --runTestsByPath src/features/auth/screens/__tests__/LoginScreen.test.tsx
- npm run typecheck
- npm run lint