### PR TITLE
fix(deploy): run migrations on backend startup

### DIFF
--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -29,6 +29,8 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     restart: always
+    command: >
+      sh -c "php artisan migrate --force && php-fpm"
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -35,6 +35,8 @@ services:
       dockerfile: Dockerfile
     container_name: bksda-backend
     restart: always
+    command: >
+      sh -c "php artisan migrate --force && php-fpm"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- run Laravel migrations before php-fpm starts in Dokploy compose
- keep production compose aligned with the same startup behavior

## Validation
- docker compose -f docker-compose.dokploy.yml config --quiet (with local dummy env)
- docker compose -f docker-compose.prod.yml config --quiet (with local dummy env)

Closes #523