### PR TITLE
fix(backend): tolerate missing KTP storage URL

### DIFF
--- a/backend/app/Modules/Bmn/Resources/PowerOfAttorneyResource.php
+++ b/backend/app/Modules/Bmn/Resources/PowerOfAttorneyResource.php
@@ -4,6 +4,8 @@ namespace App\Modules\Bmn\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
 
 class PowerOfAttorneyResource extends JsonResource
 {
@@ -21,7 +23,7 @@ class PowerOfAttorneyResource extends JsonResource
             'asset_ids' => $this->asset_ids,
             'notes' => $this->notes,
             'ktp_path' => $this->ktp_path,
-            'ktp_url' => $this->ktp_path ? \Illuminate\Support\Facades\Storage::url($this->ktp_path) : null,
+            'ktp_url' => $this->resolveKtpUrl(),
             'employee' => $this->whenLoaded('employee', fn () => [
                 'id' => $this->employee->id,
                 'nama_lengkap' => $this->employee->nama_lengkap,
@@ -37,5 +39,18 @@ class PowerOfAttorneyResource extends JsonResource
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),
         ];
+    }
+
+    private function resolveKtpUrl(): ?string
+    {
+        if (! $this->ktp_path) {
+            return null;
+        }
+
+        try {
+            return Storage::url($this->ktp_path);
+        } catch (Throwable) {
+            return null;
+        }
     }
 }

--- a/backend/tests/Unit/PowerOfAttorneyResourceTest.php
+++ b/backend/tests/Unit/PowerOfAttorneyResourceTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Modules\Bmn\Models\PowerOfAttorney;
+use App\Modules\Bmn\Resources\PowerOfAttorneyResource;
+use Tests\TestCase;
+
+class PowerOfAttorneyResourceTest extends TestCase
+{
+    public function test_it_keeps_history_response_alive_when_ktp_url_cannot_be_generated(): void
+    {
+        config([
+            'filesystems.default' => 's3',
+            'filesystems.disks.s3.bucket' => null,
+            'filesystems.disks.s3.endpoint' => null,
+            'filesystems.disks.s3.url' => null,
+        ]);
+
+        $agreement = new PowerOfAttorney([
+            'id' => '00000000-0000-0000-0000-000000000000',
+            'employee_id' => 129,
+            'number' => 'KS.TEST/K.18/TU/KAP.03.02/B/06/2026',
+            'kap' => 'KAP.03.02',
+            'document_date' => '2026-06-22',
+            'first_party_snapshot' => ['name' => 'Pemberi Kuasa'],
+            'second_party_snapshot' => ['name' => 'Penerima Kuasa'],
+            'assets_snapshot' => [],
+            'asset_ids' => [],
+            'ktp_path' => 'bmn/power-of-attorneys/ktp/KTP-TEST.jpg',
+        ]);
+
+        $payload = (new PowerOfAttorneyResource($agreement))->resolve(request());
+
+        $this->assertSame('bmn/power-of-attorneys/ktp/KTP-TEST.jpg', $payload['ktp_path']);
+        $this->assertNull($payload['ktp_url']);
+    }
+}


### PR DESCRIPTION
## Summary
- keep BMN power-of-attorney history responses alive when KTP URL generation fails
- return ktp_url as null while preserving ktp_path
- add unit coverage for broken storage URL configuration

## Tests
- php artisan test --filter=PowerOfAttorneyResourceTest
- vendor\\bin\\pint --dirty
- php artisan test --testsuite=Unit

Closes #521