### PR TITLE
feat(bmn): add auction permissions to access control

### DIFF
--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -83,6 +83,10 @@ class User extends Authenticatable
         // Izinkan aksi BMN jika user memiliki akses modul BMN. Aksi penulisan tetap memerlukan role admin.
         if (is_null($this->permissions)) {
             if (str_starts_with($permission, 'bmn.')) {
+                if (str_starts_with($permission, 'bmn.auction.')) {
+                    return $permission === 'bmn.auction.view' && in_array('bmn', $this->access_modules ?? []);
+                }
+
                 $isReadPermission = in_array($permission, ['bmn.view', 'bmn.document.history.view']);
                 if ($isReadPermission) {
                     return in_array('bmn', $this->access_modules ?? []);

--- a/backend/tests/Unit/UserPermissionFallbackTest.php
+++ b/backend/tests/Unit/UserPermissionFallbackTest.php
@@ -31,6 +31,19 @@ class UserPermissionFallbackTest extends TestCase
         $this->assertTrue($user->hasPermission('bmn.asset.update'));
     }
 
+    public function test_legacy_bmn_admin_can_only_read_auction_without_explicit_permission(): void
+    {
+        $user = new User([
+            'role' => 'admin',
+            'access_modules' => ['bmn'],
+            'permissions' => null,
+        ]);
+
+        $this->assertTrue($user->hasPermission('bmn.auction.view'));
+        $this->assertFalse($user->hasPermission('bmn.auction.update'));
+        $this->assertFalse($user->hasPermission('bmn.auction.finalize'));
+    }
+
     public function test_legacy_kepegawaian_admin_can_approve_surat_tugas(): void
     {
         $user = new User([

--- a/frontend/src/app/kepegawaian/_components/EmployeeAccessSheet.tsx
+++ b/frontend/src/app/kepegawaian/_components/EmployeeAccessSheet.tsx
@@ -55,6 +55,12 @@ const BMN_PERMISSIONS = [
   { id: "bmn.document.generate", label: "Generate Dokumen Lelang" },
   { id: "bmn.document.delete", label: "Hapus Arsip BA" },
   { id: "bmn.document.history.view", label: "Lihat Riwayat Dokumen" },
+  { id: "bmn.auction.view", label: "Lihat Paket Lelang" },
+  { id: "bmn.auction.create", label: "Buat Paket Lelang" },
+  { id: "bmn.auction.update", label: "Edit Draft Paket Lelang" },
+  { id: "bmn.auction.delete", label: "Hapus Draft Paket Lelang" },
+  { id: "bmn.auction.print", label: "Cetak Dokumen Lelang" },
+  { id: "bmn.auction.finalize", label: "Finalisasi/Jadwal Lelang" },
 ];
 
 interface EmployeeAccessSheetProps {

--- a/frontend/src/hooks/useRole.ts
+++ b/frontend/src/hooks/useRole.ts
@@ -22,6 +22,10 @@ export function useRole() {
       // Fallback untuk backward compatibility jika data permissions tidak ada
       if (user?.permissions === undefined || user?.permissions === null) {
         if (permission.startsWith("bmn.")) {
+          if (permission.startsWith("bmn.auction.")) {
+            return permission === "bmn.auction.view" && (user?.access_modules?.includes("bmn") || false);
+          }
+
           const isReadPermission = ["bmn.view", "bmn.document.history.view"].includes(permission);
           if (isReadPermission) {
             return user?.access_modules?.includes("bmn") || false;


### PR DESCRIPTION
## Summary
- expose bmn.auction.* permissions in employee access UI
- add safe legacy fallback for bmn.auction.view only
- keep auction update/finalize explicit when legacy permissions are null
- add unit test coverage for auction fallback behavior

## Verification
- php -l app/Models/User.php
- php artisan test --filter=UserPermissionFallbackTest
- npx eslint src/app/kepegawaian/_components/EmployeeAccessSheet.tsx src/hooks/useRole.ts

## Base
- develop/bmn-auction
