### PR TITLE
fix(app): replace remaining placeholder surfaces

### DIFF
--- a/backend/app/Http/Controllers/Api/MobileDashboardController.php
+++ b/backend/app/Http/Controllers/Api/MobileDashboardController.php
@@ -113,7 +113,7 @@ class MobileDashboardController extends Controller
                     'pending_approvals_count' => $pendingApprovalsCount,
                 ],
                 'urgent_tax_vehicles' => $urgentTaxVehicles,
-                'notifications' => [], // Fallback placeholder
+                'notifications' => [],
             ],
             'meta' => [
                 'generated_at' => now()->toIso8601String(),

--- a/backend/app/Modules/Inventory/Controllers/CategoryController.php
+++ b/backend/app/Modules/Inventory/Controllers/CategoryController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Modules\Inventory\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Modules\Inventory\Models\Category;
+use Illuminate\Http\JsonResponse;
+
+class CategoryController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $categories = Category::query()
+            ->select(['id', 'nama_kategori', 'deskripsi'])
+            ->orderBy('nama_kategori')
+            ->get();
+
+        return response()->json([
+            'data' => $categories,
+        ]);
+    }
+}

--- a/backend/app/Modules/Inventory/Routes/api.php
+++ b/backend/app/Modules/Inventory/Routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Modules\Inventory\Controllers\DashboardController;
+use App\Modules\Inventory\Controllers\CategoryController;
 use App\Modules\Inventory\Controllers\ExportController;
 use App\Modules\Inventory\Controllers\ItemController;
 use App\Modules\Inventory\Controllers\OfficeController;
@@ -30,6 +31,7 @@ Route::get('/ping', function () {
 // Siapapun Pegawai Biasa asalkan punya akses Modul Logistik, boleh melihat ini.
 // ==========================================
 Route::get('/dashboard/stats', [DashboardController::class, 'stats']);
+Route::get('/categories', [CategoryController::class, 'index']);
 Route::get('/offices', [OfficeController::class, 'index']);
 Route::get('/items', [ItemController::class, 'index']);
 Route::get('/transactions', [StockController::class, 'history']);

--- a/frontend/src/app/(publik)/hubungi-kami/page.tsx
+++ b/frontend/src/app/(publik)/hubungi-kami/page.tsx
@@ -5,6 +5,10 @@ import axios from "axios";
 import { Send, MapPin, Phone, Mail, Loader2, CheckCircle } from "lucide-react";
 
 const API = process.env.NEXT_PUBLIC_API_URL;
+const MAP_EMBED_URL =
+  "https://www.openstreetmap.org/export/embed.html?bbox=106.7908%2C-6.2443%2C106.8108%2C-6.2243&layer=mapnik&marker=-6.2343%2C106.8008";
+const MAP_LINK_URL =
+  "https://www.openstreetmap.org/search?query=Jl.%20Raden%20Patah%20No.%201%20Jakarta%20Selatan%20Indonesia";
 
 interface FormData {
   nama: string;
@@ -105,12 +109,22 @@ export default function HubungiKamiPage() {
             </div>
           </div>
 
-          {/* Peta Placeholder */}
-          <div className="mt-10 h-64 bg-gray-100 rounded-2xl overflow-hidden border border-gray-200 flex items-center justify-center">
-            <div className="text-center text-gray-400">
-              <MapPin className="w-10 h-10 mx-auto mb-2" />
-              <p className="text-sm">Peta Lokasi</p>
-            </div>
+          <div className="mt-10 overflow-hidden rounded-2xl border border-gray-200 bg-gray-100">
+            <iframe
+              title="Peta lokasi kantor BKSDA"
+              src={MAP_EMBED_URL}
+              className="h-64 w-full"
+              loading="lazy"
+            />
+            <a
+              href={MAP_LINK_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-2 border-t border-gray-200 bg-white px-4 py-3 text-sm font-bold text-green-700 hover:text-green-600"
+            >
+              <MapPin className="h-4 w-4" />
+              Buka peta lokasi
+            </a>
           </div>
         </div>
 

--- a/frontend/src/app/inventory/items/page.tsx
+++ b/frontend/src/app/inventory/items/page.tsx
@@ -7,6 +7,7 @@ import { PackageSearch, Plus, Loader2, Save, Trash2, Edit, Download } from "luci
 import { InventoryImportDialog } from "../_components/InventoryImportDialog";
 import { InventoryTrashDialog } from "../_components/InventoryTrashDialog";
 import { Button } from "@/components/ui/button";
+import { ICategory } from "@/types/inventory";
 
 interface IItem {
     id: string;
@@ -26,12 +27,19 @@ export default function ItemsManagementPage() {
     const queryClient = useQueryClient();
 
     const [form, setForm] = useState({
-        // Catatan: UUID dummy sementara — sesuaikan dengan UUID Kategori dari Database
-        category_id: "00000000-0000-0000-0000-000000000000",
+        category_id: "",
         kode_barang: "",
         nama_barang: "",
         satuan: "Pcs",
         min_stock: "5",
+    });
+
+    const { data: categories = [], isLoading: isLoadingCategories } = useQuery<ICategory[]>({
+        queryKey: ["inventory-categories"],
+        queryFn: async () => {
+            const res = await api.get<{ data: ICategory[] }>("/inventory/categories");
+            return res.data.data;
+        },
     });
 
     // 1. Tarik Data Tabel (Data Grid)
@@ -52,7 +60,7 @@ export default function ItemsManagementPage() {
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["inventory-items"] });
-            setForm({ ...form, kode_barang: "", nama_barang: "" });
+            setForm((current) => ({ ...current, kode_barang: "", nama_barang: "" }));
             alert("Barang baru berhasil masuk katalog!");
         },
         onError: (err: { response?: { data?: { message?: string } } }) => {
@@ -76,6 +84,8 @@ export default function ItemsManagementPage() {
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
+        if (!form.category_id)
+            return alert("Pilih kategori barang terlebih dahulu.");
         if (!form.kode_barang || !form.nama_barang)
             return alert("Kode dan Nama wajib diisi!");
         mutation.mutate(form);
@@ -119,19 +129,31 @@ export default function ItemsManagementPage() {
                         <div className="space-y-4">
                             <div>
                                 <label className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
-                                    Kategori ID
+                                    Kategori
                                 </label>
-                                <input
-                                    type="text"
+                                <select
                                     value={form.category_id}
                                     onChange={(e) =>
                                         setForm({ ...form, category_id: e.target.value })
                                     }
-                                    className="w-full mt-1 bg-zinc-50 dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 text-zinc-500 rounded-xl px-4 py-2.5 focus:outline-none font-mono text-sm"
-                                    placeholder="UUID Kategori"
-                                />
+                                    disabled={isLoadingCategories || categories.length === 0}
+                                    className="w-full mt-1 bg-zinc-50 dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 text-zinc-900 dark:text-white rounded-xl px-4 py-3 focus:outline-none focus:border-orange-500 disabled:opacity-60"
+                                >
+                                    <option value="">
+                                        {isLoadingCategories
+                                            ? "Memuat kategori..."
+                                            : categories.length === 0
+                                                ? "Belum ada kategori"
+                                                : "Pilih kategori barang"}
+                                    </option>
+                                    {categories.map((category) => (
+                                        <option key={category.id} value={category.id}>
+                                            {category.nama_kategori}
+                                        </option>
+                                    ))}
+                                </select>
                                 <p className="text-[10px] text-zinc-500 mt-1">
-                                    Isi dengan UUID Kategori dari Database Supabase Anda.
+                                    Kategori diambil langsung dari master logistik.
                                 </p>
                             </div>
 


### PR DESCRIPTION
## Summary
- Replace the public contact page map placeholder with an OpenStreetMap embed and external map link.
- Add a read endpoint for inventory categories.
- Replace the inventory item UUID dummy field with a category select backed by the API.
- Remove the mobile dashboard fallback placeholder comment while preserving the API response contract.

Closes #513.

## Validation
- npm run lint (frontend)
- npm run build (frontend)
- php artisan route:list --path=api/inventory
- php -l backend/app/Modules/Inventory/Controllers/CategoryController.php
- php -l backend/app/Modules/Inventory/Routes/api.php
- php -l backend/app/Http/Controllers/Api/MobileDashboardController.php