### PR TITLE
fix(auth): stop stale session login redirect loop

### DIFF
--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
@@ -17,7 +17,6 @@ import { toast } from "sonner";
 import { api } from "@/lib/api";
 import axios from "axios";
 import { authStore } from "@/lib/auth-store";
-import { useAuth } from "@/hooks/useAuth";
 
 // Schema Validation
 const formSchema = z.object({
@@ -26,39 +25,12 @@ const formSchema = z.object({
 });
 
 export default function LoginPage() {
-  const { isAuthenticated } = useAuth();
   const [loading, setLoading] = useState(false);
-  const [checkingSession, setCheckingSession] = useState(true);
   const [showPassword, setShowPassword] = useState(false);
 
   const redirectToPortal = () => {
     window.location.replace("/portal");
   };
-
-  useEffect(() => {
-    let cancelled = false;
-
-    async function verifyExistingSession() {
-      if (!isAuthenticated) {
-        setCheckingSession(false);
-        return;
-      }
-
-      try {
-        await api.get("/me");
-        if (!cancelled) redirectToPortal();
-      } catch {
-        authStore.logout();
-        if (!cancelled) setCheckingSession(false);
-      }
-    }
-
-    verifyExistingSession();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isAuthenticated]);
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -110,16 +82,6 @@ export default function LoginPage() {
 
   return (
     <div className="bg-zinc-50 dark:bg-zinc-950 font-sans text-zinc-900 dark:text-zinc-100 min-h-screen flex items-center justify-center">
-      {checkingSession ? (
-        <div className="flex min-h-screen w-full items-center justify-center bg-white dark:bg-zinc-950">
-          <div className="flex flex-col items-center gap-4">
-            <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
-            <p className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
-              Memeriksa sesi...
-            </p>
-          </div>
-        </div>
-      ) : (
       <div className="flex min-h-screen w-full overflow-hidden">
         {/* Left Side: Login Form */}
         <div className="w-full lg:w-[45%] flex flex-col items-center justify-center p-8 md:p-16 bg-white dark:bg-zinc-900 relative z-10 shadow-2xl">
@@ -227,7 +189,6 @@ export default function LoginPage() {
           </div>
         </div>
       </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -28,6 +28,7 @@ const formSchema = z.object({
 export default function LoginPage() {
   const { isAuthenticated } = useAuth();
   const [loading, setLoading] = useState(false);
+  const [checkingSession, setCheckingSession] = useState(true);
   const [showPassword, setShowPassword] = useState(false);
 
   const redirectToPortal = () => {
@@ -35,9 +36,28 @@ export default function LoginPage() {
   };
 
   useEffect(() => {
-    if (isAuthenticated) {
-      redirectToPortal();
+    let cancelled = false;
+
+    async function verifyExistingSession() {
+      if (!isAuthenticated) {
+        setCheckingSession(false);
+        return;
+      }
+
+      try {
+        await api.get("/me");
+        if (!cancelled) redirectToPortal();
+      } catch {
+        authStore.logout();
+        if (!cancelled) setCheckingSession(false);
+      }
     }
+
+    verifyExistingSession();
+
+    return () => {
+      cancelled = true;
+    };
   }, [isAuthenticated]);
 
   const form = useForm<z.infer<typeof formSchema>>({
@@ -90,6 +110,16 @@ export default function LoginPage() {
 
   return (
     <div className="bg-zinc-50 dark:bg-zinc-950 font-sans text-zinc-900 dark:text-zinc-100 min-h-screen flex items-center justify-center">
+      {checkingSession ? (
+        <div className="flex min-h-screen w-full items-center justify-center bg-white dark:bg-zinc-950">
+          <div className="flex flex-col items-center gap-4">
+            <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+            <p className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
+              Memeriksa sesi...
+            </p>
+          </div>
+        </div>
+      ) : (
       <div className="flex min-h-screen w-full overflow-hidden">
         {/* Left Side: Login Form */}
         <div className="w-full lg:w-[45%] flex flex-col items-center justify-center p-8 md:p-16 bg-white dark:bg-zinc-900 relative z-10 shadow-2xl">
@@ -197,6 +227,7 @@ export default function LoginPage() {
           </div>
         </div>
       </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/AuthSync.tsx
+++ b/frontend/src/components/AuthSync.tsx
@@ -35,6 +35,7 @@ export function AuthSync() {
   const { isAuthenticated, user } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
+  const isLoginRoute = pathname === "/login" || pathname.startsWith("/login/");
   
   // Menggunakan ref untuk melacak state sebelumnya agar kita tahu kapan terjadi TRANSISI
   const prevAuth = useRef<boolean | null>(null);
@@ -64,19 +65,20 @@ export function AuthSync() {
       }
     }
 
-    // 2. Deteksi LOGIN di tab lain (Transition: false -> true)
+    // 2. Deteksi LOGIN di tab lain (Transition: false -> true).
+    // Jangan redirect dari /login berdasarkan snapshot lokal saja; halaman
+    // login memvalidasi session ke backend agar cookie stale tidak membuat loop.
     if (prevAuth.current === false && isAuthenticated === true) {
-      if (pathname === "/login") {
+      if (!isLoginRoute) {
         toast.success(`Selamat datang kembali, ${user?.name || 'User'}!`, {
           id: "auth-sync-login",
         });
-        router.push("/portal");
       }
     }
 
     // Update ref untuk deteksi transisi berikutnya
     prevAuth.current = isAuthenticated;
-  }, [isAuthenticated, pathname, router, user]);
+  }, [isAuthenticated, isLoginRoute, pathname, router, user]);
 
   return null;
 }

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -25,11 +25,10 @@ export default function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // 2. Proteksi Halaman Login (Redirect jika sudah login)
+  // 2. Halaman login harus tetap bisa dibuka.
+  // Cookie penanda login bisa tertinggal setelah session backend habis, jadi
+  // validasi session dilakukan di client login page sebelum redirect ke portal.
   if (pathname === "/login") {
-    if (loggedIn && userCookie) {
-      return NextResponse.redirect(new URL("/portal", request.url));
-    }
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Summary
- allow /login to render even when stale auth cookies exist
- validate an existing frontend auth snapshot against /me before redirecting to /portal
- clear stale frontend auth state and show the login form when the backend session has expired

## Validation
- frontend: npm run lint -- --max-warnings=0
- frontend: npx tsc --noEmit
- frontend: npm run build