### PR TITLE
feat(bmn): align auction workflow with Srikandi sequence

### DIFF
--- a/backend/app/Modules/Bmn/Controllers/AuctionBatchController.php
+++ b/backend/app/Modules/Bmn/Controllers/AuctionBatchController.php
@@ -12,6 +12,7 @@ use App\Modules\Bmn\Requests\CreateAuctionBatchRequest;
 use App\Modules\Bmn\Requests\AddAuctionAssetsRequest;
 use App\Modules\Bmn\Requests\UpdateAuctionAssetOrderRequest;
 use App\Modules\Bmn\Requests\UpdateAuctionValuationRequest;
+use App\Modules\Bmn\Requests\UpdateAuctionBatchDraftMetadataRequest;
 use App\Modules\Bmn\Requests\TransitionAuctionBatchRequest;
 use App\Modules\Bmn\Requests\FirstAuctionResultsRequest;
 use App\Modules\Bmn\Requests\ReauctionResultsRequest;
@@ -195,6 +196,20 @@ class AuctionBatchController extends Controller
             'message' => 'Nilai taksiran aset berhasil diperbarui.',
             'data' => $pivot,
         ]);
+    }
+
+    /**
+     * Update draft metadata without transitioning status.
+     *
+     * @param string $id
+     * @param UpdateAuctionBatchDraftMetadataRequest $request
+     * @return AuctionBatchResource
+     */
+    public function updateDraftMetadata(string $id, UpdateAuctionBatchDraftMetadataRequest $request): AuctionBatchResource
+    {
+        $batch = $this->service->updateDraftMetadata($id, $request->validated(), Auth::id());
+
+        return new AuctionBatchResource($batch);
     }
 
     /**

--- a/backend/app/Modules/Bmn/Requests/UpdateAuctionBatchDraftMetadataRequest.php
+++ b/backend/app/Modules/Bmn/Requests/UpdateAuctionBatchDraftMetadataRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Modules\Bmn\Requests;
+
+use App\Modules\Bmn\Services\AuctionBatchDocumentWorkflow;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
+
+class UpdateAuctionBatchDraftMetadataRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->hasPermission('bmn.auction.update');
+    }
+
+    public function rules(): array
+    {
+        $workflow = app(AuctionBatchDocumentWorkflow::class);
+        $statuses = implode(',', $workflow->statuses());
+
+        return [
+            'kepala_balai_id' => ['nullable'],
+            'signatories' => ['nullable', 'array'],
+            'signatories.panitia' => ['nullable', 'array'],
+            'signatories.panitia.*' => ['nullable'],
+            'signatories.tim_penilai' => ['nullable', 'array'],
+            'signatories.tim_penilai.*' => ['nullable'],
+            'signatories.pemeriksa' => ['nullable', 'array'],
+            'signatories.pemeriksa.*' => ['nullable'],
+            'document_numbers' => ['nullable', 'array'],
+            'document_numbers.*' => ['nullable', 'string', 'max:255'],
+            'document_dates' => ['nullable', 'array'],
+            'document_dates.*' => ['nullable', 'date'],
+            'workflow' => ['nullable', 'array'],
+            'workflow.documents' => ['nullable', 'array'],
+            'workflow.documents.*' => ['nullable', 'array'],
+            'workflow.documents.*.status' => ['nullable', 'string', "in:{$statuses}"],
+            'workflow.documents.*.channel' => ['nullable', 'string', 'in:srikandi,manual_ttd,external,app'],
+            'workflow.documents.*.completed_at' => ['nullable', 'date'],
+            'workflow.documents.*.number' => ['nullable', 'string', 'max:255'],
+            'workflow.documents.*.date' => ['nullable', 'date'],
+            'workflow.documents.*.notes' => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator) {
+            $documents = $this->input('workflow.documents', []);
+
+            if (!is_array($documents)) {
+                return;
+            }
+
+            $workflow = app(AuctionBatchDocumentWorkflow::class);
+            $invalidKeys = array_values(array_diff(array_keys($documents), $workflow->keys()));
+
+            if (!empty($invalidKeys)) {
+                $validator->errors()->add(
+                    'workflow.documents',
+                    'Dokumen workflow tidak dikenal: ' . implode(', ', $invalidKeys)
+                );
+            }
+        });
+    }
+}

--- a/backend/app/Modules/Bmn/Routes/api.php
+++ b/backend/app/Modules/Bmn/Routes/api.php
@@ -130,6 +130,7 @@ Route::prefix('auction-batches')->group(function () {
     Route::delete('/{id}/assets/{assetId}', [AuctionBatchController::class, 'removeAsset'])->middleware('permission:bmn.auction.update');
     Route::put('/{id}/assets/order', [AuctionBatchController::class, 'updateOrder'])->middleware('permission:bmn.auction.update');
     Route::put('/{id}/assets/{assetId}/valuation', [AuctionBatchController::class, 'updateValuation'])->middleware('permission:bmn.auction.update');
+    Route::patch('/{id}/draft-metadata', [AuctionBatchController::class, 'updateDraftMetadata'])->middleware('permission:bmn.auction.update');
     Route::post('/{id}/transition', [AuctionBatchController::class, 'transition']);
     Route::post('/{id}/first-auction-results', [AuctionBatchController::class, 'recordFirstAuctionResults'])->middleware('permission:bmn.auction.finalize');
     Route::post('/{id}/reauction-results', [AuctionBatchController::class, 'recordReauctionResults'])->middleware('permission:bmn.auction.finalize');

--- a/backend/app/Modules/Bmn/Services/AuctionBatchCompletenessChecker.php
+++ b/backend/app/Modules/Bmn/Services/AuctionBatchCompletenessChecker.php
@@ -2,20 +2,22 @@
 
 namespace App\Modules\Bmn\Services;
 
+use App\Models\User;
+use App\Modules\Bmn\Enums\AuctionBatchStatus;
 use App\Modules\Bmn\Models\AuctionBatch;
-use App\Modules\Kepegawaian\Models\Employee;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
 class AuctionBatchCompletenessChecker
 {
     public function __construct(
-        private AuctionAssetDocumentReadinessService $readinessService,
         private AuctionBatchMetadataBuilder $metadataBuilder,
-        private AuctionAssetSnapshotBuilder $snapshotBuilder
+        private AuctionAssetSnapshotBuilder $snapshotBuilder,
+        private AuctionBatchDocumentWorkflow $documentWorkflow
     ) {}
 
     /**
-     * Check completeness of the batch (Task 17 & Task 69).
+     * Check completeness of the batch.
      *
      * @param AuctionBatch $batch
      * @param array $payload Optional payload for pre-lock check
@@ -23,238 +25,134 @@ class AuctionBatchCompletenessChecker
      */
     public function check(AuctionBatch $batch, array $payload = []): array
     {
+        $batch->loadMissing('assets');
         $assets = $batch->assets;
         $assetsCount = $assets->count();
+        $metadata = $this->mergedMetadata($batch, $payload);
 
-        // 1. assets_present
         $assetsPresent = $assetsCount > 0;
+        $allLotNumbersPresent = $assetsPresent;
+        $allValuationsPositive = $assetsPresent;
 
-        // 2. all_lot_numbers_present
-        $allLotNumbersPresent = $assetsCount > 0;
         foreach ($assets as $asset) {
             if (empty($asset->pivot->lot_number)) {
                 $allLotNumbersPresent = false;
-                break;
             }
-        }
 
-        // 3. all_valuations_positive
-        $allValuationsPositive = $assetsCount > 0;
-        foreach ($assets as $asset) {
             if (is_null($asset->pivot->nilai_taksiran) || $asset->pivot->nilai_taksiran <= 0) {
                 $allValuationsPositive = false;
-                break;
             }
         }
 
-        // Inputs
         $kepalaBalaiId = $payload['kepala_balai_id'] ?? $batch->kepala_balai_id;
         $kepalaBalaiSelected = !empty($kepalaBalaiId);
 
-        $signatoriesInput = $payload['signatories'] ?? [];
-        $panitiaIds = $signatoriesInput['panitia'] ?? $batch->metadata['committees']['panitia_penghapusan'] ?? [];
-        $timPenilaiIds = $signatoriesInput['tim_penilai'] ?? $batch->metadata['committees']['tim_penilai'] ?? [];
-        $pemeriksaIds = $signatoriesInput['pemeriksa'] ?? $batch->metadata['committees']['pemeriksa'] ?? [];
+        $signatoriesInput = $payload['signatories'] ?? $metadata['signatories_raw'] ?? [];
+        $panitiaIds = $signatoriesInput['panitia'] ?? [];
+        $timPenilaiIds = $signatoriesInput['tim_penilai'] ?? [];
+        $pemeriksaIds = $signatoriesInput['pemeriksa'] ?? [];
 
-        // Count elements
-        $panitiaCount = is_array($panitiaIds) ? count($panitiaIds) : 0;
-        $timPenilaiCount = is_array($timPenilaiIds) ? count($timPenilaiIds) : 0;
-        $pemeriksaCount = is_array($pemeriksaIds) ? count($pemeriksaIds) : 0;
-
-        $panitiaPresent = $panitiaCount > 0;
-        $timPenilaiPresent = $timPenilaiCount > 0;
-        $pemeriksaPresent = $pemeriksaCount > 0;
-
-        $documentNumbers = $payload['document_numbers'] ?? $batch->metadata['document_numbers'] ?? [];
-        $documentDates = $payload['document_dates'] ?? $batch->metadata['document_dates'] ?? [];
-
-        $documentNumbersPresent = !empty($documentNumbers);
-        $documentDatesPresent = !empty($documentDates);
-
-        // Duplicate assets check
-        $assetIds = $assets->pluck('id')->toArray();
-        $duplicates = 0;
-        if (!empty($assetIds)) {
-            $duplicates = \DB::table('bmn_asset_auction_batch')
-                ->join('bmn_auction_batches', 'bmn_asset_auction_batch.bmn_auction_batch_id', '=', 'bmn_auction_batches.id')
-                ->whereIn('bmn_asset_auction_batch.bmn_asset_id', $assetIds)
-                ->where('bmn_auction_batches.id', '!=', $batch->id)
-                ->whereIn('bmn_auction_batches.status', ['DRAFT', 'DIAJUKAN', 'JADWAL_DITETAPKAN', 'LELANG_ULANG'])
-                ->whereNull('bmn_auction_batches.deleted_at')
-                ->count();
+        if (empty($panitiaIds) && !empty($metadata['committees']['panitia_penghapusan'])) {
+            $panitiaIds = $metadata['committees']['panitia_penghapusan'];
         }
-        $noActiveDuplicateAssets = $duplicates === 0;
-
-        $documentReadinessReviewed = true; // Always reviewed since we compute it dynamically
-
-        // JSON contract validation
-        $metadataContractValid = false;
-        $assetSnapshotContractValid = false;
-        $freezeSnapshotContractValid = false;
-
-        // Verify if already locked in DB
-        $isLocked = ($batch->status !== \App\Modules\Bmn\Enums\AuctionBatchStatus::DRAFT);
-
-        if ($isLocked) {
-            $metadata = $batch->metadata;
-            $metadataContractValid = (($metadata['schema_version'] ?? null) === 1);
-
-            $assetSnapshotContractValid = ($assetsCount > 0);
-            $freezeSnapshotContractValid = ($assetsCount > 0);
-
-            foreach ($assets as $asset) {
-                if (($asset->pivot->asset_snapshot['schema_version'] ?? null) !== 1) {
-                    $assetSnapshotContractValid = false;
-                }
-                if (($asset->pivot->freeze_snapshot['schema_version'] ?? null) !== 1) {
-                    $freezeSnapshotContractValid = false;
-                }
-            }
-        } elseif (!empty($payload)) {
-            // Build in-memory to validate JSON contracts before locking (Task 69)
-            try {
-                $actor = Auth::user() ?? User::first() ?? new \App\Models\User(['id' => '00000000-0000-0000-0000-000000000000']);
-                $tempMetadata = $this->metadataBuilder->buildForLock($batch, $actor, $payload);
-                $metadataContractValid = (($tempMetadata['schema_version'] ?? null) === 1) && !empty($tempMetadata['signatories']['kepala_balai']);
-
-                $assetSnapshotContractValid = ($assetsCount > 0);
-                $freezeSnapshotContractValid = ($assetsCount > 0);
-
-                foreach ($assets as $asset) {
-                    $tempAssetSnap = $this->snapshotBuilder->buildAssetSnapshot($asset);
-                    $tempFreezeSnap = $this->snapshotBuilder->buildFreezeSnapshot($asset);
-
-                    if (($tempAssetSnap['schema_version'] ?? null) !== 1 || empty($tempAssetSnap['document_readiness'])) {
-                        $assetSnapshotContractValid = false;
-                    }
-                    if (($tempFreezeSnap['schema_version'] ?? null) !== 1 || !array_key_exists('previous_status_penggunaan', $tempFreezeSnap)) {
-                        $freezeSnapshotContractValid = false;
-                    }
-                }
-            } catch (\Exception $e) {
-                // If anything fails in building, contracts are invalid
-                $metadataContractValid = false;
-                $assetSnapshotContractValid = false;
-                $freezeSnapshotContractValid = false;
-            }
+        if (empty($timPenilaiIds) && !empty($metadata['committees']['tim_penilai'])) {
+            $timPenilaiIds = $metadata['committees']['tim_penilai'];
+        }
+        if (empty($pemeriksaIds) && !empty($metadata['committees']['pemeriksa'])) {
+            $pemeriksaIds = $metadata['committees']['pemeriksa'];
         }
 
-        $items = [
-            [
-                'key' => 'assets_present',
-                'label' => 'Minimal 1 aset dipilih',
-                'passed' => $assetsPresent,
-                'message' => $assetsPresent ? null : 'Batch tidak memiliki aset.',
-                'required' => true,
-            ],
-            [
-                'key' => 'all_lot_numbers_present',
-                'label' => 'Semua Lot Aset Terisi',
-                'passed' => $allLotNumbersPresent,
-                'message' => $allLotNumbersPresent ? null : 'Ada aset yang belum memiliki nomor lot.',
-                'required' => true,
-            ],
-            [
-                'key' => 'all_valuations_positive',
-                'label' => 'Semua Nilai Taksiran Aset Valid (> 0)',
-                'passed' => $allValuationsPositive,
-                'message' => $allValuationsPositive ? null : 'Ada aset yang belum memiliki nilai taksiran valid.',
-                'required' => true,
-            ],
-            [
-                'key' => 'kepala_balai_selected',
-                'label' => 'Kepala Balai Terpilih',
-                'passed' => $kepalaBalaiSelected,
-                'message' => $kepalaBalaiSelected ? null : 'Kepala Balai penandatangan belum dipilih.',
-                'required' => true,
-            ],
-            [
-                'key' => 'panitia_present',
-                'label' => 'Anggota Panitia Penghapusan Terisi',
-                'passed' => $panitiaPresent,
-                'message' => $panitiaPresent ? null : 'Minimal harus ada 1 anggota Panitia Penghapusan.',
-                'required' => true,
-            ],
-            [
-                'key' => 'tim_penilai_present',
-                'label' => 'Anggota Tim Penilai Terisi',
-                'passed' => $timPenilaiPresent,
-                'message' => $timPenilaiPresent ? null : 'Minimal harus ada 1 anggota Tim Penilai.',
-                'required' => true,
-            ],
-            [
-                'key' => 'pemeriksa_present',
-                'label' => 'Anggota Panitia Pemeriksa Terisi',
-                'passed' => $pemeriksaPresent,
-                'message' => $pemeriksaPresent ? null : 'Minimal harus ada 1 anggota Panitia Pemeriksa.',
-                'required' => true,
-            ],
-            [
-                'key' => 'document_numbers_present',
-                'label' => 'Nomor Dokumen Terisi',
-                'passed' => $documentNumbersPresent,
-                'message' => $documentNumbersPresent ? null : 'Nomor dokumen pendukung belum lengkap.',
-                'required' => true,
-            ],
-            [
-                'key' => 'document_dates_present',
-                'label' => 'Tanggal Dokumen Terisi',
-                'passed' => $documentDatesPresent,
-                'message' => $documentDatesPresent ? null : 'Tanggal dokumen pendukung belum lengkap.',
-                'required' => true,
-            ],
-            [
-                'key' => 'no_active_duplicate_assets',
-                'label' => 'Aset Tidak Sedang Aktif di Batch Lain',
-                'passed' => $noActiveDuplicateAssets,
-                'message' => $noActiveDuplicateAssets ? null : 'Terdapat aset yang sudah terdaftar pada Paket Lelang aktif lainnya.',
-                'required' => true,
-            ],
-            [
-                'key' => 'document_readiness_reviewed',
-                'label' => 'Kelengkapan Dokumen Aset Di-review',
-                'passed' => $documentReadinessReviewed,
-                'message' => null,
-                'required' => false, // Advisory warning only
-            ],
-            [
-                'key' => 'metadata_contract_valid',
-                'label' => 'Kontrak Metadata Valid',
-                'passed' => $metadataContractValid,
-                'message' => $metadataContractValid ? null : 'Kontrak dokumen metadata lelang tidak valid.',
-                'required' => true,
-            ],
-            [
-                'key' => 'asset_snapshot_contract_valid',
-                'label' => 'Kontrak Snapshot Aset Valid',
-                'passed' => $assetSnapshotContractValid,
-                'message' => $assetSnapshotContractValid ? null : 'Kontrak snapshot aset lelang tidak valid.',
-                'required' => true,
-            ],
-            [
-                'key' => 'freeze_snapshot_contract_valid',
-                'label' => 'Kontrak Snapshot Pembekuan Aset Valid',
-                'passed' => $freezeSnapshotContractValid,
-                'message' => $freezeSnapshotContractValid ? null : 'Kontrak snapshot pembekuan operasional aset tidak valid.',
-                'required' => true,
-            ],
+        $panitiaPresent = is_array($panitiaIds) && count($panitiaIds) > 0;
+        $timPenilaiPresent = is_array($timPenilaiIds) && count($timPenilaiIds) > 0;
+        $pemeriksaPresent = is_array($pemeriksaIds) && count($pemeriksaIds) > 0;
+
+        $documentNumbers = $payload['document_numbers'] ?? $metadata['document_numbers'] ?? [];
+        $documentDates = $payload['document_dates'] ?? $metadata['document_dates'] ?? [];
+        $documentNumbersPresent = !empty(array_filter($documentNumbers, fn($value) => $value !== null && $value !== ''));
+        $documentDatesPresent = !empty(array_filter($documentDates, fn($value) => $value !== null && $value !== ''));
+
+        $noActiveDuplicateAssets = $this->hasNoActiveDuplicateAssets($batch, $assets->pluck('id')->toArray());
+        $workflowDocuments = $metadata['workflow']['documents'] ?? [];
+
+        $assetsLotItems = [
+            $this->item('assets_present', 'Minimal 1 aset dipilih', $assetsPresent, $assetsPresent ? null : 'Batch tidak memiliki aset.'),
+            $this->item('all_lot_numbers_present', 'Semua Lot Aset Terisi', $allLotNumbersPresent, $allLotNumbersPresent ? null : 'Ada aset yang belum memiliki nomor lot.'),
+            $this->item('no_active_duplicate_assets', 'Aset Tidak Sedang Aktif di Batch Lain', $noActiveDuplicateAssets, $noActiveDuplicateAssets ? null : 'Terdapat aset yang sudah terdaftar pada Paket Lelang aktif lainnya.'),
+            $this->item('document_readiness_reviewed', 'Kelengkapan Dokumen Aset Di-review', true, null, false),
         ];
 
-        $complete = true;
-        foreach ($items as $item) {
-            if ($item['required'] && !$item['passed']) {
-                $complete = false;
-            }
-        }
+        $signatoryItems = [
+            $this->item('kepala_balai_selected', 'Kepala Balai Terpilih', $kepalaBalaiSelected, $kepalaBalaiSelected ? null : 'Kepala Balai penandatangan belum dipilih.'),
+            $this->item('panitia_present', 'Anggota Panitia Penghapusan Terisi', $panitiaPresent, $panitiaPresent ? null : 'Minimal harus ada 1 anggota Panitia Penghapusan.'),
+            $this->item('tim_penilai_present', 'Anggota Tim Penilai Terisi', $timPenilaiPresent, $timPenilaiPresent ? null : 'Minimal harus ada 1 anggota Tim Penilai/Penaksir.'),
+            $this->item('pemeriksa_present', 'Anggota Panitia Pemeriksa Terisi', $pemeriksaPresent, $pemeriksaPresent ? null : 'Minimal harus ada 1 anggota Panitia Pemeriksa.'),
+            $this->item('document_numbers_present', 'Nomor Dokumen Terisi', $documentNumbersPresent, $documentNumbersPresent ? null : 'Nomor dokumen pendukung belum lengkap.'),
+            $this->item('document_dates_present', 'Tanggal Dokumen Terisi', $documentDatesPresent, $documentDatesPresent ? null : 'Tanggal dokumen pendukung belum lengkap.'),
+        ];
+
+        $preValuationDocumentItems = $this->documentItems(
+            'pre_valuation_document',
+            $workflowDocuments,
+            fn(array $definition) => $definition['required_for_valuation'],
+            'Dokumen awal belum ditandai selesai.'
+        );
+
+        $valuationItems = [
+            $this->item('all_valuations_positive', 'Semua Nilai Taksiran Aset Valid (> 0)', $allValuationsPositive, $allValuationsPositive ? null : 'Ada aset yang belum memiliki nilai taksiran valid.'),
+        ];
+
+        $postValuationDocumentItems = $this->documentItems(
+            'post_valuation_document',
+            $workflowDocuments,
+            fn(array $definition) => $definition['requires_valuation'] && $definition['required_for_submit'],
+            'Dokumen setelah taksiran belum ditandai selesai.'
+        );
+
+        [$metadataContractValid, $assetSnapshotContractValid, $freezeSnapshotContractValid] = $this->contractChecks($batch, $payload, $assetsCount);
+        $contractItems = [
+            $this->item('metadata_contract_valid', 'Kontrak Metadata Valid', $metadataContractValid, $metadataContractValid ? null : 'Kontrak dokumen metadata lelang tidak valid.'),
+            $this->item('asset_snapshot_contract_valid', 'Kontrak Snapshot Aset Valid', $assetSnapshotContractValid, $assetSnapshotContractValid ? null : 'Kontrak snapshot aset lelang tidak valid.'),
+            $this->item('freeze_snapshot_contract_valid', 'Kontrak Snapshot Pembekuan Aset Valid', $freezeSnapshotContractValid, $freezeSnapshotContractValid ? null : 'Kontrak snapshot pembekuan operasional aset tidak valid.'),
+        ];
+
+        $sections = [
+            $this->section('assets_lot', 'Aset & Lot', $assetsLotItems),
+            $this->section('pre_valuation_documents', 'Dokumen Awal', array_merge($signatoryItems, $preValuationDocumentItems)),
+            $this->section('valuation', 'Nilai Taksiran', $valuationItems),
+            $this->section('post_valuation_documents', 'Setelah Taksiran', $postValuationDocumentItems),
+            $this->section('final_submission', 'Kunci & Ajukan', []),
+            $this->section('contracts', 'Kontrak Sistem', $contractItems),
+        ];
+
+        $canEnterValuation = $sections[0]['complete'] && $sections[1]['complete'];
+        $canCompletePostValuationDocuments = $sections[2]['complete'];
+
+        $sections[4]['items'] = [
+            $this->item('pre_valuation_gate_complete', 'Dokumen awal selesai', $canEnterValuation, $canEnterValuation ? null : 'Selesaikan dokumen awal sebelum masuk pengajuan akhir.'),
+            $this->item('post_valuation_gate_complete', 'Dokumen setelah taksiran selesai', $sections[3]['complete'], $sections[3]['complete'] ? null : 'Nota dinas/permohonan setelah taksiran belum lengkap.'),
+        ];
+        $sections[4] = $this->section($sections[4]['key'], $sections[4]['label'], $sections[4]['items']);
+
+        $canLockSubmit = $sections[0]['complete']
+            && $sections[1]['complete']
+            && $sections[2]['complete']
+            && $sections[3]['complete']
+            && $sections[5]['complete'];
+
+        $items = array_merge(...array_map(fn(array $section) => $section['items'], $sections));
 
         return [
-            'complete' => $complete,
+            'complete' => $canLockSubmit,
             'items' => $items,
+            'sections' => $sections,
+            'can_enter_valuation' => $canEnterValuation,
+            'can_complete_post_valuation_documents' => $canCompletePostValuationDocuments,
+            'can_lock_submit' => $canLockSubmit,
         ];
     }
 
     /**
-     * Pre-lock check using the input payload (Task 17).
+     * Pre-lock check using the input payload.
      *
      * @param AuctionBatch $batch
      * @param array $payload
@@ -263,5 +161,199 @@ class AuctionBatchCompletenessChecker
     public function checkForLock(AuctionBatch $batch, array $payload): array
     {
         return $this->check($batch, $payload);
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     * @param callable(array<string, mixed>): bool $filter
+     * @return list<array<string, mixed>>
+     */
+    private function documentItems(string $prefix, array $metadata, callable $filter, string $missingMessage): array
+    {
+        $items = [];
+
+        foreach ($this->documentWorkflow->definitions() as $definition) {
+            if (!$filter($definition)) {
+                continue;
+            }
+
+            $key = $definition['key'];
+            $complete = $this->documentComplete($metadata[$key] ?? null);
+            $items[] = $this->item(
+                "{$prefix}_{$key}",
+                $definition['title'],
+                $complete,
+                $complete ? null : $missingMessage
+            );
+        }
+
+        return $items;
+    }
+
+    private function documentComplete(mixed $document): bool
+    {
+        if (!is_array($document)) {
+            return false;
+        }
+
+        return in_array($document['status'] ?? null, [
+            AuctionBatchDocumentWorkflow::STATUS_SIGNED,
+            AuctionBatchDocumentWorkflow::STATUS_COMPLETED,
+        ], true);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $items
+     * @return array<string, mixed>
+     */
+    private function section(string $key, string $label, array $items): array
+    {
+        $complete = true;
+        foreach ($items as $item) {
+            if (($item['required'] ?? true) && !$item['passed']) {
+                $complete = false;
+                break;
+            }
+        }
+
+        return [
+            'key' => $key,
+            'label' => $label,
+            'complete' => $complete,
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function item(string $key, string $label, bool $passed, ?string $message = null, bool $required = true): array
+    {
+        return [
+            'key' => $key,
+            'label' => $label,
+            'passed' => $passed,
+            'message' => $message,
+            'required' => $required,
+        ];
+    }
+
+    /**
+     * @param list<string> $assetIds
+     */
+    private function hasNoActiveDuplicateAssets(AuctionBatch $batch, array $assetIds): bool
+    {
+        if (empty($assetIds)) {
+            return true;
+        }
+
+        $duplicates = DB::table('bmn_asset_auction_batch')
+            ->join('bmn_auction_batches', 'bmn_asset_auction_batch.bmn_auction_batch_id', '=', 'bmn_auction_batches.id')
+            ->whereIn('bmn_asset_auction_batch.bmn_asset_id', $assetIds)
+            ->where('bmn_auction_batches.id', '!=', $batch->id)
+            ->whereIn('bmn_auction_batches.status', ['DRAFT', 'DIAJUKAN', 'JADWAL_DITETAPKAN', 'LELANG_ULANG'])
+            ->whereNull('bmn_auction_batches.deleted_at')
+            ->count();
+
+        return $duplicates === 0;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function mergedMetadata(AuctionBatch $batch, array $payload): array
+    {
+        $metadata = is_array($batch->metadata) ? $batch->metadata : [];
+
+        if (array_key_exists('signatories', $payload)) {
+            $metadata['signatories_raw'] = array_replace($metadata['signatories_raw'] ?? [], $payload['signatories'] ?? []);
+        }
+        if (array_key_exists('document_numbers', $payload)) {
+            $metadata['document_numbers'] = array_replace($metadata['document_numbers'] ?? [], $payload['document_numbers'] ?? []);
+        }
+        if (array_key_exists('document_dates', $payload)) {
+            $metadata['document_dates'] = array_replace($metadata['document_dates'] ?? [], $payload['document_dates'] ?? []);
+        }
+        if (array_key_exists('workflow', $payload)) {
+            $metadata['workflow'] = array_replace_recursive($metadata['workflow'] ?? [], $payload['workflow'] ?? []);
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * @return array{0: bool, 1: bool, 2: bool}
+     */
+    private function contractChecks(AuctionBatch $batch, array $payload, int $assetsCount): array
+    {
+        $metadataContractValid = false;
+        $assetSnapshotContractValid = false;
+        $freezeSnapshotContractValid = false;
+        $isLocked = $batch->status !== AuctionBatchStatus::DRAFT;
+
+        if ($isLocked) {
+            $metadata = $batch->metadata;
+            $metadataContractValid = in_array(($metadata['schema_version'] ?? null), [1, 2], true);
+            $assetSnapshotContractValid = $assetsCount > 0;
+            $freezeSnapshotContractValid = $assetsCount > 0;
+
+            foreach ($batch->assets as $asset) {
+                if (($asset->pivot->asset_snapshot['schema_version'] ?? null) !== 1) {
+                    $assetSnapshotContractValid = false;
+                }
+                if (($asset->pivot->freeze_snapshot['schema_version'] ?? null) !== 1) {
+                    $freezeSnapshotContractValid = false;
+                }
+            }
+
+            return [$metadataContractValid, $assetSnapshotContractValid, $freezeSnapshotContractValid];
+        }
+
+        try {
+            $actor = Auth::user() ?? User::first() ?? new User(['id' => '00000000-0000-0000-0000-000000000000']);
+            $tempPayload = $this->lockPayloadFromDraft($batch, $payload);
+            $tempMetadata = $this->metadataBuilder->buildForLock($batch, $actor, $tempPayload);
+
+            $metadataContractValid = (($tempMetadata['schema_version'] ?? null) === 2)
+                && !empty($tempMetadata['signatories']['kepala_balai'])
+                && !empty($tempMetadata['workflow']);
+
+            $assetSnapshotContractValid = $assetsCount > 0;
+            $freezeSnapshotContractValid = $assetsCount > 0;
+
+            foreach ($batch->assets as $asset) {
+                $tempAssetSnap = $this->snapshotBuilder->buildAssetSnapshot($asset);
+                $tempFreezeSnap = $this->snapshotBuilder->buildFreezeSnapshot($asset);
+
+                if (($tempAssetSnap['schema_version'] ?? null) !== 1 || empty($tempAssetSnap['document_readiness'])) {
+                    $assetSnapshotContractValid = false;
+                }
+                if (($tempFreezeSnap['schema_version'] ?? null) !== 1 || !array_key_exists('previous_status_penggunaan', $tempFreezeSnap)) {
+                    $freezeSnapshotContractValid = false;
+                }
+            }
+        } catch (\Throwable) {
+            $metadataContractValid = false;
+            $assetSnapshotContractValid = false;
+            $freezeSnapshotContractValid = false;
+        }
+
+        return [$metadataContractValid, $assetSnapshotContractValid, $freezeSnapshotContractValid];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function lockPayloadFromDraft(AuctionBatch $batch, array $payload): array
+    {
+        $metadata = is_array($batch->metadata) ? $batch->metadata : [];
+
+        return [
+            'kepala_balai_id' => $payload['kepala_balai_id'] ?? $batch->kepala_balai_id,
+            'signatories' => array_replace($metadata['signatories_raw'] ?? [], $payload['signatories'] ?? []),
+            'document_numbers' => array_replace($metadata['document_numbers'] ?? [], $payload['document_numbers'] ?? []),
+            'document_dates' => array_replace($metadata['document_dates'] ?? [], $payload['document_dates'] ?? []),
+            'workflow' => array_replace_recursive($metadata['workflow'] ?? [], $payload['workflow'] ?? []),
+        ];
     }
 }

--- a/backend/app/Modules/Bmn/Services/AuctionBatchDocumentWorkflow.php
+++ b/backend/app/Modules/Bmn/Services/AuctionBatchDocumentWorkflow.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace App\Modules\Bmn\Services;
+
+class AuctionBatchDocumentWorkflow
+{
+    public const STATUS_NOT_STARTED = 'not_started';
+    public const STATUS_PREPARED = 'prepared';
+    public const STATUS_PRINTED = 'printed';
+    public const STATUS_SIGNED = 'signed';
+    public const STATUS_COMPLETED = 'completed';
+    public const STATUS_SKIPPED = 'skipped';
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function definitions(): array
+    {
+        return [
+            [
+                'key' => 'sk_penghentian',
+                'title' => 'Penghentian Penggunaan BMN',
+                'channel' => 'srikandi',
+                'phase' => 'pre_valuation',
+                'order' => 10,
+                'requires_valuation' => false,
+                'number_key' => 'sk_penghentian',
+                'date_key' => 'sk_penghentian',
+                'required_for_valuation' => true,
+                'required_for_submit' => true,
+            ],
+            [
+                'key' => 'ba_koreksi',
+                'title' => 'Koreksi Perubahan Kondisi BMN',
+                'channel' => 'srikandi',
+                'phase' => 'pre_valuation',
+                'order' => 20,
+                'requires_valuation' => false,
+                'number_key' => 'ba_koreksi',
+                'date_key' => 'ba_koreksi',
+                'required_for_valuation' => true,
+                'required_for_submit' => true,
+            ],
+            [
+                'key' => 'sk_panitia_penghapusan',
+                'title' => 'Panitia Penghapusan Barang Milik Negara Berupa Alat Angkutan Bermotor Pada Balai Konservasi Sumber Daya Alam Kalimantan Timur',
+                'channel' => 'srikandi',
+                'phase' => 'pre_valuation',
+                'order' => 30,
+                'requires_valuation' => false,
+                'number_key' => 'sk_panitia',
+                'date_key' => 'sk_panitia',
+                'required_for_valuation' => true,
+                'required_for_submit' => true,
+                'legacy_key' => 'sk_panitia',
+            ],
+            [
+                'key' => 'sk_kebenaran',
+                'title' => 'Surat Pernyataan Kebenaran Data BMN',
+                'channel' => 'manual_ttd',
+                'phase' => 'pre_valuation',
+                'order' => 40,
+                'requires_valuation' => false,
+                'number_key' => 'sk_kebenaran',
+                'date_key' => 'sk_kebenaran',
+                'required_for_valuation' => true,
+                'required_for_submit' => true,
+            ],
+            [
+                'key' => 'sptjm',
+                'title' => 'Surat Pernyataan Tanggung Jawab Mutlak',
+                'channel' => 'manual_ttd',
+                'phase' => 'pre_valuation',
+                'order' => 50,
+                'requires_valuation' => false,
+                'number_key' => 'sptjm',
+                'date_key' => 'sptjm',
+                'required_for_valuation' => true,
+                'required_for_submit' => true,
+            ],
+            [
+                'key' => 'sp_kelancaran_tugas',
+                'title' => 'Surat Pernyataan Kelancaran Tugas Dinas',
+                'channel' => 'manual_ttd',
+                'phase' => 'pre_valuation',
+                'order' => 60,
+                'requires_valuation' => false,
+                'number_key' => 'sp_tugas',
+                'date_key' => 'sp_tugas',
+                'required_for_valuation' => true,
+                'required_for_submit' => true,
+                'legacy_key' => 'sp_tugas',
+            ],
+            [
+                'key' => 'ba_pemeriksaan',
+                'title' => 'Berita Acara Pemeriksaan BMN',
+                'channel' => 'manual_ttd',
+                'phase' => 'pre_valuation',
+                'order' => 70,
+                'requires_valuation' => false,
+                'number_key' => 'ba_pemeriksaan',
+                'date_key' => 'ba_pemeriksaan',
+                'required_for_valuation' => true,
+                'required_for_submit' => true,
+            ],
+            [
+                'key' => 'surat_tugas_pemeriksaan_penilaian',
+                'title' => 'Surat Tugas Pemeriksaan dan Penilaian BMN',
+                'channel' => 'srikandi',
+                'phase' => 'pre_valuation',
+                'order' => 80,
+                'requires_valuation' => false,
+                'number_key' => 'surat_tugas_pemeriksaan_penilaian',
+                'date_key' => 'surat_tugas_pemeriksaan_penilaian',
+                'required_for_valuation' => true,
+                'required_for_submit' => true,
+            ],
+            [
+                'key' => 'sk_panitia_penaksir_harga',
+                'title' => 'Pembentukan Panitia Penaksir Harga Barang Milik Negara Pada Balai Konservasi Sumber Daya Alam Kalimantan Timur',
+                'channel' => 'srikandi',
+                'phase' => 'pre_valuation',
+                'order' => 90,
+                'requires_valuation' => false,
+                'number_key' => 'sk_tim_penilai',
+                'date_key' => 'sk_tim_penilai',
+                'required_for_valuation' => true,
+                'required_for_submit' => true,
+                'legacy_key' => 'sk_tim_penilai',
+            ],
+            [
+                'key' => 'nilai_taksiran',
+                'title' => 'Nilai Taksiran BMN',
+                'channel' => 'app',
+                'phase' => 'valuation',
+                'order' => 100,
+                'requires_valuation' => false,
+                'number_key' => null,
+                'date_key' => null,
+                'required_for_valuation' => false,
+                'required_for_submit' => true,
+            ],
+            [
+                'key' => 'sptj_limit',
+                'title' => 'Surat Pernyataan Tanggung Jawab Nilai Limit',
+                'channel' => 'manual_ttd',
+                'phase' => 'post_valuation',
+                'order' => 110,
+                'requires_valuation' => true,
+                'number_key' => 'sptj_limit',
+                'date_key' => 'sptj_limit',
+                'required_for_valuation' => false,
+                'required_for_submit' => true,
+            ],
+            [
+                'key' => 'nota_dinas_ksdae',
+                'title' => 'Nota Dinas KSDAE Setelah Penaksiran',
+                'channel' => 'srikandi',
+                'phase' => 'post_valuation',
+                'order' => 120,
+                'requires_valuation' => true,
+                'number_key' => 'nota_dinas',
+                'date_key' => 'nota_dinas',
+                'required_for_valuation' => false,
+                'required_for_submit' => true,
+                'legacy_key' => 'nota_dinas',
+            ],
+            [
+                'key' => 'permohonan_kpknl',
+                'title' => 'Permohonan Penjualan BMN ke KPKNL',
+                'channel' => 'external',
+                'phase' => 'post_valuation',
+                'order' => 130,
+                'requires_valuation' => true,
+                'number_key' => 'permohonan_kpknl',
+                'date_key' => 'permohonan_kpknl',
+                'required_for_valuation' => false,
+                'required_for_submit' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function keys(): array
+    {
+        return array_map(fn(array $definition) => $definition['key'], $this->definitions());
+    }
+
+    public function has(string $key): bool
+    {
+        return $this->get($key) !== null;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function get(string $key): ?array
+    {
+        foreach ($this->definitions() as $definition) {
+            if ($definition['key'] === $key) {
+                return $definition;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function statuses(): array
+    {
+        return [
+            self::STATUS_NOT_STARTED,
+            self::STATUS_PREPARED,
+            self::STATUS_PRINTED,
+            self::STATUS_SIGNED,
+            self::STATUS_COMPLETED,
+            self::STATUS_SKIPPED,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function requiredForValuationKeys(): array
+    {
+        return array_values(array_map(
+            fn(array $definition) => $definition['key'],
+            array_filter($this->definitions(), fn(array $definition) => $definition['required_for_valuation'])
+        ));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function requiredForSubmitKeys(): array
+    {
+        return array_values(array_map(
+            fn(array $definition) => $definition['key'],
+            array_filter($this->definitions(), fn(array $definition) => $definition['required_for_submit'])
+        ));
+    }
+
+    /**
+     * @param array<string, mixed> $documents
+     * @return array<string, mixed>
+     */
+    public function sortDocumentProgress(array $documents): array
+    {
+        $ordered = [];
+
+        foreach ($this->definitions() as $definition) {
+            $key = $definition['key'];
+            if (array_key_exists($key, $documents)) {
+                $ordered[$key] = $documents[$key];
+            }
+        }
+
+        foreach ($documents as $key => $document) {
+            if (!array_key_exists($key, $ordered)) {
+                $ordered[$key] = $document;
+            }
+        }
+
+        return $ordered;
+    }
+}

--- a/backend/app/Modules/Bmn/Services/AuctionBatchMetadataBuilder.php
+++ b/backend/app/Modules/Bmn/Services/AuctionBatchMetadataBuilder.php
@@ -8,6 +8,10 @@ use App\Models\User;
 
 class AuctionBatchMetadataBuilder
 {
+    public function __construct(
+        private AuctionBatchDocumentWorkflow $documentWorkflow
+    ) {}
+
     /**
      * Build frozen metadata for an auction batch before locking it.
      *
@@ -18,10 +22,15 @@ class AuctionBatchMetadataBuilder
      */
     public function buildForLock(AuctionBatch $batch, User $actor, array $input): array
     {
+        $existingMetadata = is_array($batch->metadata) ? $batch->metadata : [];
+
         $kepalaBalaiId = $input['kepala_balai_id'] ?? $batch->kepala_balai_id;
         $kepalaBalai = $kepalaBalaiId ? Employee::find($kepalaBalaiId) : null;
 
-        $signatoriesInput = $input['signatories'] ?? [];
+        $signatoriesInput = array_replace(
+            $existingMetadata['signatories_raw'] ?? [],
+            $input['signatories'] ?? []
+        );
         $panitiaIds = $signatoriesInput['panitia'] ?? $input['committees']['panitia_penghapusan'] ?? [];
         $timPenilaiIds = $signatoriesInput['tim_penilai'] ?? $input['committees']['tim_penilai'] ?? [];
         $pemeriksaIds = $signatoriesInput['pemeriksa'] ?? $input['committees']['pemeriksa'] ?? [];
@@ -50,10 +59,31 @@ class AuctionBatchMetadataBuilder
             ->values()
             ->toArray();
 
+        $documentNumbers = array_replace(
+            $existingMetadata['document_numbers'] ?? [],
+            $input['document_numbers'] ?? []
+        );
+        $documentDates = array_replace(
+            $existingMetadata['document_dates'] ?? [],
+            $input['document_dates'] ?? []
+        );
+        $workflow = $input['workflow'] ?? $existingMetadata['workflow'] ?? [];
+        $workflowDocuments = isset($workflow['documents']) && is_array($workflow['documents'])
+            ? $this->documentWorkflow->sortDocumentProgress($workflow['documents'])
+            : [];
+
         return [
-            'schema_version' => 1,
+            'schema_version' => 2,
             'locked_at' => now()->toIso8601String(),
             'locked_by' => $actor->id,
+            'workflow' => [
+                'version' => $workflow['version'] ?? 1,
+                'documents' => $workflowDocuments,
+                'pre_valuation_complete' => $this->documentsComplete($workflowDocuments, $this->documentWorkflow->requiredForValuationKeys()),
+                'valuation_complete' => $this->allAssetsHaveValuation($batch),
+                'post_valuation_complete' => $this->documentsComplete($workflowDocuments, $this->postValuationRequiredKeys()),
+            ],
+            'signatories_raw' => $signatoriesInput,
             'signatories' => [
                 'kepala_balai' => $this->mapEmployee($kepalaBalai),
             ],
@@ -62,8 +92,8 @@ class AuctionBatchMetadataBuilder
                 'tim_penilai' => $timPenilaiMapped,
                 'pemeriksa' => $pemeriksaMapped,
             ],
-            'document_numbers' => $input['document_numbers'] ?? [],
-            'document_dates' => $input['document_dates'] ?? [],
+            'document_numbers' => $documentNumbers,
+            'document_dates' => $documentDates,
             'print_config' => [
                 'paper' => 'A4',
                 'locale' => 'id-ID',
@@ -71,6 +101,53 @@ class AuctionBatchMetadataBuilder
             ],
             'document_versions' => [],
         ];
+    }
+
+    /**
+     * @param array<string, mixed> $documents
+     * @param list<string> $keys
+     */
+    private function documentsComplete(array $documents, array $keys): bool
+    {
+        foreach ($keys as $key) {
+            $status = $documents[$key]['status'] ?? null;
+            if (!in_array($status, [AuctionBatchDocumentWorkflow::STATUS_SIGNED, AuctionBatchDocumentWorkflow::STATUS_COMPLETED], true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function allAssetsHaveValuation(AuctionBatch $batch): bool
+    {
+        $assets = $batch->assets;
+
+        if ($assets->isEmpty()) {
+            return false;
+        }
+
+        foreach ($assets as $asset) {
+            if (is_null($asset->pivot->nilai_taksiran) || $asset->pivot->nilai_taksiran <= 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function postValuationRequiredKeys(): array
+    {
+        return array_values(array_map(
+            fn(array $definition) => $definition['key'],
+            array_filter(
+                $this->documentWorkflow->definitions(),
+                fn(array $definition) => $definition['requires_valuation'] && $definition['required_for_submit']
+            )
+        ));
     }
 
     /**

--- a/backend/app/Modules/Bmn/Services/AuctionBatchService.php
+++ b/backend/app/Modules/Bmn/Services/AuctionBatchService.php
@@ -24,6 +24,7 @@ class AuctionBatchService
         private AuctionAssetSnapshotBuilder $snapshotBuilder,
         private AuctionAssetDocumentReadinessService $readinessService,
         private AuctionBatchValidityService $validityService,
+        private AuctionBatchDocumentWorkflow $documentWorkflow,
         private AssetService $assetService
     ) {}
 
@@ -391,6 +392,130 @@ class AuctionBatchService
 
             return $pivot;
         });
+    }
+
+    /**
+     * Persist draft-only workflow metadata without changing auction status.
+     *
+     * @param string $batchId
+     * @param array $payload
+     * @param string|null $actorId
+     * @return AuctionBatch
+     * @throws ValidationException
+     */
+    public function updateDraftMetadata(string $batchId, array $payload, ?string $actorId = null): AuctionBatch
+    {
+        return DB::transaction(function () use ($batchId, $payload, $actorId) {
+            $actorId = $actorId ?? Auth::id();
+            $batch = AuctionBatch::findOrFail($batchId);
+
+            if (!$batch->isDraft()) {
+                throw ValidationException::withMessages([
+                    'status' => 'Metadata draft hanya dapat diubah pada paket lelang berstatus DRAFT.',
+                ]);
+            }
+
+            $previousMetadata = is_array($batch->metadata) ? $batch->metadata : [];
+            $metadata = $previousMetadata;
+
+            if (array_key_exists('kepala_balai_id', $payload)) {
+                $batch->kepala_balai_id = $payload['kepala_balai_id'] ?: null;
+            }
+
+            if (array_key_exists('signatories', $payload)) {
+                $metadata['signatories_raw'] = array_replace(
+                    $metadata['signatories_raw'] ?? [],
+                    $this->normalizeSignatories($payload['signatories'] ?? [])
+                );
+            }
+
+            if (array_key_exists('document_numbers', $payload)) {
+                $metadata['document_numbers'] = array_replace(
+                    $metadata['document_numbers'] ?? [],
+                    $payload['document_numbers'] ?? []
+                );
+            }
+
+            if (array_key_exists('document_dates', $payload)) {
+                $metadata['document_dates'] = array_replace(
+                    $metadata['document_dates'] ?? [],
+                    $payload['document_dates'] ?? []
+                );
+            }
+
+            if (isset($payload['workflow']['documents']) && is_array($payload['workflow']['documents'])) {
+                $workflow = $metadata['workflow'] ?? [];
+                $workflow['version'] = $workflow['version'] ?? 1;
+                $workflow['updated_at'] = now()->toIso8601String();
+
+                $documents = isset($workflow['documents']) && is_array($workflow['documents'])
+                    ? $workflow['documents']
+                    : [];
+
+                foreach ($payload['workflow']['documents'] as $key => $documentPayload) {
+                    $definition = $this->documentWorkflow->get($key);
+                    if ($definition === null) {
+                        throw ValidationException::withMessages([
+                            'workflow.documents' => "Dokumen workflow tidak dikenal: {$key}",
+                        ]);
+                    }
+
+                    $current = isset($documents[$key]) && is_array($documents[$key]) ? $documents[$key] : [];
+                    $status = $documentPayload['status'] ?? $current['status'] ?? AuctionBatchDocumentWorkflow::STATUS_NOT_STARTED;
+
+                    $documents[$key] = array_replace($current, $documentPayload, [
+                        'key' => $key,
+                        'title' => $definition['title'],
+                        'channel' => $definition['channel'],
+                        'phase' => $definition['phase'],
+                        'order' => $definition['order'],
+                        'status' => $status,
+                        'updated_at' => now()->toIso8601String(),
+                    ]);
+
+                    if ($status === AuctionBatchDocumentWorkflow::STATUS_COMPLETED && empty($documents[$key]['completed_at'])) {
+                        $documents[$key]['completed_at'] = now()->toIso8601String();
+                    }
+                }
+
+                $workflow['documents'] = $this->documentWorkflow->sortDocumentProgress($documents);
+                $metadata['workflow'] = $workflow;
+            }
+
+            $batch->metadata = $metadata;
+            $batch->updated_by = $actorId;
+            $batch->save();
+
+            $this->auditLogger->log(
+                $batchId,
+                AuctionBatchEventAction::DRAFT_METADATA_UPDATED,
+                $actorId,
+                null,
+                ['metadata' => $previousMetadata],
+                ['metadata' => $metadata],
+                'Metadata draft workflow diperbarui.'
+            );
+
+            return $batch->load('assets');
+        });
+    }
+
+    /**
+     * @param array<string, mixed> $signatories
+     * @return array<string, array<int, mixed>>
+     */
+    private function normalizeSignatories(array $signatories): array
+    {
+        $normalized = [];
+
+        foreach (['panitia', 'tim_penilai', 'pemeriksa'] as $key) {
+            if (array_key_exists($key, $signatories)) {
+                $value = $signatories[$key];
+                $normalized[$key] = is_array($value) ? array_values(array_filter($value, fn($id) => $id !== null && $id !== '')) : [];
+            }
+        }
+
+        return $normalized;
     }
 
     /**

--- a/backend/app/Modules/Bmn/Services/AuctionBatchService.php
+++ b/backend/app/Modules/Bmn/Services/AuctionBatchService.php
@@ -353,6 +353,24 @@ class AuctionBatchService
                 ]);
             }
 
+            $updatesValuation = array_key_exists('nilai_taksiran', $data) || array_key_exists('kertas_kerja_data', $data);
+            if ($updatesValuation) {
+                $readiness = $this->completenessChecker->check($batch);
+                if (!($readiness['can_enter_valuation'] ?? false)) {
+                    $missingLabels = collect($readiness['sections'] ?? [])
+                        ->whereIn('key', ['assets_lot', 'pre_valuation_documents'])
+                        ->flatMap(fn($section) => $section['items'] ?? [])
+                        ->filter(fn($item) => ($item['required'] ?? true) && !($item['passed'] ?? false))
+                        ->pluck('label')
+                        ->take(5)
+                        ->implode(', ');
+
+                    throw ValidationException::withMessages([
+                        'workflow' => "Nilai taksiran belum dapat diisi. Lengkapi dulu: {$missingLabels}",
+                    ]);
+                }
+            }
+
             $pivot = AssetAuctionBatch::where('bmn_auction_batch_id', $batchId)
                 ->where('bmn_asset_id', $assetId)
                 ->first();

--- a/backend/app/Modules/Bmn/Support/AuctionBatchEventAction.php
+++ b/backend/app/Modules/Bmn/Support/AuctionBatchEventAction.php
@@ -12,6 +12,7 @@ final class AuctionBatchEventAction
     public const ASSET_REMOVED = 'asset.removed';
     public const ASSET_ORDER_UPDATED = 'asset.order.updated';
     public const ASSET_VALUATION_UPDATED = 'asset.valuation.updated';
+    public const DRAFT_METADATA_UPDATED = 'draft.metadata.updated';
     public const BATCH_LOCKED = 'batch.locked';
     public const ASSET_FREEZE_SNAPSHOT_CREATED = 'asset.freeze_snapshot.created';
     public const SCHEDULE_RECORDED = 'schedule.recorded';
@@ -37,6 +38,7 @@ final class AuctionBatchEventAction
             self::ASSET_REMOVED,
             self::ASSET_ORDER_UPDATED,
             self::ASSET_VALUATION_UPDATED,
+            self::DRAFT_METADATA_UPDATED,
             self::BATCH_LOCKED,
             self::ASSET_FREEZE_SNAPSHOT_CREATED,
             self::SCHEDULE_RECORDED,

--- a/backend/tests/Feature/Bmn/AuctionBatchTest.php
+++ b/backend/tests/Feature/Bmn/AuctionBatchTest.php
@@ -278,6 +278,35 @@ class AuctionBatchTest extends TestCase
         $response->assertJsonValidationErrors('workflow');
     }
 
+    public function test_checklist_blocks_and_allows_valuation_gate(): void
+    {
+        $batch = AuctionBatch::create([
+            'batch_number' => 'LE-20260622-0001',
+            'name' => 'Batch I',
+            'status' => AuctionBatchStatus::DRAFT,
+        ]);
+
+        $asset = $this->createAsset();
+        $batch->assets()->attach($asset->id, [
+            'id' => \Illuminate\Support\Str::uuid(),
+            'lot_number' => 'LOT-01',
+        ]);
+
+        $blocked = $this->getJson("/api/bmn/auction-batches/{$batch->id}/checklist");
+        $blocked->assertStatus(200);
+        $this->assertFalse($blocked->json('can_enter_valuation'));
+
+        $batch->forceFill([
+            'kepala_balai_id' => $this->kepalaBalai->id,
+            'metadata' => $this->workflowMetadata(false),
+        ])->save();
+
+        $allowed = $this->getJson("/api/bmn/auction-batches/{$batch->id}/checklist");
+        $allowed->assertStatus(200);
+        $this->assertTrue($allowed->json('can_enter_valuation'));
+        $this->assertFalse($allowed->json('can_complete_post_valuation_documents'));
+    }
+
     public function test_cannot_update_lot_after_diajukan(): void
     {
         $batch = AuctionBatch::create([
@@ -844,6 +873,44 @@ class AuctionBatchTest extends TestCase
         $this->assertTrue($metadata['workflow']['post_valuation_complete']);
         $this->assertEquals('M. Ari Wibawanto', $metadata['signatories']['kepala_balai']['nama']);
         $this->assertEquals('Panitia Satu', $metadata['committees']['panitia_penghapusan'][0]['nama']);
+    }
+
+    public function test_schema_version_1_document_context_remains_readable(): void
+    {
+        $batch = AuctionBatch::create([
+            'batch_number' => 'LE-20260622-0001',
+            'name' => 'Batch I',
+            'status' => AuctionBatchStatus::DIAJUKAN,
+            'metadata' => [
+                'schema_version' => 1,
+                'signatories' => [
+                    'kepala_balai' => [
+                        'nama' => 'Kepala Lama',
+                        'nip' => '123',
+                    ],
+                ],
+                'committees' => [],
+                'document_numbers' => [
+                    'surat_tugas' => 'ST/OLD',
+                ],
+                'document_dates' => [
+                    'surat_tugas' => '2026-06-22',
+                ],
+            ],
+        ]);
+
+        $asset = $this->createAsset();
+        $batch->assets()->attach($asset->id, [
+            'id' => \Illuminate\Support\Str::uuid(),
+            'lot_number' => 'LOT-01',
+            'nilai_taksiran' => 5000000,
+        ]);
+
+        $response = $this->getJson("/api/bmn/auction-batches/{$batch->id}/documents/context");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.metadata_schema_version', 1);
+        $response->assertJsonPath('data.metadata.signatories.kepala_balai.nama', 'Kepala Lama');
     }
 
     public function test_document_readiness_service(): void

--- a/backend/tests/Feature/Bmn/AuctionBatchTest.php
+++ b/backend/tests/Feature/Bmn/AuctionBatchTest.php
@@ -106,6 +106,58 @@ class AuctionBatchTest extends TestCase
         ], $overrides));
     }
 
+    private function workflowMetadata(bool $includePostValuation = true): array
+    {
+        $workflow = app(AuctionBatchDocumentWorkflow::class);
+        $documents = [];
+        $documentNumbers = [
+            'surat_tugas' => 'ST/001/BMN',
+        ];
+        $documentDates = [
+            'surat_tugas' => '2026-06-22',
+        ];
+
+        foreach ($workflow->definitions() as $definition) {
+            if ($definition['key'] === 'nilai_taksiran') {
+                continue;
+            }
+            if (!$includePostValuation && $definition['phase'] === 'post_valuation') {
+                continue;
+            }
+
+            $documents[$definition['key']] = [
+                'key' => $definition['key'],
+                'title' => $definition['title'],
+                'channel' => $definition['channel'],
+                'phase' => $definition['phase'],
+                'order' => $definition['order'],
+                'status' => 'completed',
+                'completed_at' => '2026-06-22T00:00:00+08:00',
+            ];
+
+            if (!empty($definition['number_key'])) {
+                $documentNumbers[$definition['number_key']] = 'DOC/' . $definition['order'] . '/BMN';
+            }
+            if (!empty($definition['date_key'])) {
+                $documentDates[$definition['date_key']] = '2026-06-22';
+            }
+        }
+
+        return [
+            'signatories_raw' => [
+                'panitia' => [$this->panitiaMember->id],
+                'tim_penilai' => [$this->timPenilaiMember->id],
+                'pemeriksa' => [$this->pemeriksaMember->id],
+            ],
+            'document_numbers' => $documentNumbers,
+            'document_dates' => $documentDates,
+            'workflow' => [
+                'version' => 1,
+                'documents' => $documents,
+            ],
+        ];
+    }
+
     public function test_can_create_draft_batch(): void
     {
         $response = $this->postJson('/api/bmn/auction-batches', [
@@ -128,6 +180,7 @@ class AuctionBatchTest extends TestCase
             'batch_number' => 'LE-20260622-0001',
             'name' => 'Batch I',
             'status' => AuctionBatchStatus::DRAFT,
+            'metadata' => $this->workflowMetadata(),
         ]);
 
         $asset = $this->createAsset();
@@ -178,13 +231,17 @@ class AuctionBatchTest extends TestCase
             'batch_number' => 'LE-20260622-0001',
             'name' => 'Batch I',
             'status' => AuctionBatchStatus::DRAFT,
+            'kepala_balai_id' => $this->kepalaBalai->id,
+            'metadata' => $this->workflowMetadata(false),
         ]);
 
         $asset = $this->createAsset();
-        $batch->assets()->attach($asset->id, ['id' => \Illuminate\Support\Str::uuid()]);
+        $batch->assets()->attach($asset->id, [
+            'id' => \Illuminate\Support\Str::uuid(),
+            'lot_number' => 'LOT-01',
+        ]);
 
         $response = $this->putJson("/api/bmn/auction-batches/{$batch->id}/assets/{$asset->id}/valuation", [
-            'lot_number' => 'LOT-01',
             'nilai_taksiran' => 5000000,
             'kertas_kerja_data' => ['bobot' => 'tinggi'],
         ]);
@@ -196,6 +253,29 @@ class AuctionBatchTest extends TestCase
             'lot_number' => 'LOT-01',
             'nilai_taksiran' => 5000000,
         ]);
+    }
+
+    public function test_cannot_update_nilai_taksiran_before_pre_valuation_documents_complete(): void
+    {
+        $batch = AuctionBatch::create([
+            'batch_number' => 'LE-20260622-0001',
+            'name' => 'Batch I',
+            'status' => AuctionBatchStatus::DRAFT,
+            'metadata' => $this->workflowMetadata(),
+        ]);
+
+        $asset = $this->createAsset();
+        $batch->assets()->attach($asset->id, [
+            'id' => \Illuminate\Support\Str::uuid(),
+            'lot_number' => 'LOT-01',
+        ]);
+
+        $response = $this->putJson("/api/bmn/auction-batches/{$batch->id}/assets/{$asset->id}/valuation", [
+            'nilai_taksiran' => 5000000,
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('workflow');
     }
 
     public function test_cannot_update_lot_after_diajukan(): void
@@ -318,6 +398,7 @@ class AuctionBatchTest extends TestCase
             'batch_number' => 'LE-20260622-0001',
             'name' => 'Batch I',
             'status' => AuctionBatchStatus::DRAFT,
+            'metadata' => $this->workflowMetadata(),
         ]);
 
         $response = $this->patchJson("/api/bmn/auction-batches/{$batch->id}/draft-metadata", [
@@ -355,6 +436,7 @@ class AuctionBatchTest extends TestCase
             'batch_number' => 'LE-20260622-0001',
             'name' => 'Batch I',
             'status' => AuctionBatchStatus::DRAFT,
+            'metadata' => $this->workflowMetadata(),
         ]);
 
         $asset = $this->createAsset();
@@ -387,6 +469,42 @@ class AuctionBatchTest extends TestCase
         $asset->refresh();
         $this->assertTrue((bool)$asset->henti_guna);
         $this->assertEquals('Dihentikan dari Penggunaan Dinas', $asset->status_penggunaan);
+    }
+
+    public function test_cannot_lock_submit_without_post_valuation_documents(): void
+    {
+        $batch = AuctionBatch::create([
+            'batch_number' => 'LE-20260622-0001',
+            'name' => 'Batch I',
+            'status' => AuctionBatchStatus::DRAFT,
+            'metadata' => $this->workflowMetadata(false),
+        ]);
+
+        $asset = $this->createAsset();
+        $batch->assets()->attach($asset->id, [
+            'id' => \Illuminate\Support\Str::uuid(),
+            'lot_number' => 'LOT-01',
+            'nilai_taksiran' => 5000000,
+        ]);
+
+        $response = $this->postJson("/api/bmn/auction-batches/{$batch->id}/transition", [
+            'status' => 'DIAJUKAN',
+            'kepala_balai_id' => $this->kepalaBalai->id,
+            'signatories' => [
+                'panitia' => [$this->panitiaMember->id],
+                'tim_penilai' => [$this->timPenilaiMember->id],
+                'pemeriksa' => [$this->pemeriksaMember->id],
+            ],
+            'document_numbers' => [
+                'surat_tugas' => 'ST/001/BMN',
+            ],
+            'document_dates' => [
+                'surat_tugas' => '2026-06-22',
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('checklist');
     }
 
     public function test_can_record_schedule_to_jadwal_ditetapkan(): void
@@ -669,6 +787,7 @@ class AuctionBatchTest extends TestCase
             'batch_number' => 'LE-20260622-0001',
             'name' => 'Batch I',
             'status' => AuctionBatchStatus::DRAFT,
+            'metadata' => $this->workflowMetadata(),
         ]);
 
         $asset = $this->createAsset();
@@ -691,6 +810,7 @@ class AuctionBatchTest extends TestCase
             'batch_number' => 'LE-20260622-0001',
             'name' => 'Batch I',
             'status' => AuctionBatchStatus::DRAFT,
+            'metadata' => $this->workflowMetadata(),
         ]);
 
         $asset = $this->createAsset();
@@ -719,7 +839,9 @@ class AuctionBatchTest extends TestCase
         $batch->refresh();
         $metadata = $batch->metadata;
 
-        $this->assertEquals(1, $metadata['schema_version']);
+        $this->assertEquals(2, $metadata['schema_version']);
+        $this->assertTrue($metadata['workflow']['pre_valuation_complete']);
+        $this->assertTrue($metadata['workflow']['post_valuation_complete']);
         $this->assertEquals('M. Ari Wibawanto', $metadata['signatories']['kepala_balai']['nama']);
         $this->assertEquals('Panitia Satu', $metadata['committees']['panitia_penghapusan'][0]['nama']);
     }

--- a/backend/tests/Feature/Bmn/AuctionBatchTest.php
+++ b/backend/tests/Feature/Bmn/AuctionBatchTest.php
@@ -10,6 +10,7 @@ use App\Modules\Bmn\Enums\AuctionBatchStatus;
 use App\Modules\Bmn\Enums\AuctionAssetFinalResult;
 use App\Modules\Bmn\Support\AuctionBatchEventAction;
 use App\Modules\Bmn\Services\AuctionAssetDocumentReadinessService;
+use App\Modules\Bmn\Services\AuctionBatchDocumentWorkflow;
 use App\Modules\Bmn\Services\AuctionBatchValidityService;
 use App\Modules\Kepegawaian\Models\Employee;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -214,6 +215,123 @@ class AuctionBatchTest extends TestCase
         ]);
 
         $response->assertStatus(422);
+    }
+
+    public function test_document_workflow_registry_matches_srikandi_sequence(): void
+    {
+        $workflow = app(AuctionBatchDocumentWorkflow::class);
+        $keys = $workflow->keys();
+
+        $this->assertSame('sk_penghentian', $keys[0]);
+        $this->assertSame('ba_koreksi', $keys[1]);
+        $this->assertSame('sk_panitia_penaksir_harga', $keys[8]);
+        $this->assertSame('nilai_taksiran', $keys[9]);
+        $this->assertSame('nota_dinas_ksdae', $keys[11]);
+        $this->assertTrue($workflow->get('sk_panitia_penaksir_harga')['required_for_valuation']);
+        $this->assertTrue($workflow->get('nota_dinas_ksdae')['requires_valuation']);
+    }
+
+    public function test_can_update_draft_metadata_on_draft_batch(): void
+    {
+        $batch = AuctionBatch::create([
+            'batch_number' => 'LE-20260622-0001',
+            'name' => 'Batch I',
+            'status' => AuctionBatchStatus::DRAFT,
+            'metadata' => [
+                'custom_key' => 'keep-me',
+                'document_numbers' => [
+                    'existing' => 'EX-001',
+                ],
+                'signatories_raw' => [
+                    'panitia' => ['old-member'],
+                ],
+            ],
+        ]);
+
+        $response = $this->patchJson("/api/bmn/auction-batches/{$batch->id}/draft-metadata", [
+            'kepala_balai_id' => $this->kepalaBalai->id,
+            'signatories' => [
+                'panitia' => [$this->panitiaMember->id],
+                'tim_penilai' => [$this->timPenilaiMember->id],
+            ],
+            'document_numbers' => [
+                'nota_dinas' => 'ND-001/BMN',
+            ],
+            'document_dates' => [
+                'nota_dinas' => '2026-06-24',
+            ],
+            'workflow' => [
+                'documents' => [
+                    'sk_penghentian' => [
+                        'status' => 'completed',
+                        'notes' => 'Sudah terbit di Srikandi',
+                    ],
+                    'nota_dinas_ksdae' => [
+                        'status' => 'prepared',
+                    ],
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(200);
+
+        $batch->refresh();
+        $metadata = $batch->metadata;
+
+        $this->assertSame($this->kepalaBalai->id, $batch->kepala_balai_id);
+        $this->assertSame('keep-me', $metadata['custom_key']);
+        $this->assertSame('EX-001', $metadata['document_numbers']['existing']);
+        $this->assertSame('ND-001/BMN', $metadata['document_numbers']['nota_dinas']);
+        $this->assertSame([$this->panitiaMember->id], $metadata['signatories_raw']['panitia']);
+        $this->assertSame([$this->timPenilaiMember->id], $metadata['signatories_raw']['tim_penilai']);
+        $this->assertSame('completed', $metadata['workflow']['documents']['sk_penghentian']['status']);
+        $this->assertSame('Penghentian Penggunaan BMN', $metadata['workflow']['documents']['sk_penghentian']['title']);
+        $this->assertSame('prepared', $metadata['workflow']['documents']['nota_dinas_ksdae']['status']);
+
+        $this->assertDatabaseHas('bmn_auction_batch_events', [
+            'bmn_auction_batch_id' => $batch->id,
+            'action' => AuctionBatchEventAction::DRAFT_METADATA_UPDATED,
+        ]);
+    }
+
+    public function test_cannot_update_draft_metadata_after_diajukan(): void
+    {
+        $batch = AuctionBatch::create([
+            'batch_number' => 'LE-20260622-0001',
+            'name' => 'Batch I',
+            'status' => AuctionBatchStatus::DIAJUKAN,
+        ]);
+
+        $response = $this->patchJson("/api/bmn/auction-batches/{$batch->id}/draft-metadata", [
+            'document_numbers' => [
+                'nota_dinas' => 'ND-001/BMN',
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('status');
+    }
+
+    public function test_draft_metadata_rejects_invalid_workflow_document_key(): void
+    {
+        $batch = AuctionBatch::create([
+            'batch_number' => 'LE-20260622-0001',
+            'name' => 'Batch I',
+            'status' => AuctionBatchStatus::DRAFT,
+        ]);
+
+        $response = $this->patchJson("/api/bmn/auction-batches/{$batch->id}/draft-metadata", [
+            'workflow' => [
+                'documents' => [
+                    'dokumen_ngawur' => [
+                        'status' => 'completed',
+                    ],
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('workflow.documents');
     }
 
     public function test_cannot_lock_incomplete_batch(): void

--- a/docs/bmn-auction-srikandi-workflow/design.md
+++ b/docs/bmn-auction-srikandi-workflow/design.md
@@ -56,15 +56,15 @@ Proposed initial registry mapping:
 | `sk_penghentian` | `sk_penghentian` | Srikandi | pre_valuation | Penghentian Penggunaan BMN |
 | `ba_koreksi` | `ba_koreksi` | Srikandi | pre_valuation | Koreksi Perubahan Kondisi BMN |
 | `sk_panitia_penghapusan` | `sk_panitia` | Srikandi | pre_valuation | Panitia Penghapusan BMN kendaraan bermotor |
-| `surat_tugas_pemeriksaan_penilaian` | needs audit, maybe current `sp_tugas` is not this | Srikandi | pre_valuation | Must be verified/implemented |
+| `surat_tugas_pemeriksaan_penilaian` | `SuratTugasPemeriksaanPenilaianDocument` | Srikandi | pre_valuation | Dedicated Surat Tugas Pemeriksaan dan Penilaian BMN template |
 | `sk_panitia_penaksir_harga` | `sk_tim_penilai` | Srikandi | pre_valuation | Pembentukan Panitia Penaksir Harga |
 | `sk_kebenaran` | `sk_kebenaran` | Manual TTD | pre_valuation | Existing manual supporting doc |
-| `sptjm` | `sptjm` | Manual TTD | pre_valuation | Existing manual supporting doc, confirm placement |
+| `sptjm` | `sptjm` | Manual TTD | pre_valuation | Existing manual supporting doc |
 | `sp_kelancaran_tugas` | `sp_tugas` | Manual TTD | pre_valuation | Current title suggests statement, not Srikandi surat tugas |
-| `ba_pemeriksaan` | `ba_pemeriksaan` | Manual TTD or Srikandi support | pre_valuation | Confirm whether part of Surat Tugas process |
+| `ba_pemeriksaan` | `ba_pemeriksaan` | Manual TTD | pre_valuation | Existing manual supporting doc before Panitia Penaksir Harga |
 | `nilai_taksiran` | `ValuationTab` | App workflow | valuation | Enabled only after pre-valuation gate |
-| `sptj_limit` | `sptj_limit` | Manual TTD | post_valuation | Depends on nilai limit, confirm final placement |
-| `nota_dinas_ksdae` | maybe current `nota_dinas`, needs title audit | Srikandi/manual process after valuation | post_valuation | Must appear after Tim Penilai valuation |
+| `sptj_limit` | `sptj_limit` | Manual TTD | post_valuation | Depends on nilai limit |
+| `nota_dinas_ksdae` | `nota_dinas` | Srikandi | post_valuation | Must appear after Tim Penilai valuation |
 | `permohonan_kpknl` | `permohonan_kpknl` | External/KPKNL | post_valuation | Must appear after Tim Penilai valuation |
 
 The registry should be the source of truth for document ordering, grouping, and checklist labels.
@@ -141,7 +141,7 @@ For non-vehicle assets:
 
 Show post-valuation documents only after all asset valuations are valid:
 
-- SPTJ Nilai Limit, if confirmed post-valuation.
+- SPTJ Nilai Limit.
 - Nota Dinas KSDAE.
 - Permohonan/Nota KPKNL.
 

--- a/docs/bmn-auction-srikandi-workflow/design.md
+++ b/docs/bmn-auction-srikandi-workflow/design.md
@@ -1,0 +1,255 @@
+# Design: BMN Auction Srikandi Workflow Alignment
+
+## Current State Summary
+
+Current frontend flow in `frontend/src/app/bmn/auction-batches/[id]/page.tsx`:
+
+1. Aset & Lot
+2. Nilai Taksiran
+3. Dokumen & Tanda Tangan
+4. Pusat Dokumen
+5. Jadwal Lelang, when not DRAFT
+6. Realisasi & Hasil, when advanced enough
+7. Riwayat Audit
+
+Current backend lock checklist in `backend/app/Modules/Bmn/Services/AuctionBatchCompletenessChecker.php` requires all valuations before lock. This is technically correct for final lock, but the UI currently presents valuation too early in the operator workflow.
+
+Current document list in `DocumentsCenterTab.tsx` is flat and mixes Srikandi, manual TTD, pre-valuation, and post-valuation documents.
+
+Current signatory UI in `SignatoriesDocumentsTab.tsx` mixes signatory selection, committee selection, document numbers, checklist, and the final lock button.
+
+## Desired Information Architecture
+
+Replace the flat mental model with ordered stages:
+
+1. Aset & Lot
+2. Dokumen Awal
+3. Panitia & Surat Tugas
+4. Nilai Taksiran
+5. Dokumen Setelah Taksiran
+6. Kunci & Ajukan
+7. Jadwal Lelang
+8. Realisasi & Hasil
+9. Riwayat Audit
+
+The exact tab labels can be shortened in UI, but the order must communicate that valuation happens after Panitia Penaksir Harga is formed.
+
+## Document Registry
+
+Add a shared document registry used by frontend and backend. At minimum each document needs:
+
+- `key`
+- `title`
+- `channel`: `srikandi` or `manual_ttd`
+- `phase`: `pre_valuation`, `valuation`, `post_valuation`, `auction`
+- `order`
+- `requires_completion_before`: optional gate key
+- `requires_valuation`: boolean
+- `rootId`: frontend print root id when printable
+- `numberKey`: optional metadata document number key
+- `dateKey`: optional metadata document date key
+
+Proposed initial registry mapping:
+
+| Key | Current component/key | Channel | Phase | Notes |
+| --- | --- | --- | --- | --- |
+| `sk_penghentian` | `sk_penghentian` | Srikandi | pre_valuation | Penghentian Penggunaan BMN |
+| `ba_koreksi` | `ba_koreksi` | Srikandi | pre_valuation | Koreksi Perubahan Kondisi BMN |
+| `sk_panitia_penghapusan` | `sk_panitia` | Srikandi | pre_valuation | Panitia Penghapusan BMN kendaraan bermotor |
+| `surat_tugas_pemeriksaan_penilaian` | needs audit, maybe current `sp_tugas` is not this | Srikandi | pre_valuation | Must be verified/implemented |
+| `sk_panitia_penaksir_harga` | `sk_tim_penilai` | Srikandi | pre_valuation | Pembentukan Panitia Penaksir Harga |
+| `sk_kebenaran` | `sk_kebenaran` | Manual TTD | pre_valuation | Existing manual supporting doc |
+| `sptjm` | `sptjm` | Manual TTD | pre_valuation | Existing manual supporting doc, confirm placement |
+| `sp_kelancaran_tugas` | `sp_tugas` | Manual TTD | pre_valuation | Current title suggests statement, not Srikandi surat tugas |
+| `ba_pemeriksaan` | `ba_pemeriksaan` | Manual TTD or Srikandi support | pre_valuation | Confirm whether part of Surat Tugas process |
+| `nilai_taksiran` | `ValuationTab` | App workflow | valuation | Enabled only after pre-valuation gate |
+| `sptj_limit` | `sptj_limit` | Manual TTD | post_valuation | Depends on nilai limit, confirm final placement |
+| `nota_dinas_ksdae` | maybe current `nota_dinas`, needs title audit | Srikandi/manual process after valuation | post_valuation | Must appear after Tim Penilai valuation |
+| `permohonan_kpknl` | `permohonan_kpknl` | External/KPKNL | post_valuation | Must appear after Tim Penilai valuation |
+
+The registry should be the source of truth for document ordering, grouping, and checklist labels.
+
+## Frontend Design
+
+### Workflow navigation
+
+`BmnAuctionBatchDetailPage` should derive tabs from workflow stage definitions instead of a hard-coded simple list.
+
+Suggested tabs:
+
+- `assets`: Aset & Lot
+- `pre-docs`: Dokumen Awal
+- `valuation`: Nilai Taksiran
+- `post-docs`: Setelah Taksiran
+- `submit`: Kunci & Ajukan
+- `schedule`: Jadwal Lelang, available after DIAJUKAN
+- `realization`: Realisasi & Hasil, available after JADWAL_DITETAPKAN or lelang ulang path
+- `audit`: Riwayat Audit
+
+If the team wants fewer tabs, combine `pre-docs` and `submit`, but keep the stage cards visibly separated.
+
+### Gating behavior
+
+When a tab is not ready:
+
+- It can remain visible but disabled, or open to a read-only blocked state.
+- The blocked state must list missing prerequisites.
+- The `Lanjut ke ...` button must skip impossible states only when there is a clear reason, otherwise show disabled with explanation.
+
+Example:
+
+- `Nilai Taksiran` shows locked card: "Selesaikan SK Panitia Penaksir Harga terlebih dahulu."
+- `Dokumen Setelah Taksiran` shows locked card: "Isi nilai taksiran seluruh aset terlebih dahulu."
+- `Kunci & Ajukan` shows checklist grouped by stage.
+
+### Dokumen Awal tab
+
+Use grouped document cards:
+
+- Srikandi sequence
+- Manual TTD sebelum penaksiran
+
+Each card should show:
+
+- Document title.
+- Channel badge.
+- Order number.
+- Status: belum disiapkan, dicetak, ditandatangani, selesai.
+- Number/date fields when required.
+- Print button if a template exists.
+- Manual completion checkbox or action.
+
+### Nilai Taksiran tab
+
+Keep the recently integrated vehicle worksheet.
+
+Add a gate:
+
+- If pre-valuation stage incomplete, show blocked state and do not allow editing.
+- If complete, allow per-asset valuation and worksheet editing.
+
+For vehicle assets:
+
+- Use `KertasKerjaAssetSection`.
+- Save `nilai_taksiran` and `kertas_kerja_data`.
+
+For non-vehicle assets:
+
+- Keep current simple worksheet until another template is specified.
+
+### Dokumen Setelah Taksiran tab
+
+Show post-valuation documents only after all asset valuations are valid:
+
+- SPTJ Nilai Limit, if confirmed post-valuation.
+- Nota Dinas KSDAE.
+- Permohonan/Nota KPKNL.
+
+If valuation is incomplete, show blocked state with missing assets.
+
+### Kunci & Ajukan tab
+
+Move final lock action out of the old `Dokumen & Tanda Tangan` form and into a dedicated final submission stage.
+
+Checklist groups:
+
+- Aset & lot
+- Dokumen awal
+- Nilai taksiran
+- Dokumen setelah taksiran
+- Metadata/signatories
+- Snapshot/contracts
+
+## Backend Design
+
+### Metadata schema
+
+Keep schema version 1 readable. Introduce schema version 2 for new workflow metadata.
+
+Suggested structure:
+
+```json
+{
+  "schema_version": 2,
+  "workflow": {
+    "documents": {
+      "sk_penghentian": {
+        "status": "completed",
+        "channel": "srikandi",
+        "completed_at": "2026-06-24T00:00:00Z",
+        "number": "...",
+        "date": "2026-06-24"
+      }
+    },
+    "pre_valuation_complete": true,
+    "valuation_complete": true,
+    "post_valuation_complete": true
+  },
+  "signatories": {},
+  "committees": {},
+  "document_numbers": {},
+  "document_dates": {}
+}
+```
+
+Store draft workflow metadata before lock. Do not depend on `transition(status=DRAFT)` because `TransitionAuctionBatchRequest` currently does not allow `DRAFT`.
+
+### Draft metadata endpoint
+
+Add a dedicated endpoint such as:
+
+- `PATCH /bmn/auction-batches/{id}/draft-metadata`
+- Or `PUT /bmn/auction-batches/{id}/workflow`
+
+It should update:
+
+- selected signatories
+- committee IDs
+- document progress
+- document numbers/dates
+- workflow status flags
+
+It must only work while batch status is `DRAFT`.
+
+### Checklist service
+
+Refactor `AuctionBatchCompletenessChecker` to compute grouped checklist sections:
+
+- assets
+- pre_valuation_documents
+- valuation
+- post_valuation_documents
+- final_submission
+- contracts
+
+The old flat `items` array can remain for compatibility, but the frontend should use grouped data if available.
+
+### Valuation guard
+
+`AuctionBatchService::updateValuation` should reject valuation edits if pre-valuation prerequisites are incomplete.
+
+Exception:
+
+- Existing data repair/admin override can be added later if needed.
+
+### Lock guard
+
+`lockAndSubmit` should require:
+
+- pre-valuation complete
+- all valuations positive
+- post-valuation complete
+- final metadata valid
+
+## Compatibility
+
+- Existing locked schema version 1 batches must keep printing.
+- Existing draft batches without workflow metadata should be treated as incomplete for new gates but should not crash.
+- Existing `kertas_kerja_data` must continue loading because vehicle worksheet integration already supports fallback data.
+
+## Risks
+
+- Misclassifying a manual TTD document as Srikandi may confuse operators.
+- Some current component names do not match real document titles.
+- Existing frontend silently posts `status: DRAFT` to transition endpoint; this likely does not persist reliably and should be replaced.
+- If backend and frontend gates diverge, users may see available actions that fail on submit.

--- a/docs/bmn-auction-srikandi-workflow/requirements.md
+++ b/docs/bmn-auction-srikandi-workflow/requirements.md
@@ -48,7 +48,7 @@ The expected high-level order is:
 10. KPKNL submission/permohonan after valuation is complete
 11. Lock/submit package, scheduling, auction result, and realization
 
-The exact relative order of items 5 and 6 may be refined during implementation if the operator confirms a more specific manual signature sequence. However, valuation must not be available before the Panitia Penaksir Harga stage is complete.
+Manual TTD supporting documents are not part of Srikandi, but they remain required before the Panitia Penaksir Harga/valuation stage. Valuation must not be available before the Panitia Penaksir Harga stage is complete.
 
 ## Document Channel Requirements
 
@@ -83,7 +83,8 @@ Known post-valuation exceptions:
 
 - Nota Dinas KSDAE must be after goods/assets are valued by Tim Penilai.
 - KPKNL request/submission must be after goods/assets are valued by Tim Penilai.
-- Any document whose content includes nilai limit/nilai taksiran must be placed after valuation unless the operator explicitly confirms otherwise.
+- SPTJ Nilai Limit must be after goods/assets are valued because it depends on the resulting nilai limit/nilai taksiran.
+- Any future document whose content includes nilai limit/nilai taksiran must be placed after valuation unless the operator explicitly confirms otherwise.
 
 ## Valuation Requirements
 
@@ -142,11 +143,11 @@ Existing locked packages with `metadata_schema_version = 1` must remain printabl
 - Tests must cover the new gating order.
 - The implementation should minimize migration risk by adding metadata-compatible fields rather than rewriting existing locked metadata.
 
-## Open Questions To Confirm With Operator
+## Resolved Operator Decisions
 
-- Exact manual TTD document order before Panitia Penaksir Harga.
-- Whether SPTJ Nilai Limit is post-valuation in the final office process.
-- Whether `sp_tugas` in the current code is actually Surat Tugas Pemeriksaan dan Penilaian BMN or a different statement document.
-- Whether Nota Dinas KSDAE is the current `nota_dinas` component or a missing separate document template.
-- Whether KPKNL document means current `permohonan_kpknl` only, or includes another nota/surat.
-
+- Existing support documents that are not in the Srikandi sequence remain Manual TTD and must be completed before Panitia Penaksir Harga unless they depend on valuation.
+- `sp_tugas` is treated as Surat Pernyataan Kelancaran Tugas Dinas, not Surat Tugas Pemeriksaan dan Penilaian BMN.
+- Surat Tugas Pemeriksaan dan Penilaian BMN has its own Srikandi workflow entry/template.
+- SPTJ Nilai Limit, Nota Dinas KSDAE, and KPKNL request/submission are post-valuation documents.
+- The current `nota_dinas` component maps to the Nota Dinas KSDAE workflow entry for this iteration.
+- The current `permohonan_kpknl` component maps to the KPKNL request/submission workflow entry for this iteration.

--- a/docs/bmn-auction-srikandi-workflow/requirements.md
+++ b/docs/bmn-auction-srikandi-workflow/requirements.md
@@ -1,0 +1,152 @@
+# Requirements: BMN Auction Srikandi Workflow Alignment
+
+## Background
+
+BMN Auction currently lets operators work on lot numbers, valuation, signatories, and document printing in a mostly parallel order. Based on the current Srikandi workflow used by the operator, the application must guide users through a stricter document order before valuation and before external submission.
+
+This document defines the required business flow. It is intentionally written before implementation so the next coding pass can align UI, backend validation, metadata, and document generation without guessing the intended process.
+
+## Scope
+
+In scope:
+
+- Align BMN Auction batch detail workflow with the real Srikandi sequence.
+- Separate Srikandi documents from manual signature documents.
+- Move valuation and vehicle worksheet entry after the Panitia Penaksir Harga stage.
+- Move Nota Dinas KSDAE and KPKNL submission documents after valuation by Tim Penilai.
+- Update checklist/gating so users cannot accidentally skip required stages.
+- Preserve the existing BMN Auction status model unless implementation proves a new status is required.
+
+Out of scope for this specification:
+
+- Changing non-auction BMN modules.
+- Replacing all document templates.
+- Integrating directly with Srikandi APIs. The current target is workflow guidance, metadata, print/sign tracking, and gating inside this app.
+
+## Definitions
+
+- Srikandi document: A document whose official process/order follows the Srikandi workflow.
+- Manual TTD document: A document printed/generated from the app but manually signed outside Srikandi.
+- Pre-valuation document: A document that must be completed before nilai taksiran/kertas kerja can be entered.
+- Post-valuation document: A document that depends on nilai taksiran or must happen after Tim Penilai finishes valuation.
+- Valuation: Nilai taksiran per asset, including kertas kerja kendaraan bermotor where applicable.
+- Lock/submit: The app action that freezes assets and moves a batch out of DRAFT into the next official auction status.
+
+## Required Workflow Order
+
+The expected high-level order is:
+
+1. Aset & Lot
+2. Penghentian Penggunaan BMN
+3. Koreksi Perubahan Kondisi BMN
+4. Panitia Penghapusan Barang Milik Negara Berupa Alat Angkutan Bermotor Pada Balai Konservasi Sumber Daya Alam Kalimantan Timur
+5. Manual TTD supporting documents that are not Srikandi and are required before Panitia Penaksir Harga
+6. Surat Tugas Pemeriksaan dan Penilaian BMN
+7. Pembentukan Panitia Penaksir Harga Barang Milik Negara Pada Balai Konservasi Sumber Daya Alam Kalimantan Timur
+8. Nilai taksiran / kertas kerja by Tim Penilai
+9. Nota Dinas KSDAE after valuation is complete
+10. KPKNL submission/permohonan after valuation is complete
+11. Lock/submit package, scheduling, auction result, and realization
+
+The exact relative order of items 5 and 6 may be refined during implementation if the operator confirms a more specific manual signature sequence. However, valuation must not be available before the Panitia Penaksir Harga stage is complete.
+
+## Document Channel Requirements
+
+### Srikandi sequence
+
+The app must treat these as the official Srikandi sequence:
+
+1. Penghentian Penggunaan BMN
+2. Koreksi Perubahan Kondisi BMN
+3. Panitia Penghapusan Barang Milik Negara Berupa Alat Angkutan Bermotor Pada Balai Konservasi Sumber Daya Alam Kalimantan Timur
+4. Surat Tugas Pemeriksaan dan Penilaian BMN
+5. Pembentukan Panitia Penaksir Harga Barang Milik Negara Pada Balai Konservasi Sumber Daya Alam Kalimantan Timur
+
+Each Srikandi item must have:
+
+- A clear title matching operator wording.
+- A phase/order number.
+- A document key.
+- A completion marker.
+- A channel badge or label: `Srikandi`.
+
+### Manual TTD documents
+
+Existing documents that are not part of the official Srikandi sequence must not be hidden. They must be treated as manual TTD documents.
+
+Default rule:
+
+- Manual TTD documents that do not depend on valuation should appear before the Panitia Penaksir Harga/valuation step.
+- Manual TTD documents that depend on valuation must appear after valuation.
+
+Known post-valuation exceptions:
+
+- Nota Dinas KSDAE must be after goods/assets are valued by Tim Penilai.
+- KPKNL request/submission must be after goods/assets are valued by Tim Penilai.
+- Any document whose content includes nilai limit/nilai taksiran must be placed after valuation unless the operator explicitly confirms otherwise.
+
+## Valuation Requirements
+
+- Nilai taksiran must no longer be the second workflow tab immediately after Aset & Lot.
+- Nilai taksiran must be gated until the pre-valuation Srikandi and manual TTD requirements are complete.
+- For vehicle assets, the valuation input must use the full kertas kerja kendaraan format, not the simple three-comparable modal.
+- For non-vehicle assets, the existing simple comparison worksheet may remain until a domain-specific template is provided.
+- The app must keep per-asset `nilai_taksiran` and `kertas_kerja_data`.
+- Existing saved kertas kerja data must remain readable.
+
+## Lock/Submit Requirements
+
+The package must not be locked/submitted until:
+
+- At least one asset exists.
+- All assets have lot numbers.
+- Pre-valuation documents are complete.
+- Valuation is complete for all assets.
+- Post-valuation documents required for submission are complete.
+- Required signatories/committees are selected.
+- Required document numbers/dates are present.
+- Metadata and asset/freeze snapshots remain valid.
+
+The checklist must explain what is missing in the user-facing order, not in a technical order.
+
+## Metadata Requirements
+
+The implementation must persist enough data to support:
+
+- Document order.
+- Document channel: Srikandi or Manual TTD.
+- Document phase: pre-valuation or post-valuation.
+- Document completion status.
+- Document number/date fields where applicable.
+- Selected signatories and committee members.
+- Valuation readiness.
+- Backward compatibility with metadata schema version 1.
+
+Existing locked packages with `metadata_schema_version = 1` must remain printable/readable.
+
+## UX Requirements
+
+- Users must see why valuation is locked before the required documents are done.
+- Users must see which documents are Srikandi and which are manual TTD.
+- Users must be able to complete or mark document progress in order.
+- Next/previous navigation must follow the new workflow.
+- Document cards must be grouped by stage to avoid a flat, confusing list.
+- The UI must avoid forcing users to scroll through a long unrelated list before reaching the active stage.
+
+## Non-Functional Requirements
+
+- The workflow must be understandable to operators who follow Srikandi.
+- The implementation must not touch `main`; work targets `develop/bmn-auction`.
+- Existing document print components should be reused where possible.
+- Backend gates must enforce the same rules as frontend gates.
+- Tests must cover the new gating order.
+- The implementation should minimize migration risk by adding metadata-compatible fields rather than rewriting existing locked metadata.
+
+## Open Questions To Confirm With Operator
+
+- Exact manual TTD document order before Panitia Penaksir Harga.
+- Whether SPTJ Nilai Limit is post-valuation in the final office process.
+- Whether `sp_tugas` in the current code is actually Surat Tugas Pemeriksaan dan Penilaian BMN or a different statement document.
+- Whether Nota Dinas KSDAE is the current `nota_dinas` component or a missing separate document template.
+- Whether KPKNL document means current `permohonan_kpknl` only, or includes another nota/surat.
+

--- a/docs/bmn-auction-srikandi-workflow/tasks.md
+++ b/docs/bmn-auction-srikandi-workflow/tasks.md
@@ -12,6 +12,13 @@ This task list is intentionally detailed so a future AI coding session can conti
 - Run frontend lint and typecheck before committing.
 - Prefer reusing existing document components.
 
+## Resolved Operator Decisions
+
+- Existing support documents that are not in the Srikandi sequence are Manual TTD and are completed before Panitia Penaksir Harga unless they depend on valuation.
+- `sp_tugas` is Surat Pernyataan Kelancaran Tugas Dinas, not Surat Tugas Pemeriksaan dan Penilaian BMN.
+- Surat Tugas Pemeriksaan dan Penilaian BMN uses a dedicated workflow entry/template.
+- SPTJ Nilai Limit, Nota Dinas KSDAE, and KPKNL submission are post-valuation documents after Tim Penilai completes valuation.
+
 ## Phase 0 - Confirm Current Baseline
 
 1. Run `git status --short --branch` and confirm the branch is based on `develop/bmn-auction`.
@@ -90,9 +97,9 @@ This task list is intentionally detailed so a future AI coding session can conti
 5. Manual TTD documents to map:
    - `sk_kebenaran`
    - `sptjm`
-   - `sp_tugas` if it is a statement document, not the Srikandi Surat Tugas Pemeriksaan dan Penilaian BMN
-   - `ba_pemeriksaan` if office confirms it is a manual signed support document
-   - `sptj_limit`, likely post-valuation because it depends on nilai limit. Confirm before final placement.
+   - `sp_tugas` as Surat Pernyataan Kelancaran Tugas Dinas, not the Srikandi Surat Tugas Pemeriksaan dan Penilaian BMN
+   - `ba_pemeriksaan`
+   - `sptj_limit` as post-valuation because it depends on nilai limit.
 6. Add unit tests for backend registry order if test style supports it.
 
 ## Phase 2 - Add Draft Workflow Metadata Persistence
@@ -295,9 +302,7 @@ Replace autosave:
 2. Required documents after Tim Penilai finishes valuation:
    - Nota Dinas KSDAE.
    - KPKNL submission/permohonan.
-3. Confirm whether `sptj_limit` is also post-valuation.
-   - The name strongly implies it depends on nilai limit.
-   - Do not force it into pre-valuation without operator confirmation.
+3. `sptj_limit` is post-valuation because it depends on nilai limit.
 4. Add gating:
    - If any asset valuation missing, show blocked state.
    - If complete, allow document print/status completion.
@@ -374,4 +379,3 @@ The implementation is done when:
 - Backend rejects invalid out-of-order actions.
 - Existing locked packages remain readable/printable.
 - Tests and validation commands pass.
-

--- a/docs/bmn-auction-srikandi-workflow/tasks.md
+++ b/docs/bmn-auction-srikandi-workflow/tasks.md
@@ -1,0 +1,377 @@
+# Tasks: BMN Auction Srikandi Workflow Alignment
+
+This task list is intentionally detailed so a future AI coding session can continue without re-discovering the workflow from chat history.
+
+## Ground Rules
+
+- Work from `develop/bmn-auction`, not `main`.
+- Use a feature branch.
+- Do not open a PR until requested.
+- Keep schema version 1 locked batches readable.
+- Add tests for backend workflow gates.
+- Run frontend lint and typecheck before committing.
+- Prefer reusing existing document components.
+
+## Phase 0 - Confirm Current Baseline
+
+1. Run `git status --short --branch` and confirm the branch is based on `develop/bmn-auction`.
+2. Inspect current frontend workflow in:
+   - `frontend/src/app/bmn/auction-batches/[id]/page.tsx`
+   - `frontend/src/app/bmn/auction-batches/[id]/_components/SignatoriesDocumentsTab.tsx`
+   - `frontend/src/app/bmn/auction-batches/[id]/_components/DocumentsCenterTab.tsx`
+   - `frontend/src/app/bmn/auction-batches/[id]/_components/ValuationTab.tsx`
+3. Inspect current backend gates in:
+   - `backend/app/Modules/Bmn/Services/AuctionBatchCompletenessChecker.php`
+   - `backend/app/Modules/Bmn/Services/AuctionBatchService.php`
+   - `backend/app/Modules/Bmn/Services/AuctionBatchMetadataBuilder.php`
+   - `backend/app/Modules/Bmn/Requests/TransitionAuctionBatchRequest.php`
+4. Run existing validation before changes:
+   - frontend: `npm run lint -- --max-warnings=0`
+   - frontend: `npx tsc --noEmit`
+   - backend: run the BMN auction feature tests if available.
+
+## Phase 1 - Create Document Workflow Registry
+
+1. Add a shared backend document workflow registry.
+   - Suggested file: `backend/app/Modules/Bmn/Services/AuctionBatchDocumentWorkflow.php`
+   - It should expose ordered definitions for all BMN Auction documents.
+2. Each document definition must include:
+   - `key`
+   - `title`
+   - `channel`: `srikandi`, `manual_ttd`, `external`
+   - `phase`: `pre_valuation`, `valuation`, `post_valuation`, `auction`
+   - `order`
+   - `requires_valuation`
+   - `number_key`
+   - `date_key`
+   - `required_for_valuation`
+   - `required_for_submit`
+3. Add matching frontend registry.
+   - Suggested file: `frontend/src/app/bmn/auction-batches/[id]/_lib/document-workflow.ts`
+   - Keep labels and order in sync with backend.
+4. Initial registry mapping:
+   - `sk_penghentian`
+     - Title: `Penghentian Penggunaan BMN`
+     - Current component: `SkPenghentianDocument`
+     - Channel: `srikandi`
+     - Phase: `pre_valuation`
+   - `ba_koreksi`
+     - Title: `Koreksi Perubahan Kondisi BMN`
+     - Current component: `CorrectionDocument as BaKoreksiDocument`
+     - Channel: `srikandi`
+     - Phase: `pre_valuation`
+   - `sk_panitia_penghapusan`
+     - Current key/component: `sk_panitia` / `SkPanitiaDocument`
+     - Title: `Panitia Penghapusan Barang Milik Negara Berupa Alat Angkutan Bermotor Pada Balai Konservasi Sumber Daya Alam Kalimantan Timur`
+     - Channel: `srikandi`
+     - Phase: `pre_valuation`
+   - `surat_tugas_pemeriksaan_penilaian`
+     - Current component: verify. Do not assume current `sp_tugas` is this.
+     - Title: `Surat Tugas Pemeriksaan dan Penilaian BMN`
+     - Channel: `srikandi`
+     - Phase: `pre_valuation`
+   - `sk_panitia_penaksir_harga`
+     - Current key/component: likely `sk_tim_penilai` / `SkTimPenilaiDocument`
+     - Title: `Pembentukan Panitia Penaksir Harga Barang Milik Negara Pada Balai Konservasi Sumber Daya Alam Kalimantan Timur`
+     - Channel: `srikandi`
+     - Phase: `pre_valuation`
+   - `nilai_taksiran`
+     - Current component: `ValuationTab`
+     - Channel: `app`
+     - Phase: `valuation`
+   - `nota_dinas_ksdae`
+     - Current component: verify whether current `NotaDinasDocument` is KSDAE nota dinas.
+     - Phase: `post_valuation`
+     - Requires valuation: true
+   - `permohonan_kpknl`
+     - Current component: `PermohonanKpknlDocument`
+     - Phase: `post_valuation`
+     - Requires valuation: true
+5. Manual TTD documents to map:
+   - `sk_kebenaran`
+   - `sptjm`
+   - `sp_tugas` if it is a statement document, not the Srikandi Surat Tugas Pemeriksaan dan Penilaian BMN
+   - `ba_pemeriksaan` if office confirms it is a manual signed support document
+   - `sptj_limit`, likely post-valuation because it depends on nilai limit. Confirm before final placement.
+6. Add unit tests for backend registry order if test style supports it.
+
+## Phase 2 - Add Draft Workflow Metadata Persistence
+
+1. Do not keep using `transition(status=DRAFT)` for autosave.
+   - `TransitionAuctionBatchRequest` currently does not allow `DRAFT`.
+   - Existing frontend `handleFieldChange` in `SignatoriesDocumentsTab.tsx` posts `status: DRAFT`; replace this.
+2. Add backend request class:
+   - `UpdateAuctionBatchDraftMetadataRequest`
+3. Add backend service method:
+   - `AuctionBatchService::updateDraftMetadata(string $batchId, array $payload, ?string $actorId = null)`
+4. Add route:
+   - `PATCH /bmn/auction-batches/{id}/draft-metadata`
+   - Permission: `bmn.auction.update`
+   - Only allowed while status is `DRAFT`
+5. Supported payload fields:
+   - `kepala_balai_id`
+   - `signatories.panitia`
+   - `signatories.tim_penilai`
+   - `signatories.pemeriksa`
+   - `document_numbers`
+   - `document_dates`
+   - `workflow.documents`
+6. Store draft metadata in `bmn_auction_batches.metadata`.
+7. If existing `metadata.schema_version` is missing, initialize a draft-compatible metadata object.
+8. Preserve existing keys:
+   - `signatories_raw`
+   - `document_numbers`
+   - `document_dates`
+   - Any locked schema version 1 fields
+9. Add audit event when draft metadata is updated.
+   - If no enum exists, add a safe event action such as `DRAFT_METADATA_UPDATED`.
+10. Backend tests:
+   - Can update draft metadata on DRAFT.
+   - Cannot update draft metadata after DIAJUKAN.
+   - Existing metadata keys are not dropped.
+   - Invalid document key is rejected.
+
+## Phase 3 - Refactor Backend Checklist And Gates
+
+1. Refactor `AuctionBatchCompletenessChecker`.
+2. Keep existing response shape:
+   - `complete`
+   - `items`
+3. Add grouped response:
+   - `sections`
+   - Each section has `key`, `label`, `complete`, `items`.
+4. New sections:
+   - `assets_lot`
+   - `pre_valuation_documents`
+   - `valuation`
+   - `post_valuation_documents`
+   - `final_submission`
+   - `contracts`
+5. Move valuation check:
+   - Still required for final submit.
+   - Not required for pre-valuation document stages.
+6. Add `can_enter_valuation` boolean.
+   - True only when required pre-valuation documents are complete.
+7. Add `can_complete_post_valuation_documents` boolean.
+   - True only when all assets have valid valuation.
+8. Add `can_lock_submit` boolean.
+   - True only when all required sections are complete.
+9. Update `AuctionBatchService::updateValuation`.
+   - Before saving valuation, check pre-valuation document gate.
+   - If incomplete, throw validation error explaining the missing pre-valuation docs.
+10. Update `AuctionBatchService::lockAndSubmit`.
+   - It must require all sections, including post-valuation documents.
+11. Backend tests:
+   - Cannot enter valuation before Panitia Penaksir Harga stage is complete.
+   - Can enter valuation after pre-valuation docs complete.
+   - Cannot lock submit when valuation missing.
+   - Cannot lock submit when Nota Dinas KSDAE/KPKNL post-valuation docs missing.
+   - Can lock submit when all required sections complete.
+
+## Phase 4 - Update Metadata Builder
+
+1. Update `AuctionBatchMetadataBuilder`.
+2. Build schema version 2 metadata for new locks.
+3. Include:
+   - `workflow.documents`
+   - `workflow.pre_valuation_complete`
+   - `workflow.valuation_complete`
+   - `workflow.post_valuation_complete`
+   - `signatories`
+   - `committees`
+   - `document_numbers`
+   - `document_dates`
+   - `print_config`
+4. Preserve ability to print old schema version 1 batches.
+5. Update `AuctionBatchResource`.
+   - Expose checklist flags if useful:
+     - `workflow_readiness`
+     - Or rely on `/checklist` endpoint only.
+6. Tests:
+   - Schema version 2 contains workflow document progress.
+   - Schema version 1 document context still works.
+
+## Phase 5 - Rework Frontend Workflow Tabs
+
+1. Update `frontend/src/app/bmn/auction-batches/[id]/page.tsx`.
+2. Replace hard-coded tabs:
+   - Current order: `assets`, `valuation`, `signatories`, `docs-center`, ...
+3. New suggested order:
+   - `assets`: Aset & Lot
+   - `pre-docs`: Dokumen Awal
+   - `valuation`: Nilai Taksiran
+   - `post-docs`: Setelah Taksiran
+   - `submit`: Kunci & Ajukan
+   - `schedule`: Jadwal Lelang
+   - `realization`: Realisasi & Hasil
+   - `audit`: Riwayat Audit
+4. If product wants fewer tabs:
+   - Keep `docs-center`, but it must render stage groups and tab navigation must still gate valuation correctly.
+5. Update `Lanjut ke ...` button logic.
+   - It should follow new workflow order.
+   - It should show disabled state with explanation when next stage is blocked.
+6. Add helper functions:
+   - `getWorkflowTabs(batch, checklist)`
+   - `getBlockedReason(tab, checklist)`
+7. Frontend acceptance:
+   - Nilai Taksiran no longer appears immediately after Aset & Lot as an active editable step.
+   - User sees document stages before valuation.
+
+## Phase 6 - Replace SignatoriesDocumentsTab Responsibilities
+
+Current `SignatoriesDocumentsTab` does too much:
+
+- signatory picking
+- committee picking
+- document numbers
+- checklist
+- lock action
+
+Refactor into smaller components:
+
+1. `SignatoryPickerSection`
+   - Kepala Balai searchable picker.
+   - Panitia Penghapusan multi-select.
+   - Tim Penilai/Penaksir multi-select.
+   - Pemeriksa multi-select.
+2. `DocumentNumberDateSection`
+   - Number/date fields by document key.
+   - Uses document registry.
+3. `DocumentWorkflowSection`
+   - Ordered document cards.
+   - Status controls.
+4. `FinalSubmitPanel`
+   - Grouped checklist.
+   - Lock submit action.
+
+Replace autosave:
+
+- Use the new draft metadata endpoint.
+- Debounce autosave where appropriate.
+- Show save status if useful.
+
+## Phase 7 - Rework Documents Center
+
+1. Update `DocumentsCenterTab.tsx`.
+2. Stop using a flat `documents` array as the only source of display order.
+3. Render documents from frontend registry grouped by:
+   - Srikandi pre-valuation
+   - Manual TTD pre-valuation
+   - Valuation
+   - Post-valuation: Nota Dinas KSDAE and KPKNL
+   - Auction/schedule/final
+4. Keep existing print component rendering.
+5. Verify current component mapping:
+   - `NotaDinasDocument` title and content. If it is not Nota Dinas KSDAE, add/rename template.
+   - `SpTugasDocument`. If it is not Surat Tugas Pemeriksaan dan Penilaian BMN, add a new component for that document.
+6. Add badges:
+   - `Srikandi`
+   - `Manual TTD`
+   - `Setelah Taksiran`
+   - `Menunggu Nilai Taksiran`
+7. Disable post-valuation document print buttons until valuation complete.
+8. Disable valuation-dependent document fields until valuation complete.
+9. Ensure print event logging still calls `recordPrintEvent`.
+
+## Phase 8 - Gate Valuation UI
+
+1. Update `ValuationTab.tsx`.
+2. If `checklist.can_enter_valuation` is false:
+   - Render blocked state.
+   - List missing pre-valuation documents.
+   - Provide navigation/action to Dokumen Awal.
+3. If allowed:
+   - Keep current valuation table.
+   - Keep vehicle worksheet integration.
+4. Backend must also enforce the same rule.
+5. Ensure direct API calls to update valuation before gate fail.
+6. Frontend tests/manual checks:
+   - Open valuation before docs complete: blocked state.
+   - Complete docs: valuation table becomes editable.
+
+## Phase 9 - Post-Valuation Documents
+
+1. Add/adjust a post-valuation tab/section.
+2. Required documents after Tim Penilai finishes valuation:
+   - Nota Dinas KSDAE.
+   - KPKNL submission/permohonan.
+3. Confirm whether `sptj_limit` is also post-valuation.
+   - The name strongly implies it depends on nilai limit.
+   - Do not force it into pre-valuation without operator confirmation.
+4. Add gating:
+   - If any asset valuation missing, show blocked state.
+   - If complete, allow document print/status completion.
+5. Include valuation total in post-valuation document context.
+
+## Phase 10 - Tests
+
+Backend feature tests:
+
+1. Draft metadata update endpoint:
+   - stores document workflow status
+   - rejects invalid document keys
+   - rejects updates when not DRAFT
+2. Checklist:
+   - pre-valuation docs incomplete blocks `can_enter_valuation`
+   - pre-valuation docs complete allows valuation
+   - valuation incomplete blocks post-valuation docs and lock
+   - post-valuation docs incomplete blocks lock
+3. Valuation endpoint:
+   - rejects before pre-valuation gate
+   - succeeds after gate
+4. Lock:
+   - rejects incomplete document workflow
+   - succeeds with complete workflow and valid assets
+5. Metadata:
+   - lock writes schema version 2
+   - old schema version 1 document context remains readable
+
+Frontend validation:
+
+1. `npm run lint -- --max-warnings=0`
+2. `npx tsc --noEmit`
+3. Manual browser checks:
+   - Open a DRAFT auction batch.
+   - Verify tab order.
+   - Verify valuation is blocked before pre-valuation docs.
+   - Mark pre-valuation docs complete.
+   - Verify valuation opens.
+   - Save vehicle worksheet.
+   - Verify post-valuation docs unlock.
+   - Verify final submit checklist groups are readable.
+
+## Phase 11 - Migration And Backward Compatibility
+
+1. No DB migration is required if metadata JSON is enough.
+2. If adding columns, create migration with nullable columns only.
+3. Existing locked schema 1 packages:
+   - Must still show read-only signatories.
+   - Must still print documents.
+   - Must not be forced through the new draft workflow.
+4. Existing draft packages:
+   - Missing workflow metadata should show incomplete new gates.
+   - Existing lot and valuation data should remain.
+   - Existing `kertas_kerja_data` fallback must remain.
+
+## Phase 12 - Cleanup
+
+1. Remove or stop using old `transition(status=DRAFT)` autosave calls.
+2. Remove duplicated document arrays after registry is adopted.
+3. Rename labels that confuse Srikandi sequence:
+   - `SK Penunjukan Tim Penilai / Penaksir` should become the wording approved by operator if it maps to `Pembentukan Panitia Penaksir Harga...`.
+   - `Surat Pernyataan Kelancaran Tugas Dinas` must not be confused with `Surat Tugas Pemeriksaan dan Penilaian BMN`.
+4. Keep UI copy short and operational.
+5. Update this docs folder if operator confirms the open questions.
+
+## Done Criteria
+
+The implementation is done when:
+
+- New workflow order is visible in the UI.
+- Valuation is not editable before required pre-valuation documents.
+- Nota Dinas KSDAE and KPKNL are after valuation.
+- Manual TTD documents are distinct from Srikandi documents.
+- Backend rejects invalid out-of-order actions.
+- Existing locked packages remain readable/printable.
+- Tests and validation commands pass.
+

--- a/frontend/src/app/bmn/auction-batches/[id]/_components/DocumentsCenterTab.tsx
+++ b/frontend/src/app/bmn/auction-batches/[id]/_components/DocumentsCenterTab.tsx
@@ -30,6 +30,7 @@ import { SkKebenaranDokumenDocument as SkKebenaranDocument } from "../../../auct
 import { BaPemeriksaanDocument } from "../../../auction-candidates/_components/BaPemeriksaanDocument";
 import { NotaDinasDocument } from "../../../auction-candidates/_components/NotaDinasDocument";
 import { PermohonanKpknlDocument } from "../../../auction-candidates/_components/PermohonanKpknlDocument";
+import { SuratTugasPemeriksaanPenilaianDocument } from "../../../auction-candidates/_components/SuratTugasPemeriksaanPenilaianDocument";
 
 import {
   DEFAULT_MEMUTUSKAN,
@@ -68,6 +69,13 @@ interface DocumentItem {
   printable?: boolean;
 }
 
+const channelLabels: Record<string, string> = {
+  srikandi: "Srikandi",
+  manual_ttd: "Manual TTD",
+  external: "Eksternal",
+  app: "Aplikasi",
+};
+
 export function DocumentsCenterTab({ batch, phaseFilter, checklist, onRefetch }: DocumentsCenterTabProps) {
   const [printingDocKey, setPrintingDocKey] = useState<string | null>(null);
 
@@ -102,85 +110,56 @@ export function DocumentsCenterTab({ batch, phaseFilter, checklist, onRefetch }:
     },
   });
 
-  const documents: DocumentItem[] = [
-    {
-      key: "nota_dinas",
-      title: "Nota Dinas Permohonan Persetujuan Internal",
-      category: "internal",
-      description: "Surat usulan internal kepala balai untuk penghapusan aset BMN.",
+  const printDocumentConfig: Record<string, { description: string; rootId: string }> = {
+    nota_dinas: {
+      description: "Nota Dinas KSDAE setelah nilai taksiran tim penilai selesai.",
       rootId: "nota-dinas-print-root",
     },
-    {
-      key: "sk_penghentian",
-      title: "SK Penghentian Penggunaan Dinas (KPA)",
-      category: "sk",
+    sk_penghentian: {
       description: "SK penetapan penghentian penggunaan aset BMN dari operasional dinas.",
       rootId: "sk-penghentian-print-root",
     },
-    {
-      key: "sk_panitia",
-      title: "SK Pembentukan Panitia Penghapusan",
-      category: "sk",
+    sk_panitia: {
       description: "SK pembentukan panitia pelaksana penghapusan BMN.",
       rootId: "sk-panitia-print-root",
     },
-    {
-      key: "sk_tim_penilai",
-      title: "SK Penunjukan Tim Penilai / Penaksir",
-      category: "sk",
-      description: "SK penunjukan tim penilai independen untuk taksiran harga aset.",
+    sk_tim_penilai: {
+      description: "SK pembentukan Panitia Penaksir Harga BMN.",
       rootId: "sk-tim-penilai-print-root",
     },
-    {
-      key: "ba_koreksi",
-      title: "BA Koreksi Kondisi BMN",
-      category: "internal",
-      description: "Berita acara rekonsiliasi data inventaris fisik dengan sistem.",
+    ba_koreksi: {
+      description: "Berita acara koreksi perubahan kondisi BMN.",
       rootId: "ba-koreksi-print-root",
     },
-    {
-      key: "ba_pemeriksaan",
-      title: "BA Pemeriksaan Fisik Panitia",
-      category: "internal",
-      description: "Laporan pemeriksaan kelayakan fisik oleh panitia penghapusan.",
+    ba_pemeriksaan: {
+      description: "Berita acara pemeriksaan fisik oleh panitia.",
       rootId: "ba-pemeriksaan-print-root",
     },
-    {
-      key: "sk_kebenaran",
-      title: "SK KPA Kebenaran Dokumen Kepemilikan",
-      category: "sk",
+    surat_tugas_pemeriksaan_penilaian: {
+      description: "Surat tugas pemeriksaan dan penilaian BMN sebelum nilai taksiran.",
+      rootId: "surat-tugas-pemeriksaan-penilaian-print-root",
+    },
+    sk_kebenaran: {
       description: "Surat pernyataan keabsahan dokumen kepemilikan aset BMN.",
       rootId: "sk-kebenaran-print-root",
     },
-    {
-      key: "sptjm",
-      title: "Surat Pernyataan Tanggung Jawab Mutlak (SPTJM)",
-      category: "pernyataan",
+    sptjm: {
       description: "Pernyataan tanggung jawab mutlak atas penghapusan BMN.",
       rootId: "sptjm-print-root",
     },
-    {
-      key: "sptj_limit",
-      title: "Surat Pernyataan Tanggung Jawab Nilai Limit",
-      category: "pernyataan",
+    sptj_limit: {
       description: "Pernyataan tanggung jawab atas penetapan nilai limit lelang.",
       rootId: "sptj-limit-print-root",
     },
-    {
-      key: "sp_tugas",
-      title: "Surat Pernyataan Kelancaran Tugas Dinas",
-      category: "pernyataan",
+    sp_tugas: {
       description: "Surat pernyataan bahwa pemindahtanganan aset tidak mengganggu dinas.",
       rootId: "sp-tugas-print-root",
     },
-    {
-      key: "permohonan_kpknl",
-      title: "Surat Permohonan Lelang ke KPKNL",
-      category: "eksternal",
+    permohonan_kpknl: {
       description: "Surat pengajuan lelang resmi yang ditujukan kepada KPKNL setempat.",
       rootId: "permohonan-kpknl-print-root",
     },
-  ];
+  };
 
   if (isLoading) {
     return (
@@ -347,13 +326,12 @@ export function DocumentsCenterTab({ batch, phaseFilter, checklist, onRefetch }:
     sptjm: "sptjm",
     sp_kelancaran_tugas: "sp_tugas",
     ba_pemeriksaan: "ba_pemeriksaan",
-    surat_tugas_pemeriksaan_penilaian: null,
+    surat_tugas_pemeriksaan_penilaian: "surat_tugas_pemeriksaan_penilaian",
     sk_panitia_penaksir_harga: "sk_tim_penilai",
     sptj_limit: "sptj_limit",
     nota_dinas_ksdae: "nota_dinas",
     permohonan_kpknl: "permohonan_kpknl",
   };
-  const documentByKey = Object.fromEntries(documents.map((doc) => [doc.key, doc]));
   const visibleDocuments: DocumentItem[] = AUCTION_DOCUMENT_WORKFLOW
     .filter((definition) => definition.phase !== "valuation")
     .filter((definition) => !phaseFilter || definition.phase === phaseFilter)
@@ -361,7 +339,7 @@ export function DocumentsCenterTab({ batch, phaseFilter, checklist, onRefetch }:
       const printKey = Object.prototype.hasOwnProperty.call(workflowPrintKeys, definition.key)
         ? workflowPrintKeys[definition.key]
         : definition.legacy_key ?? definition.key;
-      const printDoc = printKey ? documentByKey[printKey] : null;
+      const printDoc = printKey ? printDocumentConfig[printKey] : null;
 
       return {
         key: printKey || definition.key,
@@ -380,6 +358,13 @@ export function DocumentsCenterTab({ batch, phaseFilter, checklist, onRefetch }:
         printable: Boolean(printDoc),
       };
     });
+  const groupedDocuments = ["srikandi", "manual_ttd", "external", "app"]
+    .map((channel) => ({
+      key: channel,
+      label: channelLabels[channel] || channel,
+      documents: visibleDocuments.filter((document) => document.channel === channel),
+    }))
+    .filter((group) => group.documents.length > 0);
   const valuationComplete = checklist?.can_complete_post_valuation_documents ?? false;
   const phaseTitle =
     phaseFilter === "pre_valuation"
@@ -435,83 +420,85 @@ export function DocumentsCenterTab({ batch, phaseFilter, checklist, onRefetch }:
         </p>
       </div>
 
-      {/* Group listing */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {visibleDocuments.map((doc) => {
-          const isPrintingThis = printingDocKey === doc.key;
-          const workflowKey = doc.workflowKey || doc.key;
-          const progress = meta.workflow?.documents?.[workflowKey];
-          const status = progress?.status || "not_started";
-          const workflowDisabled = batch.status !== "DRAFT" || updateWorkflowMutation.isPending || Boolean(doc.requiresValuation && !valuationComplete);
+      {groupedDocuments.map((group) => (
+        <section key={group.key} className="space-y-3">
+          <h3 className="text-[11px] font-bold uppercase text-zinc-400">{group.label}</h3>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {group.documents.map((doc) => {
+              const isPrintingThis = printingDocKey === doc.key;
+              const workflowKey = doc.workflowKey || doc.key;
+              const progress = meta.workflow?.documents?.[workflowKey];
+              const status = progress?.status || "not_started";
+              const waitingForValuation = Boolean(doc.requiresValuation && !valuationComplete);
+              const workflowDisabled = batch.status !== "DRAFT" || updateWorkflowMutation.isPending || waitingForValuation;
 
-          return (
-            <div
-              key={workflowKey}
-              className="bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 p-5 rounded-2xl shadow-xs flex flex-col justify-between"
-            >
-              <div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-[10px] font-bold uppercase text-zinc-400 dark:text-zinc-500">
-                    {doc.channel || doc.category}
-                  </span>
-                  {doc.requiresValuation && (
-                    <span className="rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-bold text-amber-700 ring-1 ring-amber-200">
-                      Setelah taksiran
-                    </span>
-                  )}
-                  {!doc.printable && (
-                    <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] font-bold text-zinc-500 ring-1 ring-zinc-200">
-                      Status saja
-                    </span>
-                  )}
-                </div>
-                <h3 className="font-bold text-sm text-zinc-900 dark:text-zinc-50 mt-1">
-                  {doc.title}
-                </h3>
-                <p className="text-xs text-zinc-500 mt-2 line-clamp-2 leading-relaxed">
-                  {doc.description}
-                </p>
-                <div className="mt-4">
-                  <label className="text-[10px] font-bold uppercase text-zinc-400">Status Workflow</label>
-                  <select
-                    value={status}
-                    disabled={workflowDisabled}
-                    onChange={(event) =>
-                      updateWorkflowMutation.mutate({
-                        workflowKey,
-                        status: event.target.value,
-                      })
-                    }
-                    className="mt-1 h-9 w-full rounded-xl border border-zinc-200 bg-white px-3 text-xs font-semibold text-zinc-800 outline-none focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 disabled:bg-zinc-50 disabled:text-zinc-400 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100"
-                  >
-                    <option value="not_started">Belum mulai</option>
-                    <option value="prepared">Disiapkan</option>
-                    <option value="printed">Dicetak</option>
-                    <option value="signed">Ditandatangani</option>
-                    <option value="completed">Selesai</option>
-                    <option value="skipped">Dilewati</option>
-                  </select>
-                </div>
-              </div>
-
-              <div className="mt-5 pt-3 border-t border-zinc-100 dark:border-zinc-800 flex justify-end">
-                <Button
-                  onClick={() => handlePrint(doc)}
-                  className="bg-emerald-600 hover:bg-emerald-700 text-white rounded-xl text-xs font-semibold flex items-center gap-1.5"
-                  disabled={!!printingDocKey || !doc.printable || Boolean(doc.requiresValuation && !valuationComplete)}
+              return (
+                <div
+                  key={workflowKey}
+                  className="flex flex-col justify-between rounded-2xl border border-zinc-200 bg-white p-5 shadow-xs dark:border-zinc-800 dark:bg-zinc-950"
                 >
-                  {isPrintingThis ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Printer className="h-4 w-4" />
-                  )}
-                  {isPrintingThis ? "Menyiapkan..." : "Cetak Dokumen"}
-                </Button>
-              </div>
-            </div>
-          );
-        })}
-      </div>
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-[10px] font-bold uppercase text-zinc-400 dark:text-zinc-500">
+                        {channelLabels[doc.channel || ""] || doc.category}
+                      </span>
+                      {doc.requiresValuation && (
+                        <span className="rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-bold text-amber-700 ring-1 ring-amber-200">
+                          Setelah taksiran
+                        </span>
+                      )}
+                      {waitingForValuation && (
+                        <span className="rounded-full bg-red-50 px-2 py-0.5 text-[10px] font-bold text-red-700 ring-1 ring-red-200">
+                          Menunggu Nilai Taksiran
+                        </span>
+                      )}
+                      {!doc.printable && (
+                        <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] font-bold text-zinc-500 ring-1 ring-zinc-200">
+                          Status saja
+                        </span>
+                      )}
+                    </div>
+                    <h3 className="mt-1 text-sm font-bold text-zinc-900 dark:text-zinc-50">{doc.title}</h3>
+                    <p className="mt-2 line-clamp-2 text-xs leading-relaxed text-zinc-500">{doc.description}</p>
+                    <div className="mt-4">
+                      <label className="text-[10px] font-bold uppercase text-zinc-400">Status Workflow</label>
+                      <select
+                        value={status}
+                        disabled={workflowDisabled}
+                        onChange={(event) =>
+                          updateWorkflowMutation.mutate({
+                            workflowKey,
+                            status: event.target.value,
+                          })
+                        }
+                        className="mt-1 h-9 w-full rounded-xl border border-zinc-200 bg-white px-3 text-xs font-semibold text-zinc-800 outline-none focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 disabled:bg-zinc-50 disabled:text-zinc-400 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100"
+                      >
+                        <option value="not_started">Belum mulai</option>
+                        <option value="prepared">Disiapkan</option>
+                        <option value="printed">Dicetak</option>
+                        <option value="signed">Ditandatangani</option>
+                        <option value="completed">Selesai</option>
+                        <option value="skipped">Dilewati</option>
+                      </select>
+                    </div>
+                  </div>
+
+                  <div className="mt-5 flex justify-end border-t border-zinc-100 pt-3 dark:border-zinc-800">
+                    <Button
+                      onClick={() => handlePrint(doc)}
+                      className="flex items-center gap-1.5 rounded-xl bg-emerald-600 text-xs font-semibold text-white hover:bg-emerald-700"
+                      disabled={!!printingDocKey || !doc.printable || waitingForValuation}
+                    >
+                      {isPrintingThis ? <Loader2 className="h-4 w-4 animate-spin" /> : <Printer className="h-4 w-4" />}
+                      {isPrintingThis ? "Menyiapkan..." : "Cetak Dokumen"}
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      ))}
 
       {/* Hidden print templates area - rendered off-screen only when needed to save DOM weight */}
       {printingDocKey && (
@@ -578,6 +565,18 @@ export function DocumentsCenterTab({ batch, phaseFilter, checklist, onRefetch }:
                 stTanggal={stTanggal}
                 assets={mappedAssets}
                 kepalaBalai={kepalaBalai}
+              />
+            </div>
+          )}
+          {printingDocKey === "surat_tugas_pemeriksaan_penilaian" && (
+            <div id="surat-tugas-pemeriksaan-penilaian-print-root">
+              <SuratTugasPemeriksaanPenilaianDocument
+                number={meta.document_numbers?.surat_tugas_pemeriksaan_penilaian || "____"}
+                kap="Balai"
+                assets={mappedAssets}
+                kepalaBalai={kepalaBalai}
+                timPenilai={timPenilaiList}
+                pemeriksa={pemeriksaList}
               />
             </div>
           )}

--- a/frontend/src/app/bmn/auction-batches/[id]/_components/DocumentsCenterTab.tsx
+++ b/frontend/src/app/bmn/auction-batches/[id]/_components/DocumentsCenterTab.tsx
@@ -2,7 +2,8 @@
 
 import React, { useState } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
-import { getDocumentContext, recordPrintEvent, AuctionBatch } from "../../_lib/api";
+import { getDocumentContext, recordPrintEvent, updateDraftMetadata, AuctionBatch, ChecklistResponse } from "../../_lib/api";
+import { AUCTION_DOCUMENT_WORKFLOW, AuctionDocumentPhase } from "../_lib/document-workflow";
 import { formatRupiah } from "../../../auction-candidates/_lib/auction-helpers";
 import { toast } from "sonner";
 import {
@@ -50,6 +51,9 @@ import {
 
 interface DocumentsCenterTabProps {
   batch: AuctionBatch;
+  phaseFilter?: AuctionDocumentPhase;
+  checklist?: ChecklistResponse | null;
+  onRefetch?: () => void;
 }
 
 interface DocumentItem {
@@ -58,13 +62,17 @@ interface DocumentItem {
   category: "internal" | "sk" | "pernyataan" | "eksternal";
   description: string;
   rootId: string;
+  workflowKey?: string;
+  channel?: string;
+  requiresValuation?: boolean;
+  printable?: boolean;
 }
 
-export function DocumentsCenterTab({ batch }: DocumentsCenterTabProps) {
+export function DocumentsCenterTab({ batch, phaseFilter, checklist, onRefetch }: DocumentsCenterTabProps) {
   const [printingDocKey, setPrintingDocKey] = useState<string | null>(null);
 
   // Load document context
-  const { data: contextResponse, isLoading, error } = useQuery({
+  const { data: contextResponse, isLoading, error, refetch: refetchContext } = useQuery({
     queryKey: ["bmn-auction-document-context", batch.id],
     queryFn: () => getDocumentContext(batch.id),
   });
@@ -74,6 +82,24 @@ export function DocumentsCenterTab({ batch }: DocumentsCenterTabProps) {
   // Record print event mutation
   const logPrintMutation = useMutation({
     mutationFn: (docKey: string) => recordPrintEvent(batch.id, docKey),
+  });
+  const updateWorkflowMutation = useMutation({
+    mutationFn: ({ workflowKey, status }: { workflowKey: string; status: string }) =>
+      updateDraftMetadata(batch.id, {
+        workflow: {
+          documents: {
+            [workflowKey]: { status: status as any },
+          },
+        },
+      }),
+    onSuccess: () => {
+      toast.success("Status dokumen diperbarui.");
+      refetchContext();
+      onRefetch?.();
+    },
+    onError: (error: any) => {
+      toast.error(error?.response?.data?.message || "Gagal memperbarui status dokumen.");
+    },
   });
 
   const documents: DocumentItem[] = [
@@ -178,13 +204,13 @@ export function DocumentsCenterTab({ batch }: DocumentsCenterTabProps) {
   }
 
   // Check Schema Version
-  if (context.metadata_schema_version && context.metadata_schema_version !== 1) {
+  if (context.metadata_schema_version && ![1, 2].includes(context.metadata_schema_version)) {
     return (
       <div className="flex h-60 flex-col items-center justify-center space-y-2 text-center p-6 bg-amber-50 dark:bg-amber-950/10 rounded-2xl border border-amber-200">
         <AlertTriangle className="h-8 w-8 text-amber-500" />
         <h3 className="font-bold text-xs text-zinc-900 dark:text-zinc-50">Skema Metadata Tidak Didukung</h3>
         <p className="text-xs text-zinc-500 dark:text-zinc-400 max-w-md">
-          Dokumen ini dibuat menggunakan skema metadata versi {context.metadata_schema_version} yang tidak didukung oleh sistem cetak saat ini (versi 1).
+          Dokumen ini dibuat menggunakan skema metadata versi {context.metadata_schema_version} yang belum didukung oleh sistem cetak saat ini.
         </p>
       </div>
     );
@@ -192,6 +218,11 @@ export function DocumentsCenterTab({ batch }: DocumentsCenterTabProps) {
 
   // Handle document printing
   const handlePrint = (doc: DocumentItem) => {
+    if (!doc.printable) {
+      toast.error("Template cetak dokumen ini belum tersedia.");
+      return;
+    }
+
     setPrintingDocKey(doc.key);
 
     // Give DOM time to render the print component
@@ -284,7 +315,7 @@ export function DocumentsCenterTab({ batch }: DocumentsCenterTabProps) {
       setTimeout(() => {
         printWindow.print();
         // Log printing event in backend audit logger
-        logPrintMutation.mutate(doc.key);
+        logPrintMutation.mutate(doc.workflowKey || doc.key);
         setPrintingDocKey(null);
       }, 500);
     }, 100);
@@ -308,44 +339,166 @@ export function DocumentsCenterTab({ batch }: DocumentsCenterTabProps) {
 
   const stNumber = meta.document_numbers?.surat_tugas || "____";
   const stTanggal = meta.document_dates?.surat_tugas || "";
+  const workflowPrintKeys: Record<string, string | null> = {
+    sk_penghentian: "sk_penghentian",
+    ba_koreksi: "ba_koreksi",
+    sk_panitia_penghapusan: "sk_panitia",
+    sk_kebenaran: "sk_kebenaran",
+    sptjm: "sptjm",
+    sp_kelancaran_tugas: "sp_tugas",
+    ba_pemeriksaan: "ba_pemeriksaan",
+    surat_tugas_pemeriksaan_penilaian: null,
+    sk_panitia_penaksir_harga: "sk_tim_penilai",
+    sptj_limit: "sptj_limit",
+    nota_dinas_ksdae: "nota_dinas",
+    permohonan_kpknl: "permohonan_kpknl",
+  };
+  const documentByKey = Object.fromEntries(documents.map((doc) => [doc.key, doc]));
+  const visibleDocuments: DocumentItem[] = AUCTION_DOCUMENT_WORKFLOW
+    .filter((definition) => definition.phase !== "valuation")
+    .filter((definition) => !phaseFilter || definition.phase === phaseFilter)
+    .map((definition) => {
+      const printKey = Object.prototype.hasOwnProperty.call(workflowPrintKeys, definition.key)
+        ? workflowPrintKeys[definition.key]
+        : definition.legacy_key ?? definition.key;
+      const printDoc = printKey ? documentByKey[printKey] : null;
+
+      return {
+        key: printKey || definition.key,
+        workflowKey: definition.key,
+        title: definition.title,
+        category:
+          definition.channel === "srikandi"
+            ? "sk"
+            : definition.channel === "external"
+            ? "eksternal"
+            : "pernyataan",
+        description: printDoc?.description || "Dokumen workflow BMN yang perlu ditandai sesuai progres administrasi.",
+        rootId: printDoc?.rootId || "",
+        channel: definition.channel,
+        requiresValuation: definition.requires_valuation,
+        printable: Boolean(printDoc),
+      };
+    });
+  const valuationComplete = checklist?.can_complete_post_valuation_documents ?? false;
+  const phaseTitle =
+    phaseFilter === "pre_valuation"
+      ? "Dokumen Awal Sebelum Penaksiran"
+      : phaseFilter === "post_valuation"
+      ? "Dokumen Setelah Nilai Taksiran"
+      : "Pusat Dokumen Cetak BMN";
+  const phaseDescription =
+    phaseFilter === "pre_valuation"
+      ? "Urutan mengikuti alur Srikandi dan dokumen manual sebelum Panitia Penaksir Harga serta nilai taksiran."
+      : phaseFilter === "post_valuation"
+      ? "Nota Dinas KSDAE, SPTJ nilai limit, dan permohonan KPKNL baru dikerjakan setelah nilai taksiran selesai."
+      : "Unduh dan cetak seluruh Surat Keputusan (SK) dan Berita Acara (BA) resmi administrasi penghapusan aset.";
+
+  if (phaseFilter === "post_valuation" && checklist && !valuationComplete) {
+    const valuationItems = checklist.sections?.find((section) => section.key === "valuation")?.items ?? [];
+    return (
+      <div className="space-y-6">
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 p-5 text-amber-900 shadow-xs dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-200">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+            <div>
+              <h2 className="text-sm font-bold">Dokumen setelah taksiran belum dibuka</h2>
+              <p className="mt-1 text-xs leading-relaxed text-amber-800/80 dark:text-amber-200/80">
+                Selesaikan nilai taksiran seluruh aset terlebih dahulu. Setelah itu Nota Dinas KSDAE dan permohonan KPKNL dapat diproses.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-xs dark:border-zinc-800 dark:bg-zinc-950">
+          <h3 className="text-sm font-bold text-zinc-900 dark:text-zinc-50">Checklist nilai taksiran</h3>
+          <div className="mt-4 space-y-2">
+            {valuationItems.map((item) => (
+              <div key={item.key} className="rounded-xl border border-zinc-100 bg-zinc-50 px-3 py-2 text-xs dark:border-zinc-800 dark:bg-zinc-900">
+                <p className="font-semibold text-zinc-800 dark:text-zinc-200">{item.label}</p>
+                {item.message && <p className="mt-0.5 text-[11px] text-zinc-500">{item.message}</p>}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
       <div className="bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 p-5 rounded-2xl shadow-xs">
         <h2 className="text-base font-bold text-zinc-900 dark:text-zinc-50">
-          Pusat Dokumen Cetak BMN
+          {phaseTitle}
         </h2>
         <p className="text-xs text-zinc-500 mt-0.5">
-          Unduh dan cetak seluruh Surat Keputusan (SK) dan Berita Acara (BA) resmi administrasi penghapusan aset.
+          {phaseDescription}
         </p>
       </div>
 
       {/* Group listing */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {documents.map((doc) => {
+        {visibleDocuments.map((doc) => {
           const isPrintingThis = printingDocKey === doc.key;
+          const workflowKey = doc.workflowKey || doc.key;
+          const progress = meta.workflow?.documents?.[workflowKey];
+          const status = progress?.status || "not_started";
+          const workflowDisabled = batch.status !== "DRAFT" || updateWorkflowMutation.isPending || Boolean(doc.requiresValuation && !valuationComplete);
+
           return (
             <div
-              key={doc.key}
+              key={workflowKey}
               className="bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 p-5 rounded-2xl shadow-xs flex flex-col justify-between"
             >
               <div>
-                <span className="text-[10px] font-bold uppercase text-zinc-400 dark:text-zinc-500">
-                  {doc.category}
-                </span>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-[10px] font-bold uppercase text-zinc-400 dark:text-zinc-500">
+                    {doc.channel || doc.category}
+                  </span>
+                  {doc.requiresValuation && (
+                    <span className="rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-bold text-amber-700 ring-1 ring-amber-200">
+                      Setelah taksiran
+                    </span>
+                  )}
+                  {!doc.printable && (
+                    <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] font-bold text-zinc-500 ring-1 ring-zinc-200">
+                      Status saja
+                    </span>
+                  )}
+                </div>
                 <h3 className="font-bold text-sm text-zinc-900 dark:text-zinc-50 mt-1">
                   {doc.title}
                 </h3>
                 <p className="text-xs text-zinc-500 mt-2 line-clamp-2 leading-relaxed">
                   {doc.description}
                 </p>
+                <div className="mt-4">
+                  <label className="text-[10px] font-bold uppercase text-zinc-400">Status Workflow</label>
+                  <select
+                    value={status}
+                    disabled={workflowDisabled}
+                    onChange={(event) =>
+                      updateWorkflowMutation.mutate({
+                        workflowKey,
+                        status: event.target.value,
+                      })
+                    }
+                    className="mt-1 h-9 w-full rounded-xl border border-zinc-200 bg-white px-3 text-xs font-semibold text-zinc-800 outline-none focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 disabled:bg-zinc-50 disabled:text-zinc-400 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100"
+                  >
+                    <option value="not_started">Belum mulai</option>
+                    <option value="prepared">Disiapkan</option>
+                    <option value="printed">Dicetak</option>
+                    <option value="signed">Ditandatangani</option>
+                    <option value="completed">Selesai</option>
+                    <option value="skipped">Dilewati</option>
+                  </select>
+                </div>
               </div>
 
               <div className="mt-5 pt-3 border-t border-zinc-100 dark:border-zinc-800 flex justify-end">
                 <Button
                   onClick={() => handlePrint(doc)}
                   className="bg-emerald-600 hover:bg-emerald-700 text-white rounded-xl text-xs font-semibold flex items-center gap-1.5"
-                  disabled={!!printingDocKey}
+                  disabled={!!printingDocKey || !doc.printable || Boolean(doc.requiresValuation && !valuationComplete)}
                 >
                   {isPrintingThis ? (
                     <Loader2 className="h-4 w-4 animate-spin" />

--- a/frontend/src/app/bmn/auction-batches/[id]/_components/SignatoriesDocumentsTab.tsx
+++ b/frontend/src/app/bmn/auction-batches/[id]/_components/SignatoriesDocumentsTab.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { api } from "@/lib/api";
-import { getChecklist, transition, AuctionBatch } from "../../_lib/api";
+import { getChecklist, transition, updateDraftMetadata, AuctionBatch } from "../../_lib/api";
 import { toast } from "sonner";
 import {
   Loader2,
@@ -143,8 +143,7 @@ export function SignatoriesDocumentsTab({ batch, readOnly, onRefetch }: Signator
   const handleFieldChange = async (fieldName: string, value: any) => {
     // Save draft state to API silently so checklist updates
     try {
-      await api.post(`/bmn/auction-batches/${batch.id}/transition`, {
-        status: "DRAFT",
+      await updateDraftMetadata(batch.id, {
         kepala_balai_id: fieldName === "kepala_balai" ? value : kepalaBalaiId || null,
         signatories: {
           panitia: fieldName === "panitia" ? value : panitiaIds,

--- a/frontend/src/app/bmn/auction-batches/[id]/_components/SignatoriesDocumentsTab.tsx
+++ b/frontend/src/app/bmn/auction-batches/[id]/_components/SignatoriesDocumentsTab.tsx
@@ -1,27 +1,12 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
-import { useQuery, useMutation } from "@tanstack/react-query";
+import React, { useEffect, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { getChecklist, transition, updateDraftMetadata, AuctionBatch } from "../../_lib/api";
 import { toast } from "sonner";
-import {
-  Loader2,
-  Lock,
-  UserCheck,
-  FileText,
-  AlertTriangle,
-  CheckCircle,
-  HelpCircle,
-  Users,
-  ShieldCheck,
-  Search,
-  Check,
-  ChevronsUpDown,
-} from "lucide-react";
+import { FileText, Loader2, Lock, ShieldCheck, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -30,7 +15,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { SignatoryPickerSection } from "./workflow/SignatoryPickerSection";
+import { DocumentNumberDateSection } from "./workflow/DocumentNumberDateSection";
+import { DocumentWorkflowSection } from "./workflow/DocumentWorkflowSection";
+import { FinalSubmitPanel } from "./workflow/FinalSubmitPanel";
+import type { Employee, SaveStatus, WorkflowDocuments } from "./workflow/types";
 
 interface SignatoriesDocumentsTabProps {
   batch: AuctionBatch;
@@ -38,17 +27,39 @@ interface SignatoriesDocumentsTabProps {
   onRefetch: () => void;
 }
 
-interface Employee {
-  id: string | number;
-  nama_lengkap?: string | null;
-  name?: string | null;
-  nip: string | null;
-  jabatan: string | null;
-  position?: string | null;
+function SaveStatusPill({ status }: { status: SaveStatus }) {
+  const label =
+    status === "saving" ? "Menyimpan..." : status === "saved" ? "Tersimpan" : status === "error" ? "Gagal simpan" : "Draft";
+  const className =
+    status === "saving"
+      ? "bg-amber-50 text-amber-700 ring-amber-200"
+      : status === "saved"
+      ? "bg-emerald-50 text-emerald-700 ring-emerald-200"
+      : status === "error"
+      ? "bg-red-50 text-red-700 ring-red-200"
+      : "bg-zinc-50 text-zinc-500 ring-zinc-200";
+
+  return (
+    <span className={`rounded-full px-2.5 py-1 text-[10px] font-bold uppercase ring-1 ${className}`}>
+      {status === "saving" && <Loader2 className="mr-1 inline h-3 w-3 animate-spin" />}
+      {label}
+    </span>
+  );
 }
 
 export function SignatoriesDocumentsTab({ batch, readOnly, onRefetch }: SignatoriesDocumentsTabProps) {
-  // Master employee data for pickers
+  const [kepalaBalaiId, setKepalaBalaiId] = useState("");
+  const [panitiaIds, setPanitiaIds] = useState<string[]>([]);
+  const [timPenilaiIds, setTimPenilaiIds] = useState<string[]>([]);
+  const [pemeriksaIds, setPemeriksaIds] = useState<string[]>([]);
+  const [documentNumbers, setDocumentNumbers] = useState<Record<string, string | null>>({});
+  const [documentDates, setDocumentDates] = useState<Record<string, string | null>>({});
+  const [workflowDocuments, setWorkflowDocuments] = useState<WorkflowDocuments>({});
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
+  const [saveVersion, setSaveVersion] = useState(0);
+  const [isHydrated, setIsHydrated] = useState(false);
+  const [isLockConfirmOpen, setIsLockConfirmOpen] = useState(false);
+
   const { data: employees = [], isLoading: isLoadingEmployees } = useQuery<Employee[]>({
     queryKey: ["employees-select-auction"],
     queryFn: async () => {
@@ -57,58 +68,78 @@ export function SignatoriesDocumentsTab({ batch, readOnly, onRefetch }: Signator
     },
   });
 
-  // State for DRAFT editing
-  const [kepalaBalaiId, setKepalaBalaiId] = useState<string>("");
-  const [panitiaIds, setPanitiaIds] = useState<string[]>([]);
-  const [timPenilaiIds, setTimPenilaiIds] = useState<string[]>([]);
-  const [pemeriksaIds, setPemeriksaIds] = useState<string[]>([]);
-  const [isKepalaBalaiPickerOpen, setIsKepalaBalaiPickerOpen] = useState(false);
-  const [kepalaBalaiSearch, setKepalaBalaiSearch] = useState("");
-
-  const [suratTugasNo, setSuratTugasNo] = useState("");
-  const [suratTugasDate, setSuratTugasDate] = useState("");
-
-  // Lock confirmation modal
-  const [isLockConfirmOpen, setIsLockConfirmOpen] = useState(false);
-
-  const getEmployeeName = (employee: Employee) => employee.nama_lengkap || employee.name || "-";
-  const getEmployeePosition = (employee: Employee) => employee.jabatan || employee.position || "";
-  const getEmployeeLabel = (employee: Employee) =>
-    `${getEmployeeName(employee)}${employee.nip ? ` - NIP. ${employee.nip}` : ""}`;
-  const selectedKepalaBalai = employees.find((employee) => String(employee.id) === kepalaBalaiId) || null;
-  const filteredKepalaBalaiEmployees = employees.filter((employee) => {
-    const query = kepalaBalaiSearch.trim().toLowerCase();
-    if (!query) return true;
-
-    return [getEmployeeName(employee), employee.nip, getEmployeePosition(employee)]
-      .filter(Boolean)
-      .some((value) => String(value).toLowerCase().includes(query));
-  });
-
-  // Load checklist
-  const { data: checklist, refetch: refetchChecklist, isLoading: isLoadingChecklist } = useQuery({
+  const {
+    data: checklist,
+    refetch: refetchChecklist,
+    isLoading: isLoadingChecklist,
+  } = useQuery({
     queryKey: ["bmn-auction-batch-checklist", batch.id],
     queryFn: () => getChecklist(batch.id),
   });
 
-  // Load saved draft values from batch model
   useEffect(() => {
-    if (!readOnly && batch) {
-      setKepalaBalaiId(batch.kepala_balai_id || "");
-      // Retrieve signatory IDs from pivot or metadata if available
-      const signatories = batch.metadata?.signatories_raw || {};
-      setPanitiaIds(signatories.panitia || []);
-      setTimPenilaiIds(signatories.tim_penilai || []);
-      setPemeriksaIds(signatories.pemeriksa || []);
+    const metadata = batch.metadata || {};
+    const signatories = metadata.signatories_raw || {};
 
-      const docNos = batch.metadata?.document_numbers || {};
-      const docDates = batch.metadata?.document_dates || {};
-      setSuratTugasNo(docNos.surat_tugas || "");
-      setSuratTugasDate(docDates.surat_tugas || "");
+    setIsHydrated(false);
+    setKepalaBalaiId(batch.kepala_balai_id || "");
+    setPanitiaIds(signatories.panitia || []);
+    setTimPenilaiIds(signatories.tim_penilai || []);
+    setPemeriksaIds(signatories.pemeriksa || []);
+    setDocumentNumbers(metadata.document_numbers || {});
+    setDocumentDates(metadata.document_dates || {});
+    setWorkflowDocuments(metadata.workflow?.documents || {});
+    setSaveStatus("idle");
+    setSaveVersion(0);
+    setIsHydrated(true);
+  }, [batch.id, batch.kepala_balai_id, batch.metadata]);
+
+  const markDirty = () => setSaveVersion((version) => version + 1);
+
+  useEffect(() => {
+    if (readOnly || !isHydrated || saveVersion === 0) {
+      return;
     }
-  }, [batch, readOnly]);
 
-  // Save/Lock transition
+    const handle = window.setTimeout(async () => {
+      setSaveStatus("saving");
+      try {
+        await updateDraftMetadata(batch.id, {
+          kepala_balai_id: kepalaBalaiId || null,
+          signatories: {
+            panitia: panitiaIds,
+            tim_penilai: timPenilaiIds,
+            pemeriksa: pemeriksaIds,
+          },
+          document_numbers: documentNumbers,
+          document_dates: documentDates,
+          workflow: {
+            documents: workflowDocuments,
+          },
+        });
+        setSaveStatus("saved");
+        refetchChecklist();
+      } catch {
+        setSaveStatus("error");
+      }
+    }, 600);
+
+    return () => window.clearTimeout(handle);
+  }, [
+    batch.id,
+    documentDates,
+    documentNumbers,
+    isHydrated,
+    kepalaBalaiId,
+    panitiaIds,
+    pemeriksaIds,
+    readOnly,
+    refetchChecklist,
+    saveVersion,
+    timPenilaiIds,
+    workflowDocuments,
+  ]);
+
   const lockMutation = useMutation({
     mutationFn: (payload: any) => transition(batch.id, payload),
     onSuccess: () => {
@@ -130,131 +161,83 @@ export function SignatoriesDocumentsTab({ batch, readOnly, onRefetch }: Signator
         tim_penilai: timPenilaiIds,
         pemeriksa: pemeriksaIds,
       },
-      document_numbers: {
-        surat_tugas: suratTugasNo || null,
-      },
-      document_dates: {
-        surat_tugas: suratTugasDate || null,
+      document_numbers: documentNumbers,
+      document_dates: documentDates,
+      workflow: {
+        documents: workflowDocuments,
       },
     });
   };
+  const canCompletePostValuationDocuments = checklist?.can_complete_post_valuation_documents ?? false;
 
-  // Helper: auto-update checklist whenever field changes
-  const handleFieldChange = async (fieldName: string, value: any) => {
-    // Save draft state to API silently so checklist updates
-    try {
-      await updateDraftMetadata(batch.id, {
-        kepala_balai_id: fieldName === "kepala_balai" ? value : kepalaBalaiId || null,
-        signatories: {
-          panitia: fieldName === "panitia" ? value : panitiaIds,
-          tim_penilai: fieldName === "tim_penilai" ? value : timPenilaiIds,
-          pemeriksa: fieldName === "pemeriksa" ? value : pemeriksaIds,
-        },
-        document_numbers: {
-          surat_tugas: fieldName === "surat_tugas_no" ? value : suratTugasNo || null,
-        },
-        document_dates: {
-          surat_tugas: fieldName === "surat_tugas_date" ? value : suratTugasDate || null,
-        },
-      });
-      refetchChecklist();
-    } catch {
-      // Ignore background save errors
-    }
-  };
-
-  // Render locked/frozen metadata view
   if (readOnly) {
-    const meta = batch.metadata || {};
-    const frozenKepalaBalai = meta.signatories?.kepala_balai?.nama || "-";
-    const frozenKepalaBalaiNip = meta.signatories?.kepala_balai?.nip || "";
-
-    const frozenPanitia = meta.committees?.panitia_penghapusan || [];
-    const frozenTimPenilai = meta.committees?.tim_penilai || [];
-    const frozenPemeriksa = meta.committees?.pemeriksa || [];
-
-    const frozenDocNos = meta.document_numbers || {};
-    const frozenDocDates = meta.document_dates || {};
+    const metadata = batch.metadata || {};
+    const frozenKepalaBalai = metadata.signatories?.kepala_balai?.nama || "-";
+    const frozenKepalaBalaiNip = metadata.signatories?.kepala_balai?.nip || "";
+    const frozenPanitia = metadata.committees?.panitia_penghapusan || [];
+    const frozenTimPenilai = metadata.committees?.tim_penilai || [];
+    const frozenPemeriksa = metadata.committees?.pemeriksa || [];
+    const frozenDocNos = metadata.document_numbers || {};
+    const frozenDocDates = metadata.document_dates || {};
 
     return (
       <div className="space-y-6">
-        {/* Banner locked */}
-        <div className="flex items-center gap-3 bg-emerald-50 dark:bg-emerald-950/20 text-emerald-800 dark:text-emerald-350 border border-emerald-100 dark:border-emerald-900/30 p-4 rounded-2xl shadow-xs">
+        <div className="flex items-center gap-3 rounded-2xl border border-emerald-100 bg-emerald-50 p-4 text-emerald-800 shadow-xs dark:border-emerald-900/30 dark:bg-emerald-950/20">
           <ShieldCheck className="h-5 w-5 shrink-0 text-emerald-600" />
           <div>
-            <h3 className="font-bold text-sm">Dokumen & Tanda Tangan Terkunci</h3>
-            <p className="text-xs text-zinc-500 mt-0.5">
-              Paket ini telah diajukan. Informasi penandatangan dan nomor dokumen di bawah ini dibekukan secara permanen dari arsip historical.
+            <h3 className="text-sm font-bold">Dokumen & Tanda Tangan Terkunci</h3>
+            <p className="mt-0.5 text-xs text-zinc-500">
+              Paket ini telah diajukan. Informasi penandatangan dan nomor dokumen dibekukan dari arsip saat penguncian.
             </p>
           </div>
         </div>
 
         <div className="grid gap-6 md:grid-cols-2">
-          {/* Signatories Read Only */}
-          <div className="bg-white dark:bg-zinc-950 border border-zinc-205 dark:border-zinc-800 p-5 rounded-2xl shadow-xs space-y-4">
-            <h3 className="font-bold text-sm text-zinc-900 dark:text-zinc-50 border-b pb-2 dark:border-zinc-800 flex items-center gap-2">
+          <div className="space-y-4 rounded-2xl border border-zinc-200 bg-white p-5 shadow-xs dark:border-zinc-800 dark:bg-zinc-950">
+            <h3 className="flex items-center gap-2 border-b pb-2 text-sm font-bold text-zinc-900 dark:border-zinc-800 dark:text-zinc-50">
               <Users className="h-4.5 w-4.5 text-zinc-400" />
               Daftar Penandatangan
             </h3>
 
             <div>
-              <p className="text-[10px] text-zinc-400 font-semibold uppercase">Kepala Balai</p>
-              <p className="text-sm font-semibold text-zinc-800 dark:text-zinc-200 mt-0.5">{frozenKepalaBalai}</p>
-              {frozenKepalaBalaiNip && <p className="text-xs text-zinc-400 mt-0.5">NIP. {frozenKepalaBalaiNip}</p>}
+              <p className="text-[10px] font-semibold uppercase text-zinc-400">Kepala Balai</p>
+              <p className="mt-0.5 text-sm font-semibold text-zinc-800 dark:text-zinc-200">{frozenKepalaBalai}</p>
+              {frozenKepalaBalaiNip && <p className="mt-0.5 text-xs text-zinc-400">NIP. {frozenKepalaBalaiNip}</p>}
             </div>
 
-            <div>
-              <p className="text-[10px] text-zinc-400 font-semibold uppercase">Panitia Penghapusan</p>
-              <ul className="mt-1 space-y-1 text-xs text-zinc-800 dark:text-zinc-200">
-                {frozenPanitia.map((p: any, i: number) => (
-                  <li key={i} className="list-disc list-inside">
-                    {p.nama} {p.nip && <span className="text-zinc-400 font-mono">(NIP. {p.nip})</span>}
-                  </li>
-                ))}
-                {frozenPanitia.length === 0 && <li className="text-zinc-400 italic">Tidak ada</li>}
-              </ul>
-            </div>
-
-            <div>
-              <p className="text-[10px] text-zinc-400 font-semibold uppercase">Tim Penilai / Penaksir</p>
-              <ul className="mt-1 space-y-1 text-xs text-zinc-800 dark:text-zinc-200">
-                {frozenTimPenilai.map((p: any, i: number) => (
-                  <li key={i} className="list-disc list-inside">
-                    {p.nama} {p.nip && <span className="text-zinc-400 font-mono">(NIP. {p.nip})</span>}
-                  </li>
-                ))}
-                {frozenTimPenilai.length === 0 && <li className="text-zinc-400 italic">Tidak ada</li>}
-              </ul>
-            </div>
-
-            <div>
-              <p className="text-[10px] text-zinc-400 font-semibold uppercase">Tim Pemeriksa</p>
-              <ul className="mt-1 space-y-1 text-xs text-zinc-800 dark:text-zinc-200">
-                {frozenPemeriksa.map((p: any, i: number) => (
-                  <li key={i} className="list-disc list-inside">
-                    {p.nama} {p.nip && <span className="text-zinc-400 font-mono">(NIP. {p.nip})</span>}
-                  </li>
-                ))}
-                {frozenPemeriksa.length === 0 && <li className="text-zinc-400 italic">Tidak ada</li>}
-              </ul>
-            </div>
+            {[
+              ["Panitia Penghapusan", frozenPanitia],
+              ["Tim Penilai / Penaksir", frozenTimPenilai],
+              ["Tim Pemeriksa", frozenPemeriksa],
+            ].map(([label, people]) => (
+              <div key={label as string}>
+                <p className="text-[10px] font-semibold uppercase text-zinc-400">{label as string}</p>
+                <ul className="mt-1 space-y-1 text-xs text-zinc-800 dark:text-zinc-200">
+                  {(people as any[]).map((person: any, index: number) => (
+                    <li key={`${person.id || person.nip || index}`} className="list-inside list-disc">
+                      {person.nama} {person.nip && <span className="font-mono text-zinc-400">(NIP. {person.nip})</span>}
+                    </li>
+                  ))}
+                  {(people as any[]).length === 0 && <li className="italic text-zinc-400">Tidak ada</li>}
+                </ul>
+              </div>
+            ))}
           </div>
 
-          {/* Document Numbers Read Only */}
-          <div className="bg-white dark:bg-zinc-950 border border-zinc-205 dark:border-zinc-800 p-5 rounded-2xl shadow-xs space-y-4">
-            <h3 className="font-bold text-sm text-zinc-900 dark:text-zinc-50 border-b pb-2 dark:border-zinc-800 flex items-center gap-2">
+          <div className="space-y-4 rounded-2xl border border-zinc-200 bg-white p-5 shadow-xs dark:border-zinc-800 dark:bg-zinc-950">
+            <h3 className="flex items-center gap-2 border-b pb-2 text-sm font-bold text-zinc-900 dark:border-zinc-800 dark:text-zinc-50">
               <FileText className="h-4.5 w-4.5 text-zinc-400" />
               Nomor & Tanggal Dokumen
             </h3>
-
-            <div>
-              <p className="text-[10px] text-zinc-400 font-semibold uppercase">Surat Tugas Penghapusan</p>
-              <p className="text-sm font-semibold text-zinc-850 dark:text-zinc-250 mt-1">
-                Nomor: <strong className="text-zinc-900 dark:text-zinc-50 font-mono">{frozenDocNos.surat_tugas || "-"}</strong>
-              </p>
-              <p className="text-xs text-zinc-450 mt-1">
-                Tanggal: <strong>{frozenDocDates.surat_tugas ? new Intl.DateTimeFormat("id-ID", { dateStyle: "long" }).format(new Date(frozenDocDates.surat_tugas)) : "-"}</strong>
-              </p>
+            <div className="grid gap-2">
+              {Object.entries(frozenDocNos).map(([key, number]) => (
+                <div key={key} className="rounded-xl bg-zinc-50 p-3 text-xs dark:bg-zinc-900/40">
+                  <p className="font-mono text-[10px] text-zinc-400">{key}</p>
+                  <p className="mt-1 font-semibold text-zinc-900 dark:text-zinc-100">Nomor: {String(number || "-")}</p>
+                  <p className="mt-0.5 text-zinc-500">Tanggal: {String(frozenDocDates[key] || "-")}</p>
+                </div>
+              ))}
+              {Object.keys(frozenDocNos).length === 0 && <p className="text-xs italic text-zinc-400">Tidak ada nomor dokumen.</p>}
             </div>
           </div>
         </div>
@@ -262,280 +245,84 @@ export function SignatoriesDocumentsTab({ batch, readOnly, onRefetch }: Signator
     );
   }
 
-  // Active DRAFT edit view
-  const toggleSelectionList = (list: string[], setList: React.Dispatch<React.SetStateAction<string[]>>, id: string, type: string) => {
-    let nextList: string[];
-    if (list.includes(id)) {
-      nextList = list.filter((x) => x !== id);
-    } else {
-      nextList = [...list, id];
-    }
-    setList(nextList);
-    handleFieldChange(type, nextList);
-  };
-
-  const isChecklistComplete = checklist?.complete === true;
-
   return (
-    <div className="grid gap-6 md:grid-cols-[1fr_320px]">
-      {/* Forms Area */}
+    <div className="grid gap-6 md:grid-cols-[1fr_360px]">
       <div className="space-y-6">
-        {/* Signatories Forms */}
-        <div className="bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 p-6 rounded-2xl shadow-xs space-y-5">
-          <h2 className="text-base font-bold text-zinc-900 dark:text-zinc-50">
-            Daftar Penandatangan Dokumen
-          </h2>
-
-          {/* Kepala Balai */}
-          <div className="space-y-1.5">
-            <label className="text-xs font-semibold text-zinc-700 dark:text-zinc-300">
-              Kepala Balai
-            </label>
-            <Popover open={isKepalaBalaiPickerOpen} onOpenChange={setIsKepalaBalaiPickerOpen}>
-              <PopoverTrigger asChild>
-                <Button
-                  type="button"
-                  variant="outline"
-                  role="combobox"
-                  aria-expanded={isKepalaBalaiPickerOpen}
-                  className="h-auto min-h-10 w-full justify-between rounded-xl border-zinc-200 bg-white px-3 py-2 text-left text-xs font-normal dark:border-zinc-800 dark:bg-zinc-900"
-                  disabled={isLoadingEmployees}
-                >
-                  <span className="min-w-0 truncate">
-                    {selectedKepalaBalai ? getEmployeeLabel(selectedKepalaBalai) : "-- Pilih Kepala Balai --"}
-                  </span>
-                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 text-zinc-400" />
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className="w-[min(560px,calc(100vw-2rem))] p-0" align="start">
-                <div className="border-b border-zinc-100 px-3 py-2 dark:border-zinc-800">
-                  <div className="flex items-center gap-2">
-                    <Search className="h-4 w-4 shrink-0 text-zinc-400" />
-                    <Input
-                      value={kepalaBalaiSearch}
-                      onChange={(event) => setKepalaBalaiSearch(event.target.value)}
-                      placeholder="Cari nama, NIP, atau jabatan..."
-                      className="h-9 border-0 px-0 text-xs focus-visible:ring-0"
-                    />
-                  </div>
-                </div>
-                <div className="max-h-72 overflow-y-auto p-1.5">
-                  {filteredKepalaBalaiEmployees.length === 0 ? (
-                    <div className="px-3 py-6 text-center text-xs text-zinc-500">
-                      Pegawai tidak ditemukan.
-                    </div>
-                  ) : (
-                    filteredKepalaBalaiEmployees.map((emp) => (
-                      <button
-                        key={emp.id}
-                        type="button"
-                        className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs hover:bg-zinc-50 dark:hover:bg-zinc-900"
-                        onClick={() => {
-                          const employeeId = String(emp.id);
-                          setKepalaBalaiId(employeeId);
-                          setKepalaBalaiSearch("");
-                          setIsKepalaBalaiPickerOpen(false);
-                          handleFieldChange("kepala_balai", employeeId);
-                        }}
-                      >
-                        <Check
-                          className={`h-4 w-4 shrink-0 text-emerald-600 ${
-                            kepalaBalaiId === String(emp.id) ? "opacity-100" : "opacity-0"
-                          }`}
-                        />
-                        <span className="min-w-0">
-                          <span className="block truncate font-semibold text-zinc-850 dark:text-zinc-100">
-                            {getEmployeeName(emp)}
-                          </span>
-                          <span className="block truncate font-mono text-[10px] text-zinc-400">
-                            NIP. {emp.nip || "-"}
-                            {getEmployeePosition(emp) ? ` - ${getEmployeePosition(emp)}` : ""}
-                          </span>
-                        </span>
-                      </button>
-                    ))
-                  )}
-                </div>
-              </PopoverContent>
-            </Popover>
+        <div className="flex items-center justify-between rounded-2xl border border-zinc-200 bg-white px-4 py-3 shadow-xs dark:border-zinc-800 dark:bg-zinc-950">
+          <div>
+            <h2 className="text-sm font-bold text-zinc-900 dark:text-zinc-50">Kunci & Ajukan</h2>
+            <p className="mt-0.5 text-xs text-zinc-500">Isi penandatangan, nomor dokumen, dan status workflow sebelum paket dikunci.</p>
           </div>
-
-          {/* Panitia */}
-          <div className="space-y-2">
-            <label className="text-xs font-semibold text-zinc-700 dark:text-zinc-300 block">
-              Panitia Penghapusan (Multi-pilih)
-            </label>
-            <div className="max-h-40 overflow-y-auto border border-zinc-100 dark:border-zinc-800 rounded-xl p-2.5 space-y-1.5 bg-zinc-50/20">
-              {employees.map((emp) => (
-                <div
-                  key={emp.id}
-                  className="flex items-center gap-2 cursor-pointer hover:bg-zinc-50/70 p-1 rounded-lg"
-                  onClick={() => toggleSelectionList(panitiaIds, setPanitiaIds, String(emp.id), "panitia")}
-                >
-                  <Checkbox
-                    checked={panitiaIds.includes(String(emp.id))}
-                    onCheckedChange={() => toggleSelectionList(panitiaIds, setPanitiaIds, String(emp.id), "panitia")}
-                  />
-                  <span className="text-xs">
-                    {getEmployeeName(emp)} <span className="text-zinc-400 font-mono text-[10px]">(NIP. {emp.nip || "-"})</span>
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Tim Penilai */}
-          <div className="space-y-2">
-            <label className="text-xs font-semibold text-zinc-700 dark:text-zinc-300 block">
-              Tim Penilai / Penaksir (Multi-pilih)
-            </label>
-            <div className="max-h-40 overflow-y-auto border border-zinc-100 dark:border-zinc-800 rounded-xl p-2.5 space-y-1.5 bg-zinc-50/20">
-              {employees.map((emp) => (
-                <div
-                  key={emp.id}
-                  className="flex items-center gap-2 cursor-pointer hover:bg-zinc-50/70 p-1 rounded-lg"
-                  onClick={() => toggleSelectionList(timPenilaiIds, setTimPenilaiIds, String(emp.id), "tim_penilai")}
-                >
-                  <Checkbox
-                    checked={timPenilaiIds.includes(String(emp.id))}
-                    onCheckedChange={() =>
-                      toggleSelectionList(timPenilaiIds, setTimPenilaiIds, String(emp.id), "tim_penilai")
-                    }
-                  />
-                  <span className="text-xs">
-                    {getEmployeeName(emp)} <span className="text-zinc-400 font-mono text-[10px]">(NIP. {emp.nip || "-"})</span>
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Pemeriksa */}
-          <div className="space-y-2">
-            <label className="text-xs font-semibold text-zinc-700 dark:text-zinc-300 block">
-              Tim Pemeriksa (Multi-pilih)
-            </label>
-            <div className="max-h-40 overflow-y-auto border border-zinc-100 dark:border-zinc-800 rounded-xl p-2.5 space-y-1.5 bg-zinc-50/20">
-              {employees.map((emp) => (
-                <div
-                  key={emp.id}
-                  className="flex items-center gap-2 cursor-pointer hover:bg-zinc-50/70 p-1 rounded-lg"
-                  onClick={() => toggleSelectionList(pemeriksaIds, setPemeriksaIds, String(emp.id), "pemeriksa")}
-                >
-                  <Checkbox
-                    checked={pemeriksaIds.includes(String(emp.id))}
-                    onCheckedChange={() =>
-                      toggleSelectionList(pemeriksaIds, setPemeriksaIds, String(emp.id), "pemeriksa")
-                    }
-                  />
-                  <span className="text-xs">
-                    {getEmployeeName(emp)} <span className="text-zinc-400 font-mono text-[10px]">(NIP. {emp.nip || "-"})</span>
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
+          <SaveStatusPill status={saveStatus} />
         </div>
 
-        {/* Document Numbers Forms */}
-        <div className="bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 p-6 rounded-2xl shadow-xs space-y-4">
-          <h2 className="text-base font-bold text-zinc-900 dark:text-zinc-50">
-            Nomor & Tanggal Surat Tugas
-          </h2>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-1.5">
-              <label className="text-xs font-semibold text-zinc-700 dark:text-zinc-300">
-                Nomor Surat Tugas
-              </label>
-              <Input
-                placeholder="ST/XXX/BMN/YYYY"
-                value={suratTugasNo}
-                onChange={(e) => {
-                  setSuratTugasNo(e.target.value);
-                  handleFieldChange("surat_tugas_no", e.target.value);
-                }}
-                className="rounded-xl border-zinc-200 dark:border-zinc-800 text-xs focus-visible:ring-emerald-500"
-              />
-            </div>
-            <div className="space-y-1.5">
-              <label className="text-xs font-semibold text-zinc-700 dark:text-zinc-300">
-                Tanggal Surat Tugas
-              </label>
-              <Input
-                type="date"
-                value={suratTugasDate}
-                onChange={(e) => {
-                  setSuratTugasDate(e.target.value);
-                  handleFieldChange("surat_tugas_date", e.target.value);
-                }}
-                className="rounded-xl border-zinc-200 dark:border-zinc-800 text-xs focus-visible:ring-emerald-500"
-              />
-            </div>
-          </div>
-        </div>
+        <SignatoryPickerSection
+          employees={employees}
+          isLoadingEmployees={isLoadingEmployees}
+          kepalaBalaiId={kepalaBalaiId}
+          panitiaIds={panitiaIds}
+          timPenilaiIds={timPenilaiIds}
+          pemeriksaIds={pemeriksaIds}
+          onKepalaBalaiChange={(id) => {
+            setKepalaBalaiId(id);
+            markDirty();
+          }}
+          onPanitiaChange={(ids) => {
+            setPanitiaIds(ids);
+            markDirty();
+          }}
+          onTimPenilaiChange={(ids) => {
+            setTimPenilaiIds(ids);
+            markDirty();
+          }}
+          onPemeriksaChange={(ids) => {
+            setPemeriksaIds(ids);
+            markDirty();
+          }}
+        />
+
+        <DocumentNumberDateSection
+          documentNumbers={documentNumbers}
+          documentDates={documentDates}
+          canCompletePostValuationDocuments={canCompletePostValuationDocuments}
+          onDocumentNumbersChange={(values) => {
+            setDocumentNumbers(values);
+            markDirty();
+          }}
+          onDocumentDatesChange={(values) => {
+            setDocumentDates(values);
+            markDirty();
+          }}
+        />
+
+        <DocumentWorkflowSection
+          documents={workflowDocuments}
+          canCompletePostValuationDocuments={canCompletePostValuationDocuments}
+          onChange={(documents) => {
+            setWorkflowDocuments(documents);
+            markDirty();
+          }}
+        />
       </div>
 
-      {/* Checklist and Locking Panel Sidebar */}
       <div className="space-y-6">
-        {/* Checklist card */}
-        <div className="bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 p-5 rounded-2xl shadow-xs space-y-4">
-          <h3 className="font-bold text-sm text-zinc-900 dark:text-zinc-50 border-b pb-2 dark:border-zinc-800 flex items-center gap-1.5">
-            <UserCheck className="h-4.5 w-4.5 text-zinc-400" />
-            Checklist Kunci Paket
-          </h3>
-
-          {isLoadingChecklist ? (
-            <div className="flex justify-center p-6">
-              <Loader2 className="h-5 w-5 animate-spin text-emerald-600" />
-            </div>
-          ) : (
-            <div className="space-y-3">
-              {checklist?.items?.map((item: any) => {
-                const isWarning = item.key === "document_readiness_reviewed";
-
-                return (
-                  <div key={item.key} className="flex gap-2 items-start text-xs">
-                    {item.passed ? (
-                      <CheckCircle className="h-4 w-4 shrink-0 text-emerald-650 mt-0.5" />
-                    ) : isWarning ? (
-                      <AlertTriangle className="h-4 w-4 shrink-0 text-amber-500 mt-0.5" />
-                    ) : (
-                      <Lock className="h-4 w-4 shrink-0 text-red-500 mt-0.5" />
-                    )}
-                    <div>
-                      <p className={`font-semibold ${item.passed ? "text-zinc-800" : isWarning ? "text-amber-800" : "text-red-800"}`}>
-                        {item.label}
-                      </p>
-                      {item.message && <p className="text-[10px] text-zinc-450 mt-0.5">{item.message}</p>}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-
-          {/* Action locking button */}
-          <Button
-            onClick={() => setIsLockConfirmOpen(true)}
-            disabled={!isChecklistComplete || lockMutation.isPending}
-            className="w-full bg-red-600 hover:bg-red-700 text-white rounded-xl py-2 flex items-center justify-center gap-2 font-bold text-xs shadow-xs"
-          >
-            <Lock className="h-4 w-4" />
-            Kunci & Ajukan Paket
-          </Button>
-        </div>
+        <FinalSubmitPanel
+          checklist={checklist}
+          isLoading={isLoadingChecklist}
+          isLocking={lockMutation.isPending}
+          onLock={() => setIsLockConfirmOpen(true)}
+        />
       </div>
 
-      {/* Lock Confirmation Dialog */}
       <Dialog open={isLockConfirmOpen} onOpenChange={setIsLockConfirmOpen}>
-        <DialogContent className="sm:max-w-md rounded-2xl">
+        <DialogContent className="rounded-2xl sm:max-w-md">
           <DialogHeader>
-            <DialogTitle className="text-base font-bold text-zinc-900 dark:text-zinc-50 flex items-center gap-1.5">
+            <DialogTitle className="flex items-center gap-1.5 text-base font-bold text-zinc-900 dark:text-zinc-50">
               <Lock className="h-5 w-5 text-red-500" />
               Kunci & Ajukan Paket Lelang?
             </DialogTitle>
             <DialogDescription className="text-xs text-zinc-555">
-              Setelah dikunci, aset dan dokumen di dalam paket ini <strong>tidak dapat diedit kembali</strong>. Aset terpilih akan dibekukan dari status operasional dinas.
+              Setelah dikunci, aset dan dokumen di dalam paket ini tidak dapat diedit kembali. Aset terpilih akan dibekukan dari status operasional dinas.
             </DialogDescription>
           </DialogHeader>
 
@@ -545,7 +332,7 @@ export function SignatoriesDocumentsTab({ batch, readOnly, onRefetch }: Signator
             </Button>
             <Button
               onClick={handleLockSubmit}
-              className="bg-red-600 hover:bg-red-750 text-white rounded-xl font-semibold text-xs"
+              className="rounded-xl bg-red-600 text-xs font-semibold text-white hover:bg-red-750"
               disabled={lockMutation.isPending}
             >
               {lockMutation.isPending ? "Mengunci..." : "Ya, Kunci & Ajukan"}

--- a/frontend/src/app/bmn/auction-batches/[id]/_components/ValuationTab.tsx
+++ b/frontend/src/app/bmn/auction-batches/[id]/_components/ValuationTab.tsx
@@ -33,9 +33,10 @@ interface ValuationTabProps {
   readOnly: boolean;
   onRefetch: () => void;
   checklist?: ChecklistResponse | null;
+  onGoToPreDocs?: () => void;
 }
 
-export function ValuationTab({ batch, readOnly, onRefetch, checklist }: ValuationTabProps) {
+export function ValuationTab({ batch, readOnly, onRefetch, checklist, onGoToPreDocs }: ValuationTabProps) {
   const [assets, setAssets] = useState<AuctionBatchAsset[]>([]);
   const [editingAssetId, setEditingAssetId] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState("");
@@ -244,7 +245,14 @@ export function ValuationTab({ batch, readOnly, onRefetch, checklist }: Valuatio
         </div>
 
         <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-xs dark:border-zinc-800 dark:bg-zinc-950">
-          <h3 className="text-sm font-bold text-zinc-900 dark:text-zinc-50">Yang masih kurang</h3>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h3 className="text-sm font-bold text-zinc-900 dark:text-zinc-50">Yang masih kurang</h3>
+            {onGoToPreDocs && (
+              <Button variant="outline" size="sm" className="rounded-xl text-xs font-semibold" onClick={onGoToPreDocs}>
+                Buka Dokumen Awal
+              </Button>
+            )}
+          </div>
           <div className="mt-4 grid gap-2 sm:grid-cols-2">
             {missingGateItems.map((item) => (
               <div key={item.key} className="rounded-xl border border-zinc-100 bg-zinc-50 px-3 py-2 text-xs dark:border-zinc-800 dark:bg-zinc-900">

--- a/frontend/src/app/bmn/auction-batches/[id]/_components/ValuationTab.tsx
+++ b/frontend/src/app/bmn/auction-batches/[id]/_components/ValuationTab.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import { useMutation } from "@tanstack/react-query";
-import { updateValuation, AuctionBatch, AuctionBatchAsset } from "../../_lib/api";
+import { updateValuation, AuctionBatch, AuctionBatchAsset, ChecklistResponse } from "../../_lib/api";
 import { formatRupiah, type AuctionAsset } from "../../../auction-candidates/_lib/auction-helpers";
 import { KertasKerjaAssetSection } from "../../../auction-candidates/_components/KertasKerjaAssetSection";
 import { toast } from "sonner";
@@ -32,9 +32,10 @@ interface ValuationTabProps {
   batch: AuctionBatch;
   readOnly: boolean;
   onRefetch: () => void;
+  checklist?: ChecklistResponse | null;
 }
 
-export function ValuationTab({ batch, readOnly, onRefetch }: ValuationTabProps) {
+export function ValuationTab({ batch, readOnly, onRefetch, checklist }: ValuationTabProps) {
   const [assets, setAssets] = useState<AuctionBatchAsset[]>([]);
   const [editingAssetId, setEditingAssetId] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState("");
@@ -219,6 +220,46 @@ export function ValuationTab({ batch, readOnly, onRefetch }: ValuationTabProps) 
       },
     });
   };
+
+  const preValuationSection = checklist?.sections?.find((section) => section.key === "pre_valuation_documents");
+  const assetsLotSection = checklist?.sections?.find((section) => section.key === "assets_lot");
+  const missingGateItems = [...(assetsLotSection?.items ?? []), ...(preValuationSection?.items ?? [])].filter(
+    (item) => (item.required ?? true) && !item.passed
+  );
+  const isValuationBlocked = !readOnly && checklist?.can_enter_valuation === false;
+
+  if (isValuationBlocked) {
+    return (
+      <div className="space-y-6">
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 p-5 text-amber-900 shadow-xs dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-200">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+            <div>
+              <h2 className="text-sm font-bold">Nilai taksiran belum dapat diisi</h2>
+              <p className="mt-1 text-xs leading-relaxed text-amber-800/80 dark:text-amber-200/80">
+                Selesaikan dokumen awal dan kelengkapan lot sebelum tim penilai mengisi kertas kerja nilai taksiran.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-xs dark:border-zinc-800 dark:bg-zinc-950">
+          <h3 className="text-sm font-bold text-zinc-900 dark:text-zinc-50">Yang masih kurang</h3>
+          <div className="mt-4 grid gap-2 sm:grid-cols-2">
+            {missingGateItems.map((item) => (
+              <div key={item.key} className="rounded-xl border border-zinc-100 bg-zinc-50 px-3 py-2 text-xs dark:border-zinc-800 dark:bg-zinc-900">
+                <p className="font-semibold text-zinc-800 dark:text-zinc-200">{item.label}</p>
+                {item.message && <p className="mt-0.5 text-[11px] text-zinc-500">{item.message}</p>}
+              </div>
+            ))}
+            {missingGateItems.length === 0 && (
+              <p className="text-xs text-zinc-500">Checklist sedang dimuat ulang. Coba buka kembali beberapa detik lagi.</p>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/frontend/src/app/bmn/auction-batches/[id]/_components/workflow/DocumentNumberDateSection.tsx
+++ b/frontend/src/app/bmn/auction-batches/[id]/_components/workflow/DocumentNumberDateSection.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { FileText } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { AUCTION_DOCUMENT_WORKFLOW } from "../../_lib/document-workflow";
+
+interface DocumentNumberDateSectionProps {
+  documentNumbers: Record<string, string | null>;
+  documentDates: Record<string, string | null>;
+  canCompletePostValuationDocuments: boolean;
+  onDocumentNumbersChange: (values: Record<string, string | null>) => void;
+  onDocumentDatesChange: (values: Record<string, string | null>) => void;
+}
+
+const documentFields = AUCTION_DOCUMENT_WORKFLOW
+  .filter((definition) => definition.number_key || definition.date_key)
+  .map((definition) => ({
+    key: definition.key,
+    title: definition.title,
+    numberKey: definition.number_key,
+    dateKey: definition.date_key,
+    requiresValuation: definition.requires_valuation,
+  }));
+
+export function DocumentNumberDateSection({
+  documentNumbers,
+  documentDates,
+  canCompletePostValuationDocuments,
+  onDocumentNumbersChange,
+  onDocumentDatesChange,
+}: DocumentNumberDateSectionProps) {
+  return (
+    <div className="space-y-4 rounded-2xl border border-zinc-200 bg-white p-6 shadow-xs dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="flex items-center gap-2">
+        <FileText className="h-4.5 w-4.5 text-zinc-400" />
+        <h2 className="text-base font-bold text-zinc-900 dark:text-zinc-50">Nomor & Tanggal Dokumen</h2>
+      </div>
+
+      <div className="grid gap-3">
+        {documentFields.map((field) => {
+          const isLocked = field.requiresValuation && !canCompletePostValuationDocuments;
+
+          return (
+            <div
+              key={field.key}
+              className="grid gap-3 rounded-xl border border-zinc-100 bg-zinc-50/30 p-3 dark:border-zinc-800 dark:bg-zinc-900/30 md:grid-cols-[minmax(220px,1fr)_180px_160px]"
+            >
+              <div>
+                <p className="text-xs font-semibold text-zinc-850 dark:text-zinc-100">{field.title}</p>
+                <p className="mt-0.5 text-[10px] font-mono text-zinc-400">{field.key}</p>
+                {isLocked && <p className="mt-1 text-[10px] font-semibold text-amber-600">Menunggu nilai taksiran lengkap</p>}
+              </div>
+              {field.numberKey ? (
+                <Input
+                  placeholder="Nomor dokumen"
+                  value={documentNumbers[field.numberKey] || ""}
+                  disabled={isLocked}
+                  onChange={(event) =>
+                    onDocumentNumbersChange({
+                      ...documentNumbers,
+                      [field.numberKey as string]: event.target.value || null,
+                    })
+                  }
+                  className="h-9 rounded-xl border-zinc-200 text-xs focus-visible:ring-emerald-500 dark:border-zinc-800"
+                />
+              ) : (
+                <div />
+              )}
+              {field.dateKey ? (
+                <Input
+                  type="date"
+                  value={documentDates[field.dateKey] || ""}
+                  disabled={isLocked}
+                  onChange={(event) =>
+                    onDocumentDatesChange({
+                      ...documentDates,
+                      [field.dateKey as string]: event.target.value || null,
+                    })
+                  }
+                  className="h-9 rounded-xl border-zinc-200 text-xs focus-visible:ring-emerald-500 dark:border-zinc-800"
+                />
+              ) : (
+                <div />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/bmn/auction-batches/[id]/_components/workflow/DocumentWorkflowSection.tsx
+++ b/frontend/src/app/bmn/auction-batches/[id]/_components/workflow/DocumentWorkflowSection.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { ClipboardCheck } from "lucide-react";
+import { AUCTION_DOCUMENT_WORKFLOW } from "../../_lib/document-workflow";
+import type { WorkflowDocuments, WorkflowDocumentProgress } from "./types";
+
+interface DocumentWorkflowSectionProps {
+  documents: WorkflowDocuments;
+  canCompletePostValuationDocuments: boolean;
+  onChange: (documents: WorkflowDocuments) => void;
+}
+
+const statusOptions: { value: NonNullable<WorkflowDocumentProgress["status"]>; label: string }[] = [
+  { value: "not_started", label: "Belum mulai" },
+  { value: "prepared", label: "Disiapkan" },
+  { value: "printed", label: "Dicetak" },
+  { value: "signed", label: "Ditandatangani" },
+  { value: "completed", label: "Selesai" },
+  { value: "skipped", label: "Dilewati" },
+];
+
+const phaseLabels: Record<string, string> = {
+  pre_valuation: "Sebelum Nilai Taksiran",
+  valuation: "Nilai Taksiran",
+  post_valuation: "Setelah Nilai Taksiran",
+  auction: "Lelang",
+};
+
+export function DocumentWorkflowSection({ documents, canCompletePostValuationDocuments, onChange }: DocumentWorkflowSectionProps) {
+  const definitions = AUCTION_DOCUMENT_WORKFLOW.filter((definition) => definition.phase !== "valuation");
+  const phases = Array.from(new Set(definitions.map((definition) => definition.phase)));
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-zinc-200 bg-white p-6 shadow-xs dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="flex items-center gap-2">
+        <ClipboardCheck className="h-4.5 w-4.5 text-zinc-400" />
+        <h2 className="text-base font-bold text-zinc-900 dark:text-zinc-50">Status Workflow Dokumen</h2>
+      </div>
+
+      <div className="space-y-5">
+        {phases.map((phase) => (
+          <section key={phase} className="space-y-2">
+            <h3 className="text-[11px] font-bold uppercase text-zinc-400">{phaseLabels[phase] || phase}</h3>
+            <div className="grid gap-2 lg:grid-cols-2">
+              {definitions
+                .filter((definition) => definition.phase === phase)
+                .map((definition) => {
+                  const current = documents[definition.key] || {};
+                  const status = current.status || "not_started";
+                  const isLocked = definition.requires_valuation && !canCompletePostValuationDocuments;
+
+                  return (
+                    <div
+                      key={definition.key}
+                      className="rounded-xl border border-zinc-100 bg-zinc-50/40 p-3 dark:border-zinc-800 dark:bg-zinc-900/30"
+                    >
+                      <div className="flex flex-wrap items-start justify-between gap-2">
+                        <div className="min-w-0">
+                          <p className="text-xs font-semibold text-zinc-850 dark:text-zinc-100">{definition.title}</p>
+                          <p className="mt-0.5 text-[10px] font-bold uppercase text-zinc-400">{definition.channel}</p>
+                          {isLocked && <p className="mt-1 text-[10px] font-semibold text-amber-600">Menunggu nilai taksiran lengkap</p>}
+                        </div>
+                        <select
+                          value={status}
+                          disabled={isLocked}
+                          onChange={(event) =>
+                            onChange({
+                              ...documents,
+                              [definition.key]: {
+                                ...current,
+                                status: event.target.value as WorkflowDocumentProgress["status"],
+                              },
+                            })
+                          }
+                          className="h-8 rounded-lg border border-zinc-200 bg-white px-2 text-[11px] font-semibold text-zinc-800 outline-none focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500/20 disabled:cursor-not-allowed disabled:bg-zinc-100 disabled:text-zinc-400 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100 dark:disabled:bg-zinc-900"
+                        >
+                          {statusOptions.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                    </div>
+                  );
+                })}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/bmn/auction-batches/[id]/_components/workflow/FinalSubmitPanel.tsx
+++ b/frontend/src/app/bmn/auction-batches/[id]/_components/workflow/FinalSubmitPanel.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { AlertTriangle, CheckCircle, Loader2, Lock, UserCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { FinalSubmitPanelProps } from "./types";
+
+export function FinalSubmitPanel({ checklist, isLoading, isLocking, onLock }: FinalSubmitPanelProps) {
+  const isComplete = checklist?.can_lock_submit ?? checklist?.complete ?? false;
+  const sections = checklist?.sections || [];
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-zinc-200 bg-white p-5 shadow-xs dark:border-zinc-800 dark:bg-zinc-950">
+      <h3 className="flex items-center gap-1.5 border-b pb-2 text-sm font-bold text-zinc-900 dark:border-zinc-800 dark:text-zinc-50">
+        <UserCheck className="h-4.5 w-4.5 text-zinc-400" />
+        Checklist Kunci Paket
+      </h3>
+
+      {isLoading ? (
+        <div className="flex justify-center p-6">
+          <Loader2 className="h-5 w-5 animate-spin text-emerald-600" />
+        </div>
+      ) : (
+        <div className="max-h-[520px] space-y-4 overflow-y-auto pr-1">
+          {sections.map((section) => (
+            <section key={section.key} className="space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <h4 className="text-[11px] font-bold uppercase text-zinc-400">{section.label}</h4>
+                {section.complete ? (
+                  <CheckCircle className="h-4 w-4 text-emerald-600" />
+                ) : (
+                  <Lock className="h-4 w-4 text-red-500" />
+                )}
+              </div>
+              <div className="space-y-2">
+                {section.items.map((item) => {
+                  const isWarning = item.key === "document_readiness_reviewed";
+                  return (
+                    <div key={item.key} className="flex items-start gap-2 rounded-lg bg-zinc-50 px-2.5 py-2 text-xs dark:bg-zinc-900/40">
+                      {item.passed ? (
+                        <CheckCircle className="mt-0.5 h-4 w-4 shrink-0 text-emerald-650" />
+                      ) : isWarning ? (
+                        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+                      ) : (
+                        <Lock className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+                      )}
+                      <div>
+                        <p className={`font-semibold ${item.passed ? "text-zinc-800" : isWarning ? "text-amber-800" : "text-red-800"}`}>
+                          {item.label}
+                        </p>
+                        {item.message && <p className="mt-0.5 text-[10px] text-zinc-450">{item.message}</p>}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+
+      <Button
+        onClick={onLock}
+        disabled={!isComplete || isLocking}
+        className="flex w-full items-center justify-center gap-2 rounded-xl bg-red-600 py-2 text-xs font-bold text-white shadow-xs hover:bg-red-700"
+      >
+        <Lock className="h-4 w-4" />
+        {isLocking ? "Mengunci..." : "Kunci & Ajukan Paket"}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/app/bmn/auction-batches/[id]/_components/workflow/SignatoryPickerSection.tsx
+++ b/frontend/src/app/bmn/auction-batches/[id]/_components/workflow/SignatoryPickerSection.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import React, { useState } from "react";
+import { Check, ChevronsUpDown, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import type { Employee } from "./types";
+
+interface SignatoryPickerSectionProps {
+  employees: Employee[];
+  isLoadingEmployees: boolean;
+  kepalaBalaiId: string;
+  panitiaIds: string[];
+  timPenilaiIds: string[];
+  pemeriksaIds: string[];
+  onKepalaBalaiChange: (id: string) => void;
+  onPanitiaChange: (ids: string[]) => void;
+  onTimPenilaiChange: (ids: string[]) => void;
+  onPemeriksaChange: (ids: string[]) => void;
+}
+
+const getEmployeeName = (employee: Employee) => employee.nama_lengkap || employee.name || "-";
+const getEmployeePosition = (employee: Employee) => employee.jabatan || employee.position || "";
+const getEmployeeLabel = (employee: Employee) =>
+  `${getEmployeeName(employee)}${employee.nip ? ` - NIP. ${employee.nip}` : ""}`;
+
+function toggleId(list: string[], id: string) {
+  return list.includes(id) ? list.filter((value) => value !== id) : [...list, id];
+}
+
+function MultiPicker({
+  label,
+  employees,
+  selectedIds,
+  onChange,
+}: {
+  label: string;
+  employees: Employee[];
+  selectedIds: string[];
+  onChange: (ids: string[]) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <label className="block text-xs font-semibold text-zinc-700 dark:text-zinc-300">{label}</label>
+      <div className="max-h-40 overflow-y-auto rounded-xl border border-zinc-100 bg-zinc-50/20 p-2.5 dark:border-zinc-800">
+        <div className="space-y-1.5">
+          {employees.map((employee) => {
+            const id = String(employee.id);
+            return (
+              <button
+                type="button"
+                key={employee.id}
+                className="flex w-full items-center gap-2 rounded-lg p-1 text-left hover:bg-zinc-50/70"
+                onClick={() => onChange(toggleId(selectedIds, id))}
+              >
+                <Checkbox
+                  checked={selectedIds.includes(id)}
+                  onClick={(event) => event.stopPropagation()}
+                  onCheckedChange={() => onChange(toggleId(selectedIds, id))}
+                />
+                <span className="text-xs">
+                  {getEmployeeName(employee)}{" "}
+                  <span className="font-mono text-[10px] text-zinc-400">(NIP. {employee.nip || "-"})</span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SignatoryPickerSection({
+  employees,
+  isLoadingEmployees,
+  kepalaBalaiId,
+  panitiaIds,
+  timPenilaiIds,
+  pemeriksaIds,
+  onKepalaBalaiChange,
+  onPanitiaChange,
+  onTimPenilaiChange,
+  onPemeriksaChange,
+}: SignatoryPickerSectionProps) {
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const selectedKepalaBalai = employees.find((employee) => String(employee.id) === kepalaBalaiId) || null;
+  const filteredEmployees = employees.filter((employee) => {
+    const query = search.trim().toLowerCase();
+    if (!query) return true;
+
+    return [getEmployeeName(employee), employee.nip, getEmployeePosition(employee)]
+      .filter(Boolean)
+      .some((value) => String(value).toLowerCase().includes(query));
+  });
+
+  return (
+    <div className="space-y-5 rounded-2xl border border-zinc-200 bg-white p-6 shadow-xs dark:border-zinc-800 dark:bg-zinc-950">
+      <h2 className="text-base font-bold text-zinc-900 dark:text-zinc-50">Daftar Penandatangan Dokumen</h2>
+
+      <div className="space-y-1.5">
+        <label className="text-xs font-semibold text-zinc-700 dark:text-zinc-300">Kepala Balai</label>
+        <Popover open={isPickerOpen} onOpenChange={setIsPickerOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              role="combobox"
+              aria-expanded={isPickerOpen}
+              className="h-auto min-h-10 w-full justify-between rounded-xl border-zinc-200 bg-white px-3 py-2 text-left text-xs font-normal dark:border-zinc-800 dark:bg-zinc-900"
+              disabled={isLoadingEmployees}
+            >
+              <span className="min-w-0 truncate">
+                {selectedKepalaBalai ? getEmployeeLabel(selectedKepalaBalai) : "-- Pilih Kepala Balai --"}
+              </span>
+              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 text-zinc-400" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-[min(560px,calc(100vw-2rem))] p-0" align="start">
+            <div className="border-b border-zinc-100 px-3 py-2 dark:border-zinc-800">
+              <div className="flex items-center gap-2">
+                <Search className="h-4 w-4 shrink-0 text-zinc-400" />
+                <Input
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder="Cari nama, NIP, atau jabatan..."
+                  className="h-9 border-0 px-0 text-xs focus-visible:ring-0"
+                />
+              </div>
+            </div>
+            <div className="max-h-72 overflow-y-auto p-1.5">
+              {filteredEmployees.length === 0 ? (
+                <div className="px-3 py-6 text-center text-xs text-zinc-500">Pegawai tidak ditemukan.</div>
+              ) : (
+                filteredEmployees.map((employee) => (
+                  <button
+                    key={employee.id}
+                    type="button"
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs hover:bg-zinc-50 dark:hover:bg-zinc-900"
+                    onClick={() => {
+                      const employeeId = String(employee.id);
+                      onKepalaBalaiChange(employeeId);
+                      setSearch("");
+                      setIsPickerOpen(false);
+                    }}
+                  >
+                    <Check
+                      className={`h-4 w-4 shrink-0 text-emerald-600 ${
+                        kepalaBalaiId === String(employee.id) ? "opacity-100" : "opacity-0"
+                      }`}
+                    />
+                    <span className="min-w-0">
+                      <span className="block truncate font-semibold text-zinc-850 dark:text-zinc-100">
+                        {getEmployeeName(employee)}
+                      </span>
+                      <span className="block truncate font-mono text-[10px] text-zinc-400">
+                        NIP. {employee.nip || "-"}
+                        {getEmployeePosition(employee) ? ` - ${getEmployeePosition(employee)}` : ""}
+                      </span>
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      <MultiPicker label="Panitia Penghapusan" employees={employees} selectedIds={panitiaIds} onChange={onPanitiaChange} />
+      <MultiPicker label="Tim Penilai / Penaksir" employees={employees} selectedIds={timPenilaiIds} onChange={onTimPenilaiChange} />
+      <MultiPicker label="Tim Pemeriksa" employees={employees} selectedIds={pemeriksaIds} onChange={onPemeriksaChange} />
+    </div>
+  );
+}

--- a/frontend/src/app/bmn/auction-batches/[id]/_components/workflow/types.ts
+++ b/frontend/src/app/bmn/auction-batches/[id]/_components/workflow/types.ts
@@ -1,0 +1,28 @@
+import type { ChecklistResponse } from "../../../_lib/api";
+
+export interface Employee {
+  id: string | number;
+  nama_lengkap?: string | null;
+  name?: string | null;
+  nip: string | null;
+  jabatan: string | null;
+  position?: string | null;
+}
+
+export type SaveStatus = "idle" | "saving" | "saved" | "error";
+
+export interface WorkflowDocumentProgress {
+  status?: "not_started" | "prepared" | "printed" | "signed" | "completed" | "skipped";
+  notes?: string | null;
+  completed_at?: string | null;
+  [key: string]: unknown;
+}
+
+export type WorkflowDocuments = Record<string, WorkflowDocumentProgress>;
+
+export interface FinalSubmitPanelProps {
+  checklist?: ChecklistResponse;
+  isLoading: boolean;
+  isLocking: boolean;
+  onLock: () => void;
+}

--- a/frontend/src/app/bmn/auction-batches/[id]/_lib/document-workflow.ts
+++ b/frontend/src/app/bmn/auction-batches/[id]/_lib/document-workflow.ts
@@ -1,0 +1,189 @@
+export type AuctionDocumentChannel = "srikandi" | "manual_ttd" | "external" | "app";
+export type AuctionDocumentPhase = "pre_valuation" | "valuation" | "post_valuation" | "auction";
+
+export interface AuctionDocumentWorkflowDefinition {
+  key: string;
+  title: string;
+  channel: AuctionDocumentChannel;
+  phase: AuctionDocumentPhase;
+  order: number;
+  requires_valuation: boolean;
+  number_key: string | null;
+  date_key: string | null;
+  required_for_valuation: boolean;
+  required_for_submit: boolean;
+  legacy_key?: string;
+}
+
+export const AUCTION_DOCUMENT_WORKFLOW: AuctionDocumentWorkflowDefinition[] = [
+  {
+    key: "sk_penghentian",
+    title: "Penghentian Penggunaan BMN",
+    channel: "srikandi",
+    phase: "pre_valuation",
+    order: 10,
+    requires_valuation: false,
+    number_key: "sk_penghentian",
+    date_key: "sk_penghentian",
+    required_for_valuation: true,
+    required_for_submit: true,
+  },
+  {
+    key: "ba_koreksi",
+    title: "Koreksi Perubahan Kondisi BMN",
+    channel: "srikandi",
+    phase: "pre_valuation",
+    order: 20,
+    requires_valuation: false,
+    number_key: "ba_koreksi",
+    date_key: "ba_koreksi",
+    required_for_valuation: true,
+    required_for_submit: true,
+  },
+  {
+    key: "sk_panitia_penghapusan",
+    title:
+      "Panitia Penghapusan Barang Milik Negara Berupa Alat Angkutan Bermotor Pada Balai Konservasi Sumber Daya Alam Kalimantan Timur",
+    channel: "srikandi",
+    phase: "pre_valuation",
+    order: 30,
+    requires_valuation: false,
+    number_key: "sk_panitia",
+    date_key: "sk_panitia",
+    required_for_valuation: true,
+    required_for_submit: true,
+    legacy_key: "sk_panitia",
+  },
+  {
+    key: "sk_kebenaran",
+    title: "Surat Pernyataan Kebenaran Data BMN",
+    channel: "manual_ttd",
+    phase: "pre_valuation",
+    order: 40,
+    requires_valuation: false,
+    number_key: "sk_kebenaran",
+    date_key: "sk_kebenaran",
+    required_for_valuation: true,
+    required_for_submit: true,
+  },
+  {
+    key: "sptjm",
+    title: "Surat Pernyataan Tanggung Jawab Mutlak",
+    channel: "manual_ttd",
+    phase: "pre_valuation",
+    order: 50,
+    requires_valuation: false,
+    number_key: "sptjm",
+    date_key: "sptjm",
+    required_for_valuation: true,
+    required_for_submit: true,
+  },
+  {
+    key: "sp_kelancaran_tugas",
+    title: "Surat Pernyataan Kelancaran Tugas Dinas",
+    channel: "manual_ttd",
+    phase: "pre_valuation",
+    order: 60,
+    requires_valuation: false,
+    number_key: "sp_tugas",
+    date_key: "sp_tugas",
+    required_for_valuation: true,
+    required_for_submit: true,
+    legacy_key: "sp_tugas",
+  },
+  {
+    key: "ba_pemeriksaan",
+    title: "Berita Acara Pemeriksaan BMN",
+    channel: "manual_ttd",
+    phase: "pre_valuation",
+    order: 70,
+    requires_valuation: false,
+    number_key: "ba_pemeriksaan",
+    date_key: "ba_pemeriksaan",
+    required_for_valuation: true,
+    required_for_submit: true,
+  },
+  {
+    key: "surat_tugas_pemeriksaan_penilaian",
+    title: "Surat Tugas Pemeriksaan dan Penilaian BMN",
+    channel: "srikandi",
+    phase: "pre_valuation",
+    order: 80,
+    requires_valuation: false,
+    number_key: "surat_tugas_pemeriksaan_penilaian",
+    date_key: "surat_tugas_pemeriksaan_penilaian",
+    required_for_valuation: true,
+    required_for_submit: true,
+  },
+  {
+    key: "sk_panitia_penaksir_harga",
+    title:
+      "Pembentukan Panitia Penaksir Harga Barang Milik Negara Pada Balai Konservasi Sumber Daya Alam Kalimantan Timur",
+    channel: "srikandi",
+    phase: "pre_valuation",
+    order: 90,
+    requires_valuation: false,
+    number_key: "sk_tim_penilai",
+    date_key: "sk_tim_penilai",
+    required_for_valuation: true,
+    required_for_submit: true,
+    legacy_key: "sk_tim_penilai",
+  },
+  {
+    key: "nilai_taksiran",
+    title: "Nilai Taksiran BMN",
+    channel: "app",
+    phase: "valuation",
+    order: 100,
+    requires_valuation: false,
+    number_key: null,
+    date_key: null,
+    required_for_valuation: false,
+    required_for_submit: true,
+  },
+  {
+    key: "sptj_limit",
+    title: "Surat Pernyataan Tanggung Jawab Nilai Limit",
+    channel: "manual_ttd",
+    phase: "post_valuation",
+    order: 110,
+    requires_valuation: true,
+    number_key: "sptj_limit",
+    date_key: "sptj_limit",
+    required_for_valuation: false,
+    required_for_submit: true,
+  },
+  {
+    key: "nota_dinas_ksdae",
+    title: "Nota Dinas KSDAE Setelah Penaksiran",
+    channel: "srikandi",
+    phase: "post_valuation",
+    order: 120,
+    requires_valuation: true,
+    number_key: "nota_dinas",
+    date_key: "nota_dinas",
+    required_for_valuation: false,
+    required_for_submit: true,
+    legacy_key: "nota_dinas",
+  },
+  {
+    key: "permohonan_kpknl",
+    title: "Permohonan Penjualan BMN ke KPKNL",
+    channel: "external",
+    phase: "post_valuation",
+    order: 130,
+    requires_valuation: true,
+    number_key: "permohonan_kpknl",
+    date_key: "permohonan_kpknl",
+    required_for_valuation: false,
+    required_for_submit: true,
+  },
+];
+
+export function getAuctionDocumentWorkflow(key: string) {
+  return AUCTION_DOCUMENT_WORKFLOW.find((document) => document.key === key) ?? null;
+}
+
+export function getAuctionDocumentWorkflowByPhase(phase: AuctionDocumentPhase) {
+  return AUCTION_DOCUMENT_WORKFLOW.filter((document) => document.phase === phase);
+}

--- a/frontend/src/app/bmn/auction-batches/[id]/_lib/workflow-tabs.ts
+++ b/frontend/src/app/bmn/auction-batches/[id]/_lib/workflow-tabs.ts
@@ -1,0 +1,37 @@
+import type { AuctionBatch, ChecklistResponse } from "../../_lib/api";
+
+export interface WorkflowTab {
+  value: string;
+  label: string;
+}
+
+export function getWorkflowTabs(batch: AuctionBatch): WorkflowTab[] {
+  return [
+    { value: "assets", label: "Aset & Lot" },
+    { value: "pre-docs", label: "Dokumen Awal" },
+    { value: "valuation", label: "Nilai Taksiran" },
+    { value: "post-docs", label: "Setelah Taksiran" },
+    { value: "submit", label: "Kunci & Ajukan" },
+    ...(batch.status !== "DRAFT" ? [{ value: "schedule", label: "Jadwal Lelang" }] : []),
+    ...(batch.status !== "DRAFT" && batch.status !== "DIAJUKAN"
+      ? [{ value: "realization", label: "Realisasi & Hasil" }]
+      : []),
+    { value: "audit", label: "Riwayat Audit" },
+  ];
+}
+
+export function getBlockedReason(tabValue: string, checklist?: ChecklistResponse | null): string | null {
+  if (!checklist) {
+    return null;
+  }
+
+  if (tabValue === "valuation" && checklist.can_enter_valuation === false) {
+    return "Dokumen awal dan lot harus lengkap sebelum nilai taksiran.";
+  }
+
+  if (tabValue === "post-docs" && checklist.can_complete_post_valuation_documents === false) {
+    return "Semua aset harus memiliki nilai taksiran valid terlebih dahulu.";
+  }
+
+  return null;
+}

--- a/frontend/src/app/bmn/auction-batches/[id]/page.tsx
+++ b/frontend/src/app/bmn/auction-batches/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { getBlockedReason, getWorkflowTabs } from "./_lib/workflow-tabs";
 
 // Lazy-loaded or imported tab components (stubbed for compile stability)
 import { AssetsLotTab } from "./_components/AssetsLotTab";
@@ -80,26 +81,14 @@ export default function BmnAuctionBatchDetailPage({ params }: PageProps) {
     refetch();
     refetchChecklist();
   };
-  const workflowTabs = [
-    { value: "assets", label: "Aset & Lot" },
-    { value: "pre-docs", label: "Dokumen Awal" },
-    { value: "valuation", label: "Nilai Taksiran" },
-    { value: "post-docs", label: "Setelah Taksiran" },
-    { value: "submit", label: "Kunci & Ajukan" },
-    ...(batch.status !== "DRAFT"
-      ? [{ value: "schedule", label: "Jadwal Lelang" }]
-      : []),
-    ...(batch.status !== "DRAFT" && batch.status !== "DIAJUKAN"
-      ? [{ value: "realization", label: "Realisasi & Hasil" }]
-      : []),
-    { value: "audit", label: "Riwayat Audit" },
-  ];
+  const workflowTabs = getWorkflowTabs(batch);
   const activeTabIndex = Math.max(
     0,
     workflowTabs.findIndex((tab) => tab.value === activeTab)
   );
   const previousTab = workflowTabs[activeTabIndex - 1] ?? null;
   const nextTab = workflowTabs[activeTabIndex + 1] ?? null;
+  const nextBlockedReason = nextTab ? getBlockedReason(nextTab.value, checklist) : null;
 
   // Status timeline definition
   const statusesOrder = ["DRAFT", "DIAJUKAN", "JADWAL_DITETAPKAN", "LELANG_ULANG", "REALISASI"];
@@ -240,6 +229,7 @@ export default function BmnAuctionBatchDetailPage({ params }: PageProps) {
               <TabsTrigger
                 key={tab.value}
                 value={tab.value}
+                title={getBlockedReason(tab.value, checklist) || undefined}
                 className="rounded-lg text-xs py-2 px-3 font-semibold data-[state=active]:bg-white dark:data-[state=active]:bg-zinc-800 data-[state=active]:shadow-xs"
               >
                 {tab.label}
@@ -270,7 +260,8 @@ export default function BmnAuctionBatchDetailPage({ params }: PageProps) {
               <Button
                 size="sm"
                 className="rounded-xl bg-emerald-600 text-xs font-semibold text-white hover:bg-emerald-700"
-                disabled={!nextTab}
+                disabled={!nextTab || Boolean(nextBlockedReason)}
+                title={nextBlockedReason || undefined}
                 onClick={() => nextTab && setActiveTab(nextTab.value)}
               >
                 {nextTab ? `Lanjut ke ${nextTab.label}` : "Selesai"}
@@ -294,7 +285,13 @@ export default function BmnAuctionBatchDetailPage({ params }: PageProps) {
           </TabsContent>
 
           <TabsContent value="valuation" className="mt-0 focus-visible:outline-none">
-            <ValuationTab batch={batch} readOnly={readOnly} onRefetch={refetchAll} checklist={checklist} />
+            <ValuationTab
+              batch={batch}
+              readOnly={readOnly}
+              onRefetch={refetchAll}
+              checklist={checklist}
+              onGoToPreDocs={() => setActiveTab("pre-docs")}
+            />
           </TabsContent>
 
           <TabsContent value="post-docs" className="mt-0 focus-visible:outline-none">

--- a/frontend/src/app/bmn/auction-batches/[id]/page.tsx
+++ b/frontend/src/app/bmn/auction-batches/[id]/page.tsx
@@ -3,7 +3,7 @@
 import React, { use, useState } from "react";
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import { getBatch, AuctionBatch } from "../_lib/api";
+import { getBatch, getChecklist, AuctionBatch } from "../_lib/api";
 import { getStatusLabel, getStatusColorClass, isReadOnly } from "../_lib/status";
 import { formatRupiah } from "../../auction-candidates/_lib/auction-helpers";
 import {
@@ -42,6 +42,10 @@ export default function BmnAuctionBatchDetailPage({ params }: PageProps) {
     queryKey: ["bmn-auction-batch", batchId],
     queryFn: () => getBatch(batchId),
   });
+  const { data: checklist, refetch: refetchChecklist } = useQuery({
+    queryKey: ["bmn-auction-batch-checklist", batchId],
+    queryFn: () => getChecklist(batchId),
+  });
 
   const batch = response?.data;
 
@@ -72,11 +76,16 @@ export default function BmnAuctionBatchDetailPage({ params }: PageProps) {
   }
 
   const readOnly = isReadOnly(batch.status);
+  const refetchAll = () => {
+    refetch();
+    refetchChecklist();
+  };
   const workflowTabs = [
     { value: "assets", label: "Aset & Lot" },
+    { value: "pre-docs", label: "Dokumen Awal" },
     { value: "valuation", label: "Nilai Taksiran" },
-    { value: "signatories", label: "Dokumen & Tanda Tangan" },
-    { value: "docs-center", label: "Pusat Dokumen" },
+    { value: "post-docs", label: "Setelah Taksiran" },
+    { value: "submit", label: "Kunci & Ajukan" },
     ...(batch.status !== "DRAFT"
       ? [{ value: "schedule", label: "Jadwal Lelang" }]
       : []),
@@ -272,30 +281,44 @@ export default function BmnAuctionBatchDetailPage({ params }: PageProps) {
 
           {/* Tab Contents */}
           <TabsContent value="assets" className="mt-0 focus-visible:outline-none">
-            <AssetsLotTab batch={batch} readOnly={readOnly} onRefetch={refetch} />
+            <AssetsLotTab batch={batch} readOnly={readOnly} onRefetch={refetchAll} />
+          </TabsContent>
+
+          <TabsContent value="pre-docs" className="mt-0 focus-visible:outline-none">
+            <DocumentsCenterTab
+              batch={batch}
+              phaseFilter="pre_valuation"
+              checklist={checklist}
+              onRefetch={refetchAll}
+            />
           </TabsContent>
 
           <TabsContent value="valuation" className="mt-0 focus-visible:outline-none">
-            <ValuationTab batch={batch} readOnly={readOnly} onRefetch={refetch} />
+            <ValuationTab batch={batch} readOnly={readOnly} onRefetch={refetchAll} checklist={checklist} />
           </TabsContent>
 
-          <TabsContent value="signatories" className="mt-0 focus-visible:outline-none">
-            <SignatoriesDocumentsTab batch={batch} readOnly={batch.status !== "DRAFT"} onRefetch={refetch} />
+          <TabsContent value="post-docs" className="mt-0 focus-visible:outline-none">
+            <DocumentsCenterTab
+              batch={batch}
+              phaseFilter="post_valuation"
+              checklist={checklist}
+              onRefetch={refetchAll}
+            />
           </TabsContent>
 
-          <TabsContent value="docs-center" className="mt-0 focus-visible:outline-none">
-            <DocumentsCenterTab batch={batch} />
+          <TabsContent value="submit" className="mt-0 focus-visible:outline-none">
+            <SignatoriesDocumentsTab batch={batch} readOnly={batch.status !== "DRAFT"} onRefetch={refetchAll} />
           </TabsContent>
 
           {batch.status !== "DRAFT" && (
             <TabsContent value="schedule" className="mt-0 focus-visible:outline-none">
-              <ScheduleTab batch={batch} readOnly={batch.status !== "DIAJUKAN"} onRefetch={refetch} />
+              <ScheduleTab batch={batch} readOnly={batch.status !== "DIAJUKAN"} onRefetch={refetchAll} />
             </TabsContent>
           )}
 
           {batch.status !== "DRAFT" && batch.status !== "DIAJUKAN" && (
             <TabsContent value="realization" className="mt-0 focus-visible:outline-none">
-              <RealizationTab batch={batch} readOnly={readOnly} onRefetch={refetch} />
+              <RealizationTab batch={batch} readOnly={readOnly} onRefetch={refetchAll} />
             </TabsContent>
           )}
 

--- a/frontend/src/app/bmn/auction-batches/_lib/api.ts
+++ b/frontend/src/app/bmn/auction-batches/_lib/api.ts
@@ -154,6 +154,30 @@ export interface ChecklistResponse {
   items: ChecklistItem[];
 }
 
+export interface UpdateAuctionDraftMetadataPayload {
+  kepala_balai_id?: string | null;
+  signatories?: {
+    panitia?: string[];
+    tim_penilai?: string[];
+    pemeriksa?: string[];
+  };
+  document_numbers?: Record<string, string | null>;
+  document_dates?: Record<string, string | null>;
+  workflow?: {
+    documents?: Record<
+      string,
+      {
+        status?: "not_started" | "prepared" | "printed" | "signed" | "completed" | "skipped";
+        channel?: "srikandi" | "manual_ttd" | "external" | "app";
+        completed_at?: string | null;
+        number?: string | null;
+        date?: string | null;
+        notes?: string | null;
+      }
+    >;
+  };
+}
+
 // API methods
 export async function getCandidates(params?: any): Promise<PaginatedResponse<AuctionCandidateAsset>> {
   const res = await api.get("/bmn/auction-candidates", { params });
@@ -201,6 +225,14 @@ export async function updateValuation(
   data: { lot_number?: string | null; nilai_taksiran?: number | null; kertas_kerja_data?: any | null }
 ): Promise<{ message: string; data: any }> {
   const res = await api.put(`/bmn/auction-batches/${id}/assets/${assetId}/valuation`, data);
+  return res.data;
+}
+
+export async function updateDraftMetadata(
+  id: string,
+  data: UpdateAuctionDraftMetadataPayload
+): Promise<{ data: AuctionBatch }> {
+  const res = await api.patch(`/bmn/auction-batches/${id}/draft-metadata`, data);
   return res.data;
 }
 

--- a/frontend/src/app/bmn/auction-batches/_lib/api.ts
+++ b/frontend/src/app/bmn/auction-batches/_lib/api.ts
@@ -147,11 +147,23 @@ export interface ChecklistItem {
   label: string;
   passed: boolean;
   message: string | null;
+  required?: boolean;
+}
+
+export interface ChecklistSection {
+  key: string;
+  label: string;
+  complete: boolean;
+  items: ChecklistItem[];
 }
 
 export interface ChecklistResponse {
   complete: boolean;
   items: ChecklistItem[];
+  sections?: ChecklistSection[];
+  can_enter_valuation?: boolean;
+  can_complete_post_valuation_documents?: boolean;
+  can_lock_submit?: boolean;
 }
 
 export interface UpdateAuctionDraftMetadataPayload {

--- a/frontend/src/app/bmn/auction-candidates/_components/SuratTugasPemeriksaanPenilaianDocument.tsx
+++ b/frontend/src/app/bmn/auction-candidates/_components/SuratTugasPemeriksaanPenilaianDocument.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import type { AuctionAsset } from "../_lib/auction-helpers";
+import { formatDateLong } from "../_lib/auction-helpers";
+import type { SkKepalaBalai } from "../_lib/sk-defaults";
+
+interface PersonLike {
+  nama?: string | null;
+  nip?: string | null;
+  jabatan?: string | null;
+}
+
+interface SuratTugasPemeriksaanPenilaianDocumentProps {
+  number: string;
+  kap: string;
+  assets: AuctionAsset[];
+  kepalaBalai: SkKepalaBalai;
+  timPenilai: PersonLike[];
+  pemeriksa: PersonLike[];
+}
+
+function buildNomor(number: string, kap: string, today: Date) {
+  const month = String(today.getMonth() + 1).padStart(2, "0");
+  return `ST.${(number || "").trim() || "____"}/K.18/TU/${kap.trim() || "KAP.06.01"}/B/${month}/${today.getFullYear()}`;
+}
+
+export function SuratTugasPemeriksaanPenilaianDocument({
+  number,
+  kap,
+  assets,
+  kepalaBalai,
+  timPenilai,
+  pemeriksa,
+}: SuratTugasPemeriksaanPenilaianDocumentProps) {
+  const today = new Date();
+  const nomorText = buildNomor(number, kap, today);
+  const petugas = [...timPenilai, ...pemeriksa].filter((person) => person?.nama || person?.nip || person?.jabatan);
+
+  return (
+    <div className="surat-tugas-pemeriksaan-penilaian-print-root">
+      <style jsx global>{`
+        .surat-tugas-page { font-family: 'Bookman Old Style', Georgia, serif; font-size: 11pt; line-height: 1.4; color: #000; }
+        .surat-tugas-page p { margin: 0; }
+        .surat-tugas-table { width: 100%; border-collapse: collapse; margin-top: 0.75rem; font-size: 10pt; }
+        .surat-tugas-table th, .surat-tugas-table td { border: 1px solid #000; padding: 5px 6px; vertical-align: top; }
+        .surat-tugas-table th { text-align: center; font-weight: 700; }
+        .surat-tugas-edit { outline: none; border-bottom: 1px dashed transparent; }
+        .surat-tugas-edit:hover { border-bottom-color: #94a3b8; }
+      `}</style>
+
+      <article className="doc-page surat-tugas-page bg-white text-black">
+        <div className="doc-header">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/header-terbaru.png" alt="Kop Surat" />
+        </div>
+
+        <div className="doc-body">
+          <div className="doc-title">
+            <p>SURAT TUGAS</p>
+            <p>Nomor : {nomorText}</p>
+          </div>
+
+          <div className="doc-text-block">
+            <p contentEditable suppressContentEditableWarning className="surat-tugas-edit">
+              Dalam rangka pemeriksaan fisik dan penilaian Barang Milik Negara berupa alat angkutan bermotor pada Balai Konservasi Sumber Daya Alam Kalimantan Timur, dengan ini menugaskan kepada:
+            </p>
+
+            <table className="surat-tugas-table">
+              <thead>
+                <tr>
+                  <th style={{ width: "10mm" }}>No</th>
+                  <th>Nama / NIP</th>
+                  <th>Jabatan</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(petugas.length > 0 ? petugas : [{ nama: "________________", nip: "", jabatan: "________________" }]).map((person, index) => (
+                  <tr key={`${person.nama || "person"}-${index}`}>
+                    <td style={{ textAlign: "center" }}>{index + 1}</td>
+                    <td>
+                      <strong>{person.nama || "________________"}</strong>
+                      {person.nip && <div>NIP. {person.nip}</div>}
+                    </td>
+                    <td>{person.jabatan || "________________"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            <p contentEditable suppressContentEditableWarning className="surat-tugas-edit">
+              Untuk melaksanakan pemeriksaan, penelitian administrasi, dan penilaian kewajaran nilai taksiran atas objek BMN yang akan dipindahtangankan melalui penjualan secara lelang.
+            </p>
+
+            <table className="surat-tugas-table">
+              <thead>
+                <tr>
+                  <th style={{ width: "10mm" }}>No</th>
+                  <th>Nama Barang</th>
+                  <th>Kode Barang</th>
+                  <th>NUP</th>
+                  <th>No Polisi</th>
+                </tr>
+              </thead>
+              <tbody>
+                {assets.map((asset, index) => (
+                  <tr key={asset.id || `${asset.kode_barang}-${asset.nup}-${index}`}>
+                    <td style={{ textAlign: "center" }}>{index + 1}</td>
+                    <td>{asset.nama_barang}</td>
+                    <td>{asset.kode_barang}</td>
+                    <td>{asset.nup}</td>
+                    <td>{asset.no_polisi || "-"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            <p contentEditable suppressContentEditableWarning className="surat-tugas-edit">
+              Surat tugas ini berlaku sejak tanggal ditetapkan sampai dengan selesainya kegiatan pemeriksaan dan penilaian BMN dimaksud.
+            </p>
+          </div>
+
+          <div className="signature">
+            <p>Samarinda, {formatDateLong(today)}</p>
+            <p>Kepala Balai,</p>
+            <div className="ttd-placeholder">TTD</div>
+            <p style={{ fontWeight: 700, textDecoration: "underline" }}>{kepalaBalai.nama || "________________"}</p>
+            {kepalaBalai.nip && <p>NIP. {kepalaBalai.nip}</p>}
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Align BMN auction batch workflow with the Srikandi document sequence.
- Add draft workflow metadata persistence, backend gates, and schema v2 metadata support.
- Rework frontend tabs, document center grouping, final submit checklist, valuation gates, and Surat Tugas Pemeriksaan/Penilaian template.

## Validation
- npm run lint -- --max-warnings=0
- npx tsc --noEmit
- php artisan test --filter=AuctionBatchTest
- Browser QA: tab order, valuation blocked state, post-valuation blocked state, submit panel gating, searchable Kepala Balai picker

Base branch: develop/bmn-auction
Target note: not main