### PR TITLE
fix(frontend): normalize surat tugas employee spacing

### DIFF
--- a/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx
+++ b/frontend/src/app/kepegawaian/surat-tugas/builder/[id]/STBuilderPreview.tsx
@@ -228,7 +228,7 @@ export default function STBuilderPreview({
                         style={{
                           display: "grid",
                           gridTemplateColumns: "24px 1fr",
-                          padding: idx === 0 ? "0 0 2px" : "2px 0",
+                          padding: idx === 0 ? "0 0 1px" : "1px 0",
                           breakInside: "avoid",
                         }}
                       >


### PR DESCRIPTION
## Summary
- normalize spacing between Surat Tugas employee entries
- keep signature placeholder size unchanged

## Tests
- npm run lint
- npm run build

Closes #519