### PR TITLE
feat(bmn): add auction asset final result enum

### DIFF
--- a/backend/app/Modules/Bmn/Enums/AuctionAssetFinalResult.php
+++ b/backend/app/Modules/Bmn/Enums/AuctionAssetFinalResult.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Modules\Bmn\Enums;
+
+enum AuctionAssetFinalResult: string
+{
+    case SOLD_FIRST = 'SOLD_FIRST';
+    case SOLD_REAUCTION = 'SOLD_REAUCTION';
+    case UNSOLD = 'UNSOLD';
+    case CANCELED = 'CANCELED';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::SOLD_FIRST => 'Terjual Lelang Pertama',
+            self::SOLD_REAUCTION => 'Terjual Lelang Ulang',
+            self::UNSOLD => 'Tidak Terjual',
+            self::CANCELED => 'Dibatalkan',
+        };
+    }
+
+    public function isSold(): bool
+    {
+        return in_array($this, [self::SOLD_FIRST, self::SOLD_REAUCTION], true);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}


### PR DESCRIPTION
## Summary
- add AuctionAssetFinalResult enum for final auction result values
- include labels, sold-state helper, and value list helper
- keep final_result values out of services/controllers as magic strings

## Verification
- php -l app/Modules/Bmn/Enums/AuctionAssetFinalResult.php

## Note
- tasks.md described constants; this uses PHP enum to stay aligned with project rules and existing BMN enum pattern.

## Base
- develop/bmn-auction
