### PR TITLE
fix(bmn): polish auction batch document readiness and quick edit

### DIFF
--- a/backend/app/Modules/Bmn/Migrations/2026_06_22_122600_create_bmn_auction_batches_table.php
+++ b/backend/app/Modules/Bmn/Migrations/2026_06_22_122600_create_bmn_auction_batches_table.php
@@ -24,13 +24,13 @@ return new class extends Migration
             $table->date('tanggal_lelang_ulang')->nullable();
             $table->text('reauction_notes')->nullable();
 
-            $table->uuid('kepala_balai_id')->nullable();
+            $table->unsignedBigInteger('kepala_balai_id')->nullable();
             $table->jsonb('metadata')->nullable();
 
             $table->timestamp('realized_at')->nullable();
             $table->timestamp('canceled_at')->nullable();
-            $table->uuid('created_by')->nullable();
-            $table->uuid('updated_by')->nullable();
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->unsignedBigInteger('updated_by')->nullable();
 
             $table->timestamps();
             $table->softDeletes();

--- a/backend/app/Modules/Bmn/Migrations/2026_06_22_122800_create_bmn_auction_batch_events_table.php
+++ b/backend/app/Modules/Bmn/Migrations/2026_06_22_122800_create_bmn_auction_batch_events_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
             $table->uuid('id')->primary();
             $table->uuid('bmn_auction_batch_id');
             $table->uuid('bmn_asset_id')->nullable();
-            $table->uuid('actor_id')->nullable();
+            $table->unsignedBigInteger('actor_id')->nullable();
             $table->string('action', 80);
             $table->jsonb('previous_values')->nullable();
             $table->jsonb('new_values')->nullable();

--- a/backend/app/Modules/Bmn/Services/AuctionAssetDocumentReadinessService.php
+++ b/backend/app/Modules/Bmn/Services/AuctionAssetDocumentReadinessService.php
@@ -72,11 +72,6 @@ class AuctionAssetDocumentReadinessService
             $items['bpkb'] = 'warning';
         }
 
-        if (empty($asset->no_stnk)) {
-            $warnings[] = 'Nomor STNK belum tersedia di master aset.';
-            $items['stnk'] = 'warning';
-        }
-
         if (empty($asset->no_polisi)) {
             $warnings[] = 'Nomor Polisi belum tersedia di master aset.';
             $items['no_polisi'] = 'warning';

--- a/frontend/src/app/bmn/auction-batches/[id]/_components/AssetsLotTab.tsx
+++ b/frontend/src/app/bmn/auction-batches/[id]/_components/AssetsLotTab.tsx
@@ -12,6 +12,7 @@ import {
   AuctionBatchAsset,
   AuctionCandidateAsset,
 } from "../../_lib/api";
+import { api } from "@/lib/api";
 import { formatRupiah } from "../../../auction-candidates/_lib/auction-helpers";
 import { toast } from "sonner";
 import {
@@ -28,6 +29,7 @@ import {
   Check,
   ChevronDown,
   ChevronUp,
+  Pencil,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -61,6 +63,45 @@ export function AssetsLotTab({ batch, readOnly, onRefetch }: AssetsLotTabProps) 
   // Edit Lot State
   const [editingLotAssetId, setEditingLotAssetId] = useState<string | null>(null);
   const [editingLotValue, setEditingLotValue] = useState("");
+
+  // Quick Edit Asset State
+  const [isQuickEditOpen, setIsQuickEditOpen] = useState(false);
+  const [quickEditAsset, setQuickEditAsset] = useState<AuctionBatchAsset | null>(null);
+  const [quickEditBpkb, setQuickEditBpkb] = useState("");
+  const [quickEditPolisi, setQuickEditPolisi] = useState("");
+  const [quickEditRangka, setQuickEditRangka] = useState("");
+  const [quickEditMesin, setQuickEditMesin] = useState("");
+  const [isSavingQuickEdit, setIsSavingQuickEdit] = useState(false);
+
+  const handleOpenQuickEdit = (asset: AuctionBatchAsset) => {
+    setQuickEditAsset(asset);
+    setQuickEditBpkb(asset.no_bpkp || "");
+    setQuickEditPolisi(asset.no_polisi || "");
+    setQuickEditRangka(asset.no_rangka || "");
+    setQuickEditMesin(asset.no_mesin || "");
+    setIsQuickEditOpen(true);
+  };
+
+  const handleSaveQuickEdit = async () => {
+    if (!quickEditAsset) return;
+    setIsSavingQuickEdit(true);
+    try {
+      await api.put(`/bmn/assets/${quickEditAsset.id}`, {
+        no_bpkp: quickEditBpkb.trim() || null,
+        no_polisi: quickEditPolisi.trim() || null,
+        no_rangka: quickEditRangka.trim() || null,
+        no_mesin: quickEditMesin.trim() || null,
+      });
+      toast.success("Dokumen aset berhasil diperbarui.");
+      setIsQuickEditOpen(false);
+      onRefetch();
+    } catch (err: any) {
+      const errorMsg = err.response?.data?.error || err.message || "Gagal memperbarui dokumen aset.";
+      toast.error(errorMsg);
+    } finally {
+      setIsSavingQuickEdit(false);
+    }
+  };
 
   useEffect(() => {
     if (batch?.assets) {
@@ -445,6 +486,17 @@ export function AssetsLotTab({ batch, readOnly, onRefetch }: AssetsLotTabProps) 
                                   <li key={i}>{warn}</li>
                                 ))}
                               </ul>
+                              {!readOnly && (
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() => handleOpenQuickEdit(asset)}
+                                  className="rounded-xl text-xs h-7 px-3 flex items-center gap-1 bg-amber-50 hover:bg-amber-100 text-amber-850 dark:bg-amber-950/20 dark:text-amber-300 dark:hover:bg-amber-950/40 border-amber-200 mt-2.5"
+                                >
+                                  <Pencil className="h-3 w-3" />
+                                  Lengkapi Dokumen Aset
+                                </Button>
+                              )}
                               <p className="text-[10px] text-zinc-500 italic mt-2">
                                 * Peringatan ini bersifat imbauan dan tidak memblokir proses lelang.
                               </p>
@@ -588,6 +640,84 @@ export function AssetsLotTab({ batch, readOnly, onRefetch }: AssetsLotTabProps) 
                 </>
               ) : (
                 <>Tambah Terpilih ({modalSelectedIds.size})</>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Quick Edit Asset Modal */}
+      <Dialog open={isQuickEditOpen} onOpenChange={setIsQuickEditOpen}>
+        <DialogContent className="max-w-md rounded-2xl">
+          <DialogHeader>
+            <DialogTitle className="text-lg font-bold text-zinc-900 dark:text-zinc-50">
+              Lengkapi Dokumen Aset
+            </DialogTitle>
+            <DialogDescription className="text-xs text-zinc-500">
+              Perbarui dokumen administrasi untuk <strong>{quickEditAsset?.nama_barang}</strong>.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-1.5">
+              <label className="text-xs font-bold text-zinc-500">Nomor BPKB</label>
+              <Input
+                value={quickEditBpkb}
+                onChange={(e) => setQuickEditBpkb(e.target.value)}
+                placeholder="Masukkan Nomor BPKB"
+                className="rounded-xl text-xs border-zinc-200 dark:border-zinc-800 h-9"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-xs font-bold text-zinc-500">Nomor Polisi</label>
+              <Input
+                value={quickEditPolisi}
+                onChange={(e) => setQuickEditPolisi(e.target.value)}
+                placeholder="Masukkan Nomor Polisi (contoh: KT 1234 XX)"
+                className="rounded-xl text-xs border-zinc-200 dark:border-zinc-800 h-9"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-xs font-bold text-zinc-500">Nomor Rangka</label>
+              <Input
+                value={quickEditRangka}
+                onChange={(e) => setQuickEditRangka(e.target.value)}
+                placeholder="Masukkan Nomor Rangka"
+                className="rounded-xl text-xs border-zinc-200 dark:border-zinc-800 h-9"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-xs font-bold text-zinc-500">Nomor Mesin</label>
+              <Input
+                value={quickEditMesin}
+                onChange={(e) => setQuickEditMesin(e.target.value)}
+                placeholder="Masukkan Nomor Mesin"
+                className="rounded-xl text-xs border-zinc-200 dark:border-zinc-800 h-9"
+              />
+            </div>
+          </div>
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              variant="outline"
+              onClick={() => setIsQuickEditOpen(false)}
+              className="rounded-xl text-xs"
+              disabled={isSavingQuickEdit}
+            >
+              Batal
+            </Button>
+            <Button
+              onClick={handleSaveQuickEdit}
+              className="bg-emerald-650 hover:bg-emerald-700 text-white rounded-xl text-xs font-semibold flex items-center gap-1.5"
+              disabled={isSavingQuickEdit}
+            >
+              {isSavingQuickEdit ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Menyimpan...
+                </>
+              ) : (
+                "Simpan Perubahan"
               )}
             </Button>
           </DialogFooter>

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -16,7 +16,7 @@ function Tabs({
       data-slot="tabs"
       data-orientation={orientation}
       className={cn(
-        "group/tabs flex gap-2 data-horizontal:flex-col",
+        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col data-[orientation=vertical]:flex-row",
         className
       )}
       {...props}
@@ -25,7 +25,7 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-8 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
   {
     variants: {
       variant: {
@@ -63,10 +63,10 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
         "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
-        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- fix BMN auction batch user/employee reference columns to match existing schema
- remove stale STNK readiness warning and keep BPKB/document vehicle warnings aligned with current asset fields
- add quick edit modal in batch asset details for BPKB, police number, chassis number, and engine number
- update tabs component selectors to standard data-orientation variants

## Validation
- frontend: npm run lint -- --max-warnings=0
- frontend: npx tsc --noEmit
- frontend: npm run build
- backend: php artisan test (36/36)
- backend: php artisan route:list --path=bmn/auction-batches