### PR TITLE
fix(mobile): replace remaining placeholder actions

### DIFF
--- a/mobile/src/features/bmn/screens/BmnDetailScreen.tsx
+++ b/mobile/src/features/bmn/screens/BmnDetailScreen.tsx
@@ -32,7 +32,7 @@ export default function BmnDetailScreen() {
   const [isReturning, setIsReturning] = React.useState(false);
 
   const handleEdit = () => {
-    Alert.alert('Ubah Data', 'Fitur ubah data aset akan segera hadir.');
+    navigation.navigate('BmnForm', { id });
   };
 
   const handleUploadPhoto = () => {

--- a/mobile/src/features/bmn/screens/__tests__/BmnDetailScreen.test.tsx
+++ b/mobile/src/features/bmn/screens/__tests__/BmnDetailScreen.test.tsx
@@ -451,4 +451,35 @@ describe('BmnDetailScreen', () => {
       tree.unmount();
     });
   });
+
+  it('navigates to edit form when clicking edit button', () => {
+    (useAssetDetail as jest.Mock).mockReturnValue({
+      data: {
+        ...mockAsset,
+        allowed_actions: { can_edit: true },
+      },
+      isLoading: false,
+      error: undefined,
+      refetch: mockRefetch,
+    });
+
+    let tree: any;
+    act(() => {
+      tree = renderer.create(<BmnDetailScreen />);
+    });
+
+    const root = tree.root;
+    const editBtn = root.findByProps({ accessibilityLabel: 'Ubah Data Aset BMN' });
+    expect(editBtn).toBeTruthy();
+
+    act(() => {
+      editBtn.props.onPress();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('BmnForm', { id: '123' });
+
+    act(() => {
+      tree.unmount();
+    });
+  });
 });

--- a/mobile/src/features/dashboard/components/QuickActions.tsx
+++ b/mobile/src/features/dashboard/components/QuickActions.tsx
@@ -8,7 +8,6 @@ interface QuickActionsProps {
   canLoanBmn: boolean;
   canViewSuratTugas: boolean;
   canApproveSuratTugas: boolean;
-  onScanPress: () => void;
   onLoanPress: () => void;
   onViewBmnPress: () => void;
   onViewSuratTugasPress: () => void;
@@ -20,7 +19,6 @@ export default function QuickActions({
   canLoanBmn,
   canViewSuratTugas,
   canApproveSuratTugas,
-  onScanPress,
   onLoanPress,
   onViewBmnPress,
   onViewSuratTugasPress,
@@ -75,24 +73,13 @@ export default function QuickActions({
           </View>
         )}
 
-        {canViewBmn && (
-          <View style={styles.buttonWrapper}>
-            <AppButton
-              title="Scan Barcode"
-              variant="secondary"
-              onPress={onScanPress}
-              accessibilityLabel="Scan barcode barang milik negara"
-            />
-          </View>
-        )}
-
         {canLoanBmn && (
           <View style={styles.buttonWrapper}>
             <AppButton
-              title="Pinjam Aset"
+              title="Pilih Aset"
               variant="secondary"
               onPress={onLoanPress}
-              accessibilityLabel="Ajukan peminjaman aset BMN"
+              accessibilityLabel="Pilih aset BMN untuk diajukan peminjaman"
             />
           </View>
         )}

--- a/mobile/src/features/dashboard/components/__tests__/QuickActions.test.tsx
+++ b/mobile/src/features/dashboard/components/__tests__/QuickActions.test.tsx
@@ -62,7 +62,6 @@ describe('QuickActions', () => {
     canLoanBmn: false,
     canViewSuratTugas: false,
     canApproveSuratTugas: false,
-    onScanPress: jest.fn(),
     onLoanPress: jest.fn(),
     onViewBmnPress: jest.fn(),
     onViewSuratTugasPress: jest.fn(),
@@ -77,7 +76,7 @@ describe('QuickActions', () => {
     expect(tree.toJSON()).toBeNull();
   });
 
-  it('renders only BMN lists and barcode scanning when only BMN view is permitted', () => {
+  it('renders only BMN list when only BMN view is permitted', () => {
     const props = {
       ...defaultProps,
       canViewBmn: true,
@@ -94,12 +93,11 @@ describe('QuickActions', () => {
 
     const root = tree.root;
     const buttons = root.findAllByType('AppButtonMock');
-    expect(buttons.length).toBe(2);
+    expect(buttons.length).toBe(1);
 
     const titles = buttons.map((b: any) => b.props.title);
     expect(titles).toContain('Daftar BMN');
-    expect(titles).toContain('Scan Barcode');
-    expect(titles).not.toContain('Pinjam Aset');
+    expect(titles).not.toContain('Pilih Aset');
     expect(titles).not.toContain('Surat Tugas Saya');
     expect(titles).not.toContain('Persetujuan ST');
 
@@ -128,17 +126,10 @@ describe('QuickActions', () => {
 
     const root = tree.root;
     const buttons = root.findAllByType('AppButtonMock');
-    expect(buttons.length).toBe(5);
+    expect(buttons.length).toBe(4);
 
-    // Click 'Scan Barcode'
-    const scanBtn = buttons.find((b: any) => b.props.title === 'Scan Barcode');
-    act(() => {
-      scanBtn.props.onPress();
-    });
-    expect(props.onScanPress).toHaveBeenCalledTimes(1);
-
-    // Click 'Pinjam Aset'
-    const loanBtn = buttons.find((b: any) => b.props.title === 'Pinjam Aset');
+    // Click asset selection
+    const loanBtn = buttons.find((b: any) => b.props.title === 'Pilih Aset');
     act(() => {
       loanBtn.props.onPress();
     });

--- a/mobile/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/mobile/src/features/dashboard/screens/DashboardScreen.tsx
@@ -5,7 +5,6 @@ import {
   View,
   ScrollView,
   RefreshControl,
-  Alert,
 } from 'react-native';
 import { useAppTheme } from '@/hooks/useAppTheme';
 import { useForegroundRefresh } from '@/hooks/useForegroundRefresh';
@@ -40,16 +39,15 @@ export default function DashboardScreen({ navigation }: any) {
     navigation.navigate('SuratTugas');
   };
 
-  const handleScanBarcode = () => {
-    Alert.alert('Scan Barcode', 'Fitur scan barcode BMN akan segera hadir.');
-  };
-
   const handleLoanAsset = () => {
-    Alert.alert('Pinjam Aset', 'Fitur pengajuan peminjaman aset akan segera hadir.');
+    navigation.navigate('Bmn', { screen: 'BmnList' });
   };
 
   const handleApproveST = () => {
-    Alert.alert('Persetujuan Surat Tugas', 'Fitur persetujuan surat tugas akan segera hadir.');
+    navigation.navigate('SuratTugas', {
+      screen: 'SuratTugasList',
+      params: { initialMode: 'management', initialStatus: 'pending' },
+    });
   };
 
   if (isLoading && !data) {
@@ -173,7 +171,6 @@ export default function DashboardScreen({ navigation }: any) {
           canLoanBmn={showBmn}
           canViewSuratTugas={showSuratTugas}
           canApproveSuratTugas={showApproval}
-          onScanPress={handleScanBarcode}
           onLoanPress={handleLoanAsset}
           onViewBmnPress={handleViewBmn}
           onViewSuratTugasPress={handleViewSuratTugas}

--- a/mobile/src/features/dashboard/screens/__tests__/DashboardScreen.test.tsx
+++ b/mobile/src/features/dashboard/screens/__tests__/DashboardScreen.test.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable react/display-name */
 import React from 'react';
 import renderer, { act } from 'react-test-renderer';
-import { Alert } from 'react-native';
 import DashboardScreen from '../DashboardScreen';
 import { useMobileDashboard } from '../../useMobileDashboard';
 import { usePermissions } from '@/lib/permissions';
@@ -298,9 +297,7 @@ describe('DashboardScreen', () => {
     });
   });
 
-  it('triggers Alert calls when non-implemented quick actions are pressed', () => {
-    jest.spyOn(Alert, 'alert');
-
+  it('navigates to concrete screens when workflow quick actions are pressed', () => {
     (useMobileDashboard as jest.Mock).mockReturnValue({
       data: mockDashboardData,
       isLoading: false,
@@ -316,32 +313,18 @@ describe('DashboardScreen', () => {
     const root = tree.root;
     const quickActions = root.findByType('QuickActionsMock');
 
-    // Press 'Scan Barcode'
-    act(() => {
-      quickActions.props.onScanPress();
-    });
-    expect(Alert.alert).toHaveBeenCalledWith(
-      'Scan Barcode',
-      'Fitur scan barcode BMN akan segera hadir.'
-    );
-
-    // Press 'Pinjam Aset'
     act(() => {
       quickActions.props.onLoanPress();
     });
-    expect(Alert.alert).toHaveBeenCalledWith(
-      'Pinjam Aset',
-      'Fitur pengajuan peminjaman aset akan segera hadir.'
-    );
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('Bmn', { screen: 'BmnList' });
 
-    // Press 'Persetujuan ST'
     act(() => {
       quickActions.props.onApproveSuratTugasPress();
     });
-    expect(Alert.alert).toHaveBeenCalledWith(
-      'Persetujuan Surat Tugas',
-      'Fitur persetujuan surat tugas akan segera hadir.'
-    );
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('SuratTugas', {
+      screen: 'SuratTugasList',
+      params: { initialMode: 'management', initialStatus: 'pending' },
+    });
 
     act(() => {
       tree.unmount();

--- a/mobile/src/features/surat-tugas/navigation/SuratTugasNavigator.tsx
+++ b/mobile/src/features/surat-tugas/navigation/SuratTugasNavigator.tsx
@@ -6,7 +6,7 @@ import AssignmentFormScreen from '../screens/AssignmentFormScreen';
 import { AssignmentListMode } from '../types';
 
 export type SuratTugasStackParamList = {
-  SuratTugasList: undefined;
+  SuratTugasList?: { initialMode?: AssignmentListMode; initialStatus?: 'pending' };
   AssignmentDetail: { id: string | number; mode?: AssignmentListMode };
   AssignmentForm?: { id?: string | number };
 };

--- a/mobile/src/features/surat-tugas/screens/AssignmentDetailScreen.tsx
+++ b/mobile/src/features/surat-tugas/screens/AssignmentDetailScreen.tsx
@@ -6,6 +6,8 @@ import { AppButton } from '@/components/AppButton';
 import { ErrorState } from '@/components/ErrorState';
 import { IconButton } from '@/components/IconButton';
 import { LoadingSkeleton } from '@/components/LoadingSkeleton';
+import { downloadAssignmentFile } from '@/lib/files/download';
+import { openFile } from '@/lib/files/share';
 import { useAppTheme } from '@/hooks/useAppTheme';
 import { ApiError } from '@/types/api';
 import { updateAssignmentStatus } from '../assignmentActionsApi';
@@ -27,9 +29,35 @@ export default function AssignmentDetailScreen() {
   const route = useRoute<RouteProp<SuratTugasStackParamList, 'AssignmentDetail'>>();
   const { id, mode = 'personal' } = route.params;
   const { data, isLoading, error, refetch, isForbidden, isNotFound } = useAssignmentDetail(id, mode);
+  const [isDownloading, setIsDownloading] = React.useState(false);
 
-  const handleDownload = () => {
-    Alert.alert('Unduh Surat Tugas', 'Fitur unduh berkas akan disiapkan pada task file download berikutnya.');
+  const handleDownload = async () => {
+    if (!data) {
+      return;
+    }
+
+    setIsDownloading(true);
+    try {
+      const downloadedFile = await downloadAssignmentFile({
+        assignmentId: id,
+        mode,
+        filename: data.file.filename,
+        storage: 'cache',
+      });
+
+      await openFile({
+        localUri: downloadedFile.localUri,
+        mimeType: downloadedFile.mimeType || data.file.mime_type,
+        dialogTitle: 'Buka Surat Tugas',
+      });
+    } catch (downloadError: any) {
+      Alert.alert(
+        'Gagal Mengunduh',
+        downloadError?.message || 'Gagal mengunduh berkas Surat Tugas.'
+      );
+    } finally {
+      setIsDownloading(false);
+    }
   };
 
   const handleStatusAction = async (status: AssignmentActionType) => {
@@ -150,8 +178,9 @@ export default function AssignmentDetailScreen() {
         {canDownload ? (
           <View style={{ marginTop: spacing.sm }}>
             <AppButton
-              title="Unduh Berkas"
+              title={isDownloading ? 'Mengunduh...' : 'Unduh Berkas'}
               onPress={handleDownload}
+              loading={isDownloading}
               accessibilityLabel="Unduh berkas Surat Tugas"
             />
           </View>

--- a/mobile/src/features/surat-tugas/screens/SuratTugasListScreen.tsx
+++ b/mobile/src/features/surat-tugas/screens/SuratTugasListScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ActivityIndicator, FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { EmptyState } from '@/components/EmptyState';
@@ -29,14 +29,15 @@ const statusFilters: { label: string; value: StatusFilter }[] = [
 export default function SuratTugasListScreen() {
   const { colors, spacing, radius, typography } = useAppTheme();
   const navigation = useNavigation<NativeStackNavigationProp<SuratTugasStackParamList>>();
+  const route = useRoute<RouteProp<SuratTugasStackParamList, 'SuratTugasList'>>();
   const { hasModule, can } = usePermissions();
   const canUseManagementMode = hasModule('surat_tugas') || hasModule('kepegawaian');
   const canCreateAssignment =
     can('create-assignments') || can('surat_tugas.create') || can('surat_tugas.manage');
-  const [mode, setMode] = React.useState<AssignmentListMode>('personal');
+  const [mode, setMode] = React.useState<AssignmentListMode>(route.params?.initialMode ?? 'personal');
   const [search, setSearch] = React.useState('');
   const [debouncedSearch, setDebouncedSearch] = React.useState('');
-  const [status, setStatus] = React.useState<StatusFilter>('all');
+  const [status, setStatus] = React.useState<StatusFilter>(route.params?.initialStatus ?? 'all');
   const activeMode: AssignmentListMode = canUseManagementMode ? mode : 'personal';
 
   React.useEffect(() => {

--- a/mobile/src/features/surat-tugas/screens/__tests__/AssignmentDetailScreen.test.tsx
+++ b/mobile/src/features/surat-tugas/screens/__tests__/AssignmentDetailScreen.test.tsx
@@ -4,6 +4,8 @@ import renderer, { act } from 'react-test-renderer';
 import AssignmentDetailScreen from '../AssignmentDetailScreen';
 import { useAssignmentDetail } from '../../useAssignmentDetail';
 import { updateAssignmentStatus } from '../../assignmentActionsApi';
+import { downloadAssignmentFile } from '@/lib/files/download';
+import { openFile } from '@/lib/files/share';
 
 const mockGoBack = jest.fn();
 let mockRouteParams: { id: string | number; mode?: 'personal' | 'management' } = {
@@ -77,6 +79,14 @@ jest.mock('../../assignmentActionsApi', () => ({
   updateAssignmentStatus: jest.fn(),
 }));
 
+jest.mock('@/lib/files/download', () => ({
+  downloadAssignmentFile: jest.fn(),
+}));
+
+jest.mock('@/lib/files/share', () => ({
+  openFile: jest.fn(),
+}));
+
 describe('AssignmentDetailScreen', () => {
   const refetch = jest.fn();
   const assignment = {
@@ -96,6 +106,8 @@ describe('AssignmentDetailScreen', () => {
     file: {
       available: true,
       download_url: '/api/surat-tugas/my/st-1/download',
+      filename: 'ST.001/BKSDA/2026.pdf',
+      mime_type: 'application/pdf',
     },
     allowed_actions: {
       can_view: true,
@@ -115,6 +127,13 @@ describe('AssignmentDetailScreen', () => {
       isNotFound: false,
     });
     (updateAssignmentStatus as jest.Mock).mockResolvedValue({ id: 'st-1', status: 'completed' });
+    (downloadAssignmentFile as jest.Mock).mockResolvedValue({
+      localUri: 'file:///cache/surat-tugas/ST.001-BKSDA-2026.pdf',
+      filename: 'ST.001-BKSDA-2026.pdf',
+      mimeType: 'application/pdf',
+      status: 200,
+    });
+    (openFile as jest.Mock).mockResolvedValue(undefined);
   });
 
   it('renders detail sections and gated file action when file is allowed', () => {
@@ -211,23 +230,49 @@ describe('AssignmentDetailScreen', () => {
     });
   });
 
-  it('shows download placeholder alert when file action is pressed', () => {
-    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
-
+  it('downloads and opens file when file action is pressed', async () => {
     let tree: renderer.ReactTestRenderer;
-    act(() => {
+    await act(async () => {
       tree = renderer.create(<AssignmentDetailScreen />);
     });
 
     const downloadButton = tree!.root.findByProps({ accessibilityLabel: 'Unduh berkas Surat Tugas' });
-    act(() => {
+    await act(async () => {
       downloadButton.props.onPress();
     });
 
-    expect(alertSpy).toHaveBeenCalledWith(
-      'Unduh Surat Tugas',
-      'Fitur unduh berkas akan disiapkan pada task file download berikutnya.'
-    );
+    expect(downloadAssignmentFile).toHaveBeenCalledWith({
+      assignmentId: 'st-1',
+      mode: 'personal',
+      filename: assignment.file.filename,
+      storage: 'cache',
+    });
+    expect(openFile).toHaveBeenCalledWith({
+      localUri: 'file:///cache/surat-tugas/ST.001-BKSDA-2026.pdf',
+      mimeType: 'application/pdf',
+      dialogTitle: 'Buka Surat Tugas',
+    });
+
+    act(() => {
+      tree!.unmount();
+    });
+  });
+
+  it('shows a user-friendly message when file download fails', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    (downloadAssignmentFile as jest.Mock).mockRejectedValueOnce(new Error('File Surat Tugas tidak ditemukan.'));
+
+    let tree: renderer.ReactTestRenderer;
+    await act(async () => {
+      tree = renderer.create(<AssignmentDetailScreen />);
+    });
+
+    const downloadButton = tree!.root.findByProps({ accessibilityLabel: 'Unduh berkas Surat Tugas' });
+    await act(async () => {
+      downloadButton.props.onPress();
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith('Gagal Mengunduh', 'File Surat Tugas tidak ditemukan.');
 
     alertSpy.mockRestore();
     act(() => {

--- a/mobile/src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx
+++ b/mobile/src/features/surat-tugas/screens/__tests__/SuratTugasListScreen.test.tsx
@@ -12,6 +12,9 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
     navigate: mockNavigate,
   }),
+  useRoute: () => ({
+    params: undefined,
+  }),
 }));
 
 jest.mock('@/hooks/useAppTheme', () => ({

--- a/mobile/src/navigation/AppTabs.tsx
+++ b/mobile/src/navigation/AppTabs.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { NavigatorScreenParams } from '@react-navigation/native';
 import DashboardScreen from '@/features/dashboard/screens/DashboardScreen';
 import BmnNavigator from '@/features/bmn/navigation/BmnNavigator';
+import { BmnStackParamList } from '@/features/bmn/navigation/BmnNavigator';
 import SuratTugasNavigator from '@/features/surat-tugas/navigation/SuratTugasNavigator';
+import { SuratTugasStackParamList } from '@/features/surat-tugas/navigation/SuratTugasNavigator';
 import ProfileScreen from '@/features/profile/screens/ProfileScreen';
 import { useAppTheme } from '@/hooks/useAppTheme';
 
@@ -10,8 +13,8 @@ import { usePermissions } from '@/lib/permissions';
 
 export type AppTabParamList = {
   Dashboard: undefined;
-  Bmn?: undefined;
-  SuratTugas?: undefined;
+  Bmn?: NavigatorScreenParams<BmnStackParamList>;
+  SuratTugas?: NavigatorScreenParams<SuratTugasStackParamList>;
   Profile: undefined;
 };
 


### PR DESCRIPTION
## Summary
- Replaced dashboard placeholder alerts with real navigation for BMN selection and Surat Tugas approvals.
- Removed the unsupported dashboard barcode quick action instead of exposing a dead-end button.
- Wired BMN edit action to the existing edit form.
- Wired Surat Tugas file download to the existing authenticated download/open-file helpers.

Closes #511.

## Validation
- npm test -- --runInBand
- npm run typecheck
- npm run lint